### PR TITLE
refactor(player): extract quantizedPositionStream helper

### DIFF
--- a/lib/features/player/application/display_position_provider.dart
+++ b/lib/features/player/application/display_position_provider.dart
@@ -4,6 +4,7 @@ library;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'player_engine_provider.dart';
+import 'quantized_position.dart';
 
 part 'display_position_provider.g.dart';
 
@@ -12,10 +13,5 @@ Stream<Duration> displayPosition(Ref ref) {
   final engine = ref.watch(playerEngineProvider);
   // Windows accessibility bridge can get flooded when semantics-heavy widgets
   // (slider, transcript list items) rebuild for every raw position tick.
-  const bucketMs = 400;
-  return engine.position.map((position) {
-    final ms = position.inMilliseconds;
-    final quantizedMs = (ms ~/ bucketMs) * bucketMs;
-    return Duration(milliseconds: quantizedMs);
-  }).distinct();
+  return quantizedPositionStream(engine.position, bucketMs: 400);
 }

--- a/lib/features/player/application/quantized_position.dart
+++ b/lib/features/player/application/quantized_position.dart
@@ -1,0 +1,25 @@
+/// Quantized player position stream.
+///
+/// Folds [PlayerEngine.position] (ADR-0015) into N-millisecond buckets and
+/// drops equal emissions, so downstream widgets only rebuild when the
+/// quantized value actually changes. Used by both the transcript cue
+/// highlight (400ms buckets) and the transport scrubber (50ms buckets);
+/// see [displayPosition] and [transportSliderPositionProvider].
+library;
+
+/// Returns a stream that emits a new [Duration] every time the input
+/// position crosses a [bucketMs]-sized grid boundary, and deduplicates
+/// consecutive equal values.
+///
+/// The function is pure (no Riverpod) so both `@riverpod`-generated and
+/// manual `StreamProvider` callers can share it.
+Stream<Duration> quantizedPositionStream(
+  Stream<Duration> position, {
+  required int bucketMs,
+}) {
+  return position.map((position) {
+    final ms = position.inMilliseconds;
+    final quantizedMs = (ms ~/ bucketMs) * bucketMs;
+    return Duration(milliseconds: quantizedMs);
+  }).distinct();
+}

--- a/lib/features/player/application/transport_slider_position_provider.dart
+++ b/lib/features/player/application/transport_slider_position_provider.dart
@@ -4,14 +4,10 @@ library;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'player_engine_provider.dart';
+import 'quantized_position.dart';
 
 /// ~50ms buckets — smooth enough for the slider without flooding semantics rebuilds.
 final transportSliderPositionProvider = StreamProvider<Duration>((ref) {
   final engine = ref.watch(playerEngineProvider);
-  const bucketMs = 50;
-  return engine.position.map((position) {
-    final ms = position.inMilliseconds;
-    final quantizedMs = (ms ~/ bucketMs) * bucketMs;
-    return Duration(milliseconds: quantizedMs);
-  }).distinct();
+  return quantizedPositionStream(engine.position, bucketMs: 50);
 });

--- a/test/features/player/quantized_position_test.dart
+++ b/test/features/player/quantized_position_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:enjoy_player/features/player/application/quantized_position.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('quantizedPositionStream', () {
+    test(
+      'quantizes a single position to the nearest lower bucket boundary',
+      () async {
+        final source = Stream<Duration>.fromIterable([
+          const Duration(milliseconds: 430),
+        ]);
+        final result = await quantizedPositionStream(
+          source,
+          bucketMs: 400,
+        ).toList();
+        expect(result, [const Duration(milliseconds: 400)]);
+      },
+    );
+
+    test('emits a new value when crossing a bucket boundary', () async {
+      final source = Stream<Duration>.fromIterable([
+        const Duration(milliseconds: 100),
+        const Duration(milliseconds: 850),
+      ]);
+      final result = await quantizedPositionStream(
+        source,
+        bucketMs: 400,
+      ).toList();
+      expect(result, [
+        const Duration(milliseconds: 0),
+        const Duration(milliseconds: 800),
+      ]);
+    });
+
+    test('deduplicates consecutive equal quantized values', () async {
+      final source = Stream<Duration>.fromIterable([
+        const Duration(milliseconds: 50),
+        const Duration(milliseconds: 100),
+        const Duration(milliseconds: 380),
+        const Duration(milliseconds: 401),
+        const Duration(milliseconds: 800),
+      ]);
+      // bucketMs = 400 → bucket boundaries: 0, 400, 800.
+      // Values 50/100/380 all land in [0,400) → 0.
+      // Values 401 lands at 400.
+      // Value 800 lands at 800.
+      final result = await quantizedPositionStream(
+        source,
+        bucketMs: 400,
+      ).toList();
+      expect(result, [
+        const Duration(milliseconds: 0),
+        const Duration(milliseconds: 400),
+        const Duration(milliseconds: 800),
+      ]);
+    });
+
+    test('respects a 50ms bucket size (slider use case)', () async {
+      final source = Stream<Duration>.fromIterable([
+        const Duration(milliseconds: 0),
+        const Duration(milliseconds: 49),
+        const Duration(milliseconds: 50),
+        const Duration(milliseconds: 99),
+        const Duration(milliseconds: 100),
+      ]);
+      final result = await quantizedPositionStream(
+        source,
+        bucketMs: 50,
+      ).toList();
+      expect(result, [
+        const Duration(milliseconds: 0),
+        const Duration(milliseconds: 50),
+        const Duration(milliseconds: 100),
+      ]);
+    });
+
+    test('truncates (floor), never rounds up', () async {
+      final source = Stream<Duration>.fromIterable([
+        const Duration(milliseconds: 399),
+        const Duration(milliseconds: 400),
+        const Duration(milliseconds: 999),
+      ]);
+      final result = await quantizedPositionStream(
+        source,
+        bucketMs: 400,
+      ).toList();
+      // 399 → bucket 0; 400 → bucket 400; 999 → bucket 800.
+      expect(result, [
+        const Duration(milliseconds: 0),
+        const Duration(milliseconds: 400),
+        const Duration(milliseconds: 800),
+      ]);
+    });
+
+    test('deduplicates adjacent identical bucket values', () async {
+      final source = Stream<Duration>.fromIterable([
+        const Duration(milliseconds: 401),
+        const Duration(milliseconds: 500),
+        const Duration(milliseconds: 600),
+      ]);
+      // All three land in bucket 400; only the first should be emitted.
+      final result = await quantizedPositionStream(
+        source,
+        bucketMs: 400,
+      ).toList();
+      expect(result, [const Duration(milliseconds: 400)]);
+    });
+
+    test('emits nothing for an empty source', () async {
+      final source = const Stream<Duration>.empty();
+      final result = await quantizedPositionStream(
+        source,
+        bucketMs: 400,
+      ).toList();
+      expect(result, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`displayPositionProvider` (400ms buckets, transcript cue highlights) and `transportSliderPositionProvider` (50ms buckets, scrubber) shared an identical "map position to N-ms bucket then `.distinct()`" body that differed only in bucket size and the Riverpod declaration style. This is the duplicate-code finding from #29.

Extract a pure helper `quantizedPositionStream(Stream<Duration>, {int bucketMs})` in `lib/features/player/application/quantized_position.dart` and have both providers call it. The helper is intentionally **not** a provider so it can be shared by both the `@riverpod`-generated `displayPosition` and the manual `StreamProvider` for the transport slider without forcing a `build_runner` regeneration of the latter.

## Changes

- `lib/features/player/application/quantized_position.dart` (new) — pure helper.
- `test/features/player/quantized_position_test.dart` (new) — 7 unit tests.
- `lib/features/player/application/display_position_provider.dart` — call helper (400ms).
- `lib/features/player/application/transport_slider_position_provider.dart` — call helper (50ms).

Net: +149 / −12 across 4 files. No public API change; default bucket sizes preserved; `transportSliderPositionProvider` remains a manual `StreamProvider` (no build_runner step).

Test status (per the issue body):
- `flutter test test/features/player/quantized_position_test.dart` — 7/7 pass
- `flutter analyze` clean
- `dart format` clean

🤖 Generated by 🌈 [Repo Assist](https://github.com/baizhiheizi/enjoy_player/actions/runs/28147584283)

Closes #33