### PR TITLE
fix(logging): redact Windows absolute paths correctly on POSIX hosts

### DIFF
--- a/lib/core/logging/log_redaction.dart
+++ b/lib/core/logging/log_redaction.dart
@@ -30,10 +30,7 @@ String redactLogLine(String line) {
   var out = line;
   out = out.replaceAll(_bearerToken, 'Bearer [REDACTED]');
   out = out.replaceAll(_authorizationHeader, 'Authorization: [REDACTED]');
-  out = out.replaceAllMapped(
-    _cookiePair,
-    (m) => '${m.group(1)}=[REDACTED]',
-  );
+  out = out.replaceAllMapped(_cookiePair, (m) => '${m.group(1)}=[REDACTED]');
   out = _redactAbsolutePaths(out);
   return out;
 }
@@ -41,7 +38,11 @@ String redactLogLine(String line) {
 String _redactAbsolutePaths(String line) {
   String shorten(String path) {
     if (path.length <= 48) return path;
-    return '.../${p.basename(path)}';
+    // `p.basename` splits on the host platform's separator, so on Linux/macOS
+    // it leaves Windows back-slash paths untouched. Normalize to `/` first so
+    // the basename is correct regardless of the host platform.
+    final normalized = path.replaceAll(r'\', '/');
+    return '.../${p.basename(normalized)}';
   }
 
   return line


### PR DESCRIPTION
## Summary

`p.basename` from `package:path` splits on the host platform's separator. On Linux/macOS — the only platforms the agent runner and CI run on — it leaves back-slash paths untouched, so a Windows path like `C:\Users\alice\...\enjoy-player.log` survived redaction as `.../C:\Users\alice\...\enjoy-player.log` (longer than the original, and exposing the user's filesystem layout into the very logs they are asked to attach to bug reports).

Normalize `\` → `/` before calling `p.basename` so the basename is computed the same way regardless of host platform.

## Why this matters

- Diagnostic log redaction is the only line of defense against leaking the user's local filesystem layout into on-disk logs.
- A user who hits the path-shortening code path is *guaranteed* to be on Windows (the only platform producing `C:\...` paths) — exactly the platform where the protection was broken.

Test status (per the issue body):
- `flutter test test/core/logging/log_redaction_test.dart` — 5/5 pass (including the previously-failing Windows-path case)
- `dart format` clean
- `flutter analyze` clean

🤖 Generated by 🌈 [Repo Assist](https://github.com/baizhiheizi/enjoy_player/actions/runs/28109415369)

Closes #23, closes #27