### PR TITLE
perf(library): dedupe identical home/filter list emissions

### DIFF
--- a/lib/core/utils/stream_distinct.dart
+++ b/lib/core/utils/stream_distinct.dart
@@ -1,0 +1,26 @@
+/// Stream dedupe helpers — skip emissions whose value compares equal to the
+/// last value the subscriber already saw.
+///
+/// Used to absorb redundant Drift re-emissions (and any upstream re-mapping
+/// that produces a new container but no semantic change) before the value
+/// reaches Riverpod listeners.
+library;
+
+/// Returns a stream that forwards [this] emissions for which [equals] returns
+/// `false` against the previously forwarded value.
+///
+/// The dedupe state is per-subscriber: each subscription to the returned
+/// stream keeps its own "last seen" reference. This matches Drift's
+/// per-subscriber behavior and avoids cross-talk between consumers.
+extension StreamDistinctExt<T> on Stream<T> {
+  Stream<T> distinctBy(bool Function(T previous, T current) equals) async* {
+    var hasLast = false;
+    late T last;
+    await for (final value in this) {
+      if (hasLast && equals(last, value)) continue;
+      last = value;
+      hasLast = true;
+      yield value;
+    }
+  }
+}

--- a/lib/features/library/application/library_media_provider.dart
+++ b/lib/features/library/application/library_media_provider.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:enjoy_player/core/utils/stream_distinct.dart';
 import 'package:enjoy_player/features/library/domain/media.dart';
 
 import 'library_repository_provider.dart';
@@ -13,6 +14,12 @@ final libraryMediaProvider = StreamProvider<List<Media>>((ref) {
 });
 
 /// Up to 12 most recently updated items for [HomeScreen] (pre-sorted).
+///
+/// Subscribes to `watchAll()` and applies the same library-wide dedupe as
+/// [libraryFilteredListsProvider]: a single Drift tick that re-queries without
+/// changing the top-12 still produces a brand-new list, which would otherwise
+/// rebuild every `ConsumerWidget` watching this provider. Skip the emission
+/// when the new top-12 is element-wise equal to the previous one.
 final libraryHomeRecentsProvider = StreamProvider<List<Media>>((ref) {
   const recentLimit = 12;
   final repo = ref.watch(mediaLibraryRepositoryProvider);
@@ -20,10 +27,16 @@ final libraryHomeRecentsProvider = StreamProvider<List<Media>>((ref) {
     final sorted = [...items]
       ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
     return sorted.take(recentLimit).toList();
-  });
+  }).distinctBy(_listEqualsMedia);
 });
 
 /// Pre-filtered + title-sorted audio/video lists for [LibraryScreen].
+///
+/// `watchAll()` re-emits a new list on every Drift table change. A background
+/// `playbackSessionPersister` write or a duration probe on a non-matching row
+/// re-sorts both halves and rebuilds every library-tab widget, even when the
+/// filtered + title-sorted lists are byte-for-byte identical to the previous
+/// emission. Dedupe on element equality of both halves to avoid that work.
 final libraryFilteredListsProvider =
     StreamProvider<({List<Media> audio, List<Media> video})>((ref) {
       final repo = ref.watch(mediaLibraryRepositoryProvider);
@@ -37,6 +50,9 @@ final libraryFilteredListsProvider =
             filtered.where((m) => m.kind == MediaKind.video).toList()
               ..sort((a, b) => a.title.compareTo(b.title));
         return (audio: audioItems, video: videoItems);
+      }).distinctBy((prev, next) {
+        return _listEqualsMedia(prev.audio, next.audio) &&
+            _listEqualsMedia(prev.video, next.video);
       });
     });
 
@@ -44,4 +60,18 @@ List<Media> _filterMediaByQuery(List<Media> items, String query) {
   if (query.isEmpty) return items;
   final lower = query.toLowerCase();
   return items.where((m) => m.title.toLowerCase().contains(lower)).toList();
+}
+
+/// Element-wise equality for two `List<Media>`.
+///
+/// `List` defaults to identity, and `Media` already overrides `==` / `hashCode`
+/// (added in the `perf(library): dedupe identical watchAll emissions` PR),
+/// so this is the right granularity — no need to pull in `package:collection`.
+bool _listEqualsMedia(List<Media> a, List<Media> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
 }

--- a/test/core/utils/stream_distinct_test.dart
+++ b/test/core/utils/stream_distinct_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:enjoy_player/core/utils/stream_distinct.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('StreamDistinctExt', () {
+    test('forwards first value', () async {
+      final source = Stream<int>.fromIterable(const [1]);
+      final out = await source.distinctBy((a, b) => a == b).toList();
+      expect(out, [1]);
+    });
+
+    test('drops values equal to last forwarded', () async {
+      final source = Stream<int>.fromIterable(const [1, 1, 1, 2, 2, 3, 3]);
+      final out = await source.distinctBy((a, b) => a == b).toList();
+      expect(out, [1, 2, 3]);
+    });
+
+    test('forwards all values when none equal the previous', () async {
+      final source = Stream<int>.fromIterable(const [1, 2, 3, 4]);
+      final out = await source.distinctBy((a, b) => a == b).toList();
+      expect(out, [1, 2, 3, 4]);
+    });
+
+    test('uses caller-provided equality (structural)', () async {
+      // Two logically-equal list-of-ints; identity differs because each `[]`
+      // literal allocates a new instance. The default `==` on `List` would
+      // see them as different — the extension's `equals` callback decides.
+      final source = Stream<List<int>>.fromIterable([
+        const [1, 2, 3],
+        const [1, 2, 3],
+        const [4, 5],
+        const [1, 2, 3],
+      ]);
+      final out = await source
+          .distinctBy((a, b) {
+            if (a.length != b.length) return false;
+            for (var i = 0; i < a.length; i++) {
+              if (a[i] != b[i]) return false;
+            }
+            return true;
+          })
+          .toList();
+      expect(out.length, 3);
+      expect(out[0], [1, 2, 3]);
+      expect(out[1], [4, 5]);
+      expect(out[2], [1, 2, 3]);
+    });
+
+    test('keeps dedupe state per subscriber', () async {
+      // Two independent subscribers on the same source stream must each see
+      // every emission — dedupe state is not shared.
+      final controller = StreamController<int>.broadcast();
+      final aFut = controller.stream.distinctBy((p, c) => p == c).toList();
+      final bFut = controller.stream.distinctBy((p, c) => p == c).toList();
+      controller
+        ..add(1)
+        ..add(1)
+        ..add(2)
+        ..close();
+      final a = await aFut;
+      final b = await bFut;
+      expect(a, [1, 2]);
+      expect(b, [1, 2]);
+    });
+
+    test('propagates errors and stays open for the next value', () async {
+      final controller = StreamController<int>();
+      final out = <int>[];
+      final sub = controller.stream
+          .distinctBy((p, c) => p == c)
+          .listen(out.add, onError: (e) => out.add(-1));
+      controller
+        ..add(1)
+        ..add(2)
+        ..addError('boom')
+        ..add(3);
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+      await controller.close();
+      expect(out, [1, 2, -1, 3]);
+    });
+  });
+}

--- a/test/features/library/library_media_provider_test.dart
+++ b/test/features/library/library_media_provider_test.dart
@@ -1,0 +1,243 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/files/file_storage.dart';
+import 'package:enjoy_player/features/library/application/library_media_provider.dart';
+import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
+import 'package:enjoy_player/features/library/application/library_search_provider.dart';
+import 'package:enjoy_player/features/library/data/library_repository.dart';
+import 'package:enjoy_player/features/library/domain/media.dart';
+import 'package:enjoy_player/features/sync/application/sync_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../support/test_path_provider.dart';
+
+typedef _FilteredLists = ({List<Media> audio, List<Media> video});
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('library provider dedupe', () {
+    late AppDatabase db;
+    late Directory root;
+    late MediaLibraryRepository repo;
+
+    setUp(() async {
+      root = Directory.systemTemp.createTempSync('enjoy_lib_media_prov_test');
+      PathProviderPlatform.instance = TestPathProvider(root.path);
+      db = AppDatabase(executor: NativeDatabase.memory());
+      repo = MediaLibraryRepository(db, FileStorage());
+      // Seed two audio + one video so the lists are non-trivial.
+      await db.audioDao.insertRow(_audio('a-old', 'Alpha', 'old', DateTime(2026, 1, 1)));
+      await db.audioDao.insertRow(_audio('b-new', 'Bravo', 'new', DateTime(2026, 6, 1)));
+      await db.videoDao.insertRow(_video('v-mid', 'Charlie', 'mid', DateTime(2026, 3, 1)));
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (root.existsSync()) {
+        root.deleteSync(recursive: true);
+      }
+    });
+
+    ProviderContainer makeContainer() {
+      return ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          mediaLibraryRepositoryProvider.overrideWithValue(repo),
+          syncEnqueueProvider.overrideWithValue((_, _, _) async {}),
+        ],
+      );
+    }
+
+    test(
+      'libraryHomeRecentsProvider skips identical re-emissions',
+      () async {
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        final emissions = <int>[];
+        final sub = container.listen<List<Media>>(
+          libraryHomeRecentsProvider,
+          (_, next) => emissions.add(next.length),
+          fireImmediately: true,
+        );
+        // Wait for the initial emission (seeded data).
+        await container.read(libraryHomeRecentsProvider.future);
+        emissions.clear();
+
+        // Force watchAll to re-query without changing the merged list by
+        // touching an unrelated column. Drift's watchAll re-emits on any
+        // row update; the merged list is the same so the home recents
+        // top-12 must skip the emission.
+        final oldRow = await db.audioDao.getById('a-old');
+        await db.audioDao.insertRow(
+          oldRow!.copyWith(size: Value(2)),
+        );
+        // Yield enough times for the StreamProvider to flush.
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(
+          emissions,
+          isEmpty,
+          reason:
+              'Identical top-12 should not re-emit. '
+              'Got $emissions emissions after a no-op write.',
+        );
+
+        // Real change to the top-12 (a brand-new most-recent item) MUST emit.
+        await db.videoDao.insertRow(
+          _video('v-newest', 'Delta', 'newest', DateTime(2026, 12, 1)),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(
+          emissions,
+          isNotEmpty,
+          reason:
+              'A real top-12 change (newest item) must re-emit. '
+              'Got $emissions emissions.',
+        );
+
+        sub.close();
+      },
+    );
+
+    test(
+      'libraryFilteredListsProvider skips identical re-emissions '
+      'and re-emits on real changes',
+      () async {
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        final emissions = <String>[];
+        final sub = container.listen<_FilteredLists>(
+          libraryFilteredListsProvider,
+          (prev, next) {
+            final sig = _signature(next);
+            if (emissions.isNotEmpty && emissions.last == sig) return;
+            emissions.add(sig);
+          },
+          fireImmediately: true,
+        );
+        await container.read(libraryFilteredListsProvider.future);
+        emissions.clear();
+
+        // No-op write: bumping fileSize on the older audio row changes
+        // the merged list but the title-sorted audio half is still
+        // [Alpha, Bravo] and the video half is still [Charlie] — so the
+        // dedupe must skip this emission.
+        final oldRow = await db.audioDao.getById('a-old');
+        await db.audioDao.insertRow(
+          oldRow!.copyWith(size: Value(9)),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(emissions, isEmpty, reason: 'No-op write should be deduped.');
+
+        // Real change: rename Alpha → Zebra. Now audio list is
+        // [Bravo, Zebra], which differs, so we must see an emission.
+        final renamedRow = await db.audioDao.getById('a-old');
+        await db.audioDao.insertRow(
+          renamedRow!.copyWith(title: 'Zebra'),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(
+          emissions,
+          isNotEmpty,
+          reason:
+              'A real filter-list change (renamed audio) must re-emit. '
+              'Got $emissions emissions.',
+        );
+
+        sub.close();
+      },
+    );
+
+    test(
+      'libraryFilteredListsProvider re-emits when search query changes',
+      () async {
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        final emissions = <int>[];
+        final sub = container.listen<_FilteredLists>(
+          libraryFilteredListsProvider,
+          (prev, next) =>
+              emissions.add(next.audio.length + next.video.length),
+          fireImmediately: true,
+        );
+        await container.read(libraryFilteredListsProvider.future);
+        emissions.clear();
+
+        container.read(librarySearchProvider.notifier).setQuery('zz');
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        // Empty result set is a real change; should emit.
+        expect(emissions, isNotEmpty);
+        expect(emissions.last, 0);
+
+        sub.close();
+      },
+    );
+  });
+}
+
+String _signature(_FilteredLists v) {
+  return '${v.audio.map((m) => m.id).join(',')}|'
+      '${v.video.map((m) => m.id).join(',')}';
+}
+
+AudioRow _audio(
+  String id,
+  String title,
+  String aid,
+  DateTime when,
+) {
+  return AudioRow(
+    id: id,
+    aid: aid,
+    provider: 'user',
+    title: title,
+    description: null,
+    thumbnailUrl: null,
+    durationSeconds: 10,
+    language: 'und',
+    translationKey: null,
+    sourceText: null,
+    voice: null,
+    source: null,
+    localUri: 'file:///$aid.mp3',
+    md5: null,
+    size: 1,
+    mediaUrl: null,
+    syncStatus: null,
+    serverUpdatedAt: null,
+    createdAt: when,
+    updatedAt: when,
+  );
+}
+
+VideoRow _video(
+  String id,
+  String title,
+  String vid,
+  DateTime when,
+) {
+  return VideoRow(
+    id: id,
+    vid: vid,
+    provider: 'user',
+    title: title,
+    description: null,
+    thumbnailUrl: null,
+    durationSeconds: 10,
+    language: 'und',
+    source: null,
+    localUri: 'file:///$vid.mp4',
+    md5: null,
+    size: 1,
+    mediaUrl: null,
+    syncStatus: null,
+    serverUpdatedAt: null,
+    createdAt: when,
+    updatedAt: when,
+  );
+}


### PR DESCRIPTION
## Summary

`MediaLibraryRepository.watchAll()` already dedupes at the repo level (PR #13), but two derived providers still rebuild every Drift tick:

- `libraryHomeRecentsProvider` maps the merged library into the top-12 most-recent items.
- `libraryFilteredListsProvider` filters by query and splits into title-sorted audio/video halves.

Both produce a brand-new list (or record) on every upstream re-emission, even when the derived list is identical to the previous one. Cache the last emitted value inside the provider and skip the emission when the new value compares equal.

## Changes

- `lib/core/utils/stream_distinct.dart` (new) — `Stream<T>.distinctBy(bool Function(T, T) equals)`. Per-subscriber state (each subscription keeps its own "last seen" reference). No new dependency.
- `lib/features/library/application/library_media_provider.dart` — apply `.distinctBy(_listEqualsMedia)` to both providers.
- `test/core/utils/stream_distinct_test.dart` (new) — 6 unit tests.
- `test/features/library/library_media_provider_test.dart` (new) — 3 integration tests with in-memory Drift.

Net: +385 / −1 across 4 files. `Media.==` already exists from PR #13.

## Why this is safe

Per-subscriber state (matches Drift's per-subscriber behavior). Only identical emissions are dropped; `Media.==` compares every field.

## Performance

For a 100-row library where one Drift row changes but the derived lists stay identical (e.g. duration probe on a non-recent video): drops from "1 sort + 1 filter + 2 widget rebuilds" to "1 O(n) compare + 0 emissions + 0 rebuilds".

🤖 Generated by ⚡ [Perf Improver](https://github.com/baizhiheizi/enjoy_player/actions/runs/28181651032)

Closes #37