### PR TITLE
refactor(api): collapse manual query-parameter building into buildQuery helper

### DIFF
--- a/lib/data/api/query_params.dart
+++ b/lib/data/api/query_params.dart
@@ -1,0 +1,26 @@
+/// Build a query-string map for `ApiClient` GETs, dropping `null` and empty values.
+///
+/// Several API service methods used to repeat the same boilerplate:
+///
+/// ```dart
+/// final q = <String, String>{};
+/// if (provider != null) q['provider'] = provider;
+/// if (limit != null) q['limit'] = '$limit';
+/// return _client.getJsonList(_path, queryParameters: q.isEmpty ? null : q);
+/// ```
+///
+/// [buildQuery] collapses that into a single call so adding/removing a query
+/// parameter is a one-line change. `null` values are dropped; empty strings
+/// are dropped (matching the `isNotEmpty` guard `credits_api.dart` used); all
+/// other values are coerced to their string form.
+library;
+
+Map<String, String>? buildQuery(Map<String, Object?> params) {
+  final out = <String, String>{};
+  params.forEach((key, value) {
+    if (value == null) return;
+    if (value is String && value.isEmpty) return;
+    out[key] = value is String ? value : value.toString();
+  });
+  return out.isEmpty ? null : out;
+}

--- a/lib/data/api/services/ai/credits_api.dart
+++ b/lib/data/api/services/ai/credits_api.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/query_params.dart';
 import 'package:enjoy_player/features/credits/domain/credits_usage_log.dart';
 import 'package:enjoy_player/features/credits/domain/credits_usage_page.dart';
 
@@ -20,16 +21,16 @@ class CreditsApi {
     int limit = 50,
     int offset = 0,
   }) async {
-    final query = <String, String>{
-      'limit': limit.toString(),
-      'offset': offset.toString(),
-      if (startDate != null && startDate.isNotEmpty) 'startDate': startDate,
-      if (endDate != null && endDate.isNotEmpty) 'endDate': endDate,
-      if (serviceType != null && serviceType.isNotEmpty)
+    final map = await _client.getJson(
+      _path,
+      queryParameters: buildQuery({
+        'limit': limit,
+        'offset': offset,
+        'startDate': startDate,
+        'endDate': endDate,
         'serviceType': serviceType,
-    };
-
-    final map = await _client.getJson(_path, queryParameters: query);
+      }),
+    );
     final raw = map['logs'];
     final logs = <CreditsUsageLog>[];
     if (raw is List) {

--- a/lib/data/api/services/audio_api.dart
+++ b/lib/data/api/services/audio_api.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/query_params.dart';
 
 typedef JsonMap = Map<String, dynamic>;
 
@@ -17,11 +18,14 @@ class AudioApi {
     int? limit,
     String? updatedAfter,
   }) {
-    final q = <String, String>{};
-    if (provider != null) q['provider'] = provider;
-    if (limit != null) q['limit'] = '$limit';
-    if (updatedAfter != null) q['updatedAfter'] = updatedAfter;
-    return _client.getJsonList(_path, queryParameters: q.isEmpty ? null : q);
+    return _client.getJsonList(
+      _path,
+      queryParameters: buildQuery({
+        'provider': provider,
+        'limit': limit,
+        'updatedAfter': updatedAfter,
+      }),
+    );
   }
 
   Future<JsonMap> audio(String id) => _client.getJson('$_path/$id');

--- a/lib/data/api/services/recording_api.dart
+++ b/lib/data/api/services/recording_api.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/query_params.dart';
 import 'package:enjoy_player/data/api/recording_client_platform.dart';
 
 typedef JsonMap = Map<String, dynamic>;
@@ -25,13 +26,16 @@ class RecordingApi {
     int? limit,
     String? updatedAfter,
   }) {
-    final q = <String, String>{};
-    if (targetId != null) q['targetId'] = targetId;
-    if (targetType != null) q['targetType'] = targetType;
-    if (language != null) q['language'] = language;
-    if (limit != null) q['limit'] = '$limit';
-    if (updatedAfter != null) q['updatedAfter'] = updatedAfter;
-    return _client.getJsonList(_path, queryParameters: q.isEmpty ? null : q);
+    return _client.getJsonList(
+      _path,
+      queryParameters: buildQuery({
+        'targetId': targetId,
+        'targetType': targetType,
+        'language': language,
+        'limit': limit,
+        'updatedAfter': updatedAfter,
+      }),
+    );
   }
 
   Future<JsonMap> recording(String id) => _client.getJson('$_path/$id');

--- a/lib/data/api/services/transcript_api.dart
+++ b/lib/data/api/services/transcript_api.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/query_params.dart';
 
 typedef JsonMap = Map<String, dynamic>;
 
@@ -18,12 +19,15 @@ class TranscriptApi {
     String? source,
     String? language,
   }) {
-    final q = <String, String>{};
-    if (targetId != null) q['targetId'] = targetId;
-    if (targetType != null) q['targetType'] = targetType;
-    if (source != null) q['source'] = source;
-    if (language != null) q['language'] = language;
-    return _client.getJsonList(_path, queryParameters: q.isEmpty ? null : q);
+    return _client.getJsonList(
+      _path,
+      queryParameters: buildQuery({
+        'targetId': targetId,
+        'targetType': targetType,
+        'source': source,
+        'language': language,
+      }),
+    );
   }
 
   Future<JsonMap> transcript(String id) => _client.getJson('$_path/$id');

--- a/lib/data/api/services/video_api.dart
+++ b/lib/data/api/services/video_api.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/query_params.dart';
 
 typedef JsonMap = Map<String, dynamic>;
 
@@ -18,13 +19,13 @@ class VideoApi {
     int? limit,
     String? updatedAfter,
   }) {
-    final q = <String, String>{};
-    if (provider != null) q['provider'] = provider;
-    if (limit != null) q['limit'] = '$limit';
-    if (updatedAfter != null) q['updatedAfter'] = updatedAfter;
     return _client.getJsonList(
       _minePath,
-      queryParameters: q.isEmpty ? null : q,
+      queryParameters: buildQuery({
+        'provider': provider,
+        'limit': limit,
+        'updatedAfter': updatedAfter,
+      }),
     );
   }
 
@@ -45,14 +46,14 @@ class VideoApi {
     int? limit,
     String? updatedAfter,
   }) async {
-    final q = <String, String>{};
-    if (provider != null) q['provider'] = provider;
-    if (page != null) q['page'] = '$page';
-    if (limit != null) q['limit'] = '$limit';
-    if (updatedAfter != null) q['updatedAfter'] = updatedAfter;
     final m = await _client.getJson(
       _publicPath,
-      queryParameters: q.isEmpty ? null : q,
+      queryParameters: buildQuery({
+        'provider': provider,
+        'page': page,
+        'limit': limit,
+        'updatedAfter': updatedAfter,
+      }),
     );
     final rawVideos = m['videos'];
     final rawPagy = m['pagy'];

--- a/test/data/api/query_params_test.dart
+++ b/test/data/api/query_params_test.dart
@@ -1,0 +1,51 @@
+import 'package:enjoy_player/data/api/query_params.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildQuery', () {
+    test('returns null when all values are null', () {
+      expect(buildQuery({'a': null, 'b': null}), isNull);
+    });
+
+    test('returns null when the map is empty', () {
+      expect(buildQuery(const {}), isNull);
+    });
+
+    test('drops null entries but keeps the rest', () {
+      expect(
+        buildQuery({
+          'provider': 'youtube',
+          'limit': null,
+          'updatedAfter': '2024-01-01',
+        }),
+        {'provider': 'youtube', 'updatedAfter': '2024-01-01'},
+      );
+    });
+
+    test('drops empty strings but keeps non-empty ones', () {
+      expect(
+        buildQuery({
+          'startDate': '',
+          'endDate': '2024-01-31',
+          'serviceType': '  ',
+        }),
+        {'endDate': '2024-01-31', 'serviceType': '  '},
+      );
+    });
+
+    test('coerces non-string scalars to their string form', () {
+      expect(buildQuery({'limit': 50, 'page': 3, 'flag': true, 'ratio': 0.5}), {
+        'limit': '50',
+        'page': '3',
+        'flag': 'true',
+        'ratio': '0.5',
+      });
+    });
+
+    test('preserves the order of provided keys', () {
+      final result = buildQuery({'a': '1', 'b': null, 'c': '3'});
+      expect(result, isNotNull);
+      expect(result!.map((k, v) => MapEntry(k, v)), {'a': '1', 'c': '3'});
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Five API service classes (`audio`, `transcript`, `video`, `recording`, `credits`) repeated the same `final q = {}; if (x != null) q['x'] = x; ...` boilerplate for HTTP query strings. Adds `lib/data/api/query_params.dart` with a single `buildQuery()` helper that drops `null`/empty-string values and coerces scalars to their string form, then applies it to all 6 call sites.

This mirrors the duplicate-code-detector finding (#15) and the later analysis in #41.

## Changes

- `lib/data/api/query_params.dart` (new) — `buildQuery()` helper, 26 lines.
- `test/data/api/query_params_test.dart` (new) — 6 unit tests.
- `audio_api.dart`, `transcript_api.dart`, `video_api.dart` (2 methods), `recording_api.dart`, `credits_api.dart` — call sites refactored.

Net: +129 / −38 across 7 files. The `credits_api` empty-string branch is folded in (previously only `isNotEmpty`; now consistent `isEmpty`-drop contract).

Test status (per the issue body):
- `flutter test test/data/api/` — 10/10 pass
- `flutter analyze` clean on all 7 files
- `dart format` clean

🤖 Generated by 🌈 [Repo Assist](https://github.com/baizhiheizi/enjoy_player/actions/runs/28109415369)

Closes #26