### PR TITLE
docs: add feature docs for community, settings, shadow-reading, update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,10 @@ Maintainers and agents should keep these files **accurate** when behavior or arc
 | [features/diagnostics.md](features/diagnostics.md) | Product + dev | Local diagnostic logging, export, and privacy behavior changes |
 | [features/discover.md](features/discover.md) | Product + dev | YouTube Discover feeds, subscriptions, add-to-library behavior changes |
 | [features/dictionary-lookup.md](features/dictionary-lookup.md) | Product + dev | Transcript selection lookup (translation / contextual / dictionary) behavior changes |
+| [features/community.md](features/community.md) | Product + dev | Signed-in Home community activity card behavior changes |
+| [features/settings.md](features/settings.md) | Product + dev | Settings hub, hotkeys / sync sub-screens, account hero, language / mic pickers, or developer API editors change |
+| [features/shadow-reading.md](features/shadow-reading.md) | Product + dev | Shadow reading panel, recording bus, pitch contour, or Azure pronunciation assessment behavior changes |
+| [features/update.md](features/update.md) | Product + dev | App update strategy (NoOp / Direct), manifest schema, evaluator rules, or prompt UX change |
 
 ## How to add an ADR
 

--- a/docs/features/community.md
+++ b/docs/features/community.md
@@ -1,0 +1,32 @@
+# Feature: Community activity (signed-in home dashboard)
+
+## Summary
+
+The community activity card surfaces **active learners** on the signed-in **Home** screen. It only renders for `AuthSignedIn` users (the Home body itself stays unchanged for signed-out users). The card is sourced from the same `GET /api/v1/users/active` endpoint that the web app uses, returning a small avatar roster plus an aggregated **today's practice** stat.
+
+## MVP behavior
+
+- **Endpoint**: `GET /api/v1/users/active`, called with the device timezone. The JSON shape is camelCase and decoded via the shared `convertKeysToCamel` helper (`lib/data/api/case_conversion.dart`).
+- **Timeout**: the request uses an **8-second client timeout**; on timeout (or any other error), the card hides / shows no data rather than a retry affordance (matches web parity).
+- **Variants**: `CommunityActivityCardVariant.card` (full stats + up to 8 avatars; tablet/desktop) and `CommunityActivityCardVariant.summary` (compact headline + up to 4 avatars; mobile insight strip).
+- **Today stats**: when the server returns `recordingsCountToday` / `recordingsDurationToday`, the card shows the aggregated practice volume; otherwise the stat row is hidden.
+- **Avatars**: rendered with `CachedNetworkImage` from `avatarUrl`; missing avatars fall back to **initials** derived from the user's name (`_initials` in `community_activity_card.dart`).
+- **Layout**: on wide viewports (≈720px+) Today's Goal and Community Activity cards share a responsive two-column row above the recent media grid; on narrow screens they stack.
+
+## Signed-in gating
+
+The card is only mounted on Home when `authCtrlProvider` reports `AuthSignedIn`. The Home screen otherwise renders the existing recents grid with no community / today's-goal section. No retry affordance for the community API: a transient error → empty card.
+
+## Code map
+
+| Area | Path |
+|------|------|
+| Domain models | [`lib/features/community/domain/active_user.dart`](../../lib/features/community/domain/active_user.dart) |
+| Riverpod provider | [`lib/features/community/application/active_users_provider.dart`](../../lib/features/community/application/active_users_provider.dart) |
+| Card UI (card + summary variants) | [`lib/features/community/presentation/community_activity_card.dart`](../../lib/features/community/presentation/community_activity_card.dart) |
+
+## Related
+
+- Home screen: [`docs/features/library.md`](library.md) (Home / Today's Goal block shares the responsive two-column row)
+- Auth: [`docs/features/auth.md`](auth.md)
+- ADR: [`docs/decisions/0010-cloud-sync-mvp.md`](../decisions/0010-cloud-sync-mvp.md)

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -1,0 +1,62 @@
+# Feature: Settings
+
+## Summary
+
+The Settings hub is reached at `/settings` and groups every preference surface in one editorial screen. It also hosts two **sub-screens** — `/settings/hotkeys` (keyboard shortcuts) and `/settings/sync` (cloud metadata sync status) — and the **About / update** entry. The screen mixes a single `SliverList` composition with **14 private widgets**, **2 `ConsumerStatefulWidget` editors**, and a dialog builder, all currently living in `lib/features/settings/presentation/settings_screen.dart` (≈1566 LOC; see [Issue #45](https://github.com/baizhiheizi/enjoy_player/issues/45) for the deferred split plan).
+
+## Routes
+
+| Path | Purpose |
+|------|---------|
+| `/settings` | Hub screen |
+| `/settings/hotkeys` | Keyboard shortcuts editor (sub-screen) |
+| `/settings/sync` | Cloud metadata sync status (sub-screen) |
+
+## Sections
+
+- **Account hero** — `_AccountHeroCard` shows the signed-in profile (avatar, name, email) or a guest chip; `_AccountHeroSkeleton` is the loading state. Sign-out lives in the account hero's overflow menu with a confirmation dialog.
+- **Guest data migration** — visible only when signed out; explains that locally stored media will be claimed on sign-in.
+- **Cloud sync** — links to `/settings/sync` and surfaces a `_SyncQueueStatusPill` (synced / queued / error) read from the sync status provider.
+- **Appearance & language** — display + native language pickers (`language_choice_sheet.dart`). Selection persists via `SettingsKeys.prefsDisplayLanguage` / `prefsNativeLanguage`.
+- **Recording** — microphone picker (auto + every input device returned by `AudioRecorder.listInputDevices()`; see [`echo-mode.md`](echo-mode.md) for the virtual-device skip list).
+- **Keyboard shortcuts** — link to `/settings/hotkeys` (full editor).
+- **Developer** — API base URL editors for the **Worker** and the **AI gateway** (`_ApiBaseUrlEditor`, `_AiApiBaseUrlEditor`); visible only in debug builds. Also links to the AI playground (see [`ai.md`](ai.md)).
+- **About / update** — gradient About card (`about_section_card.dart`) and a link into the update prompt flow (see [`update.md`](update.md)).
+
+## Sub-screens
+
+### `/settings/hotkeys`
+
+Full keyboard shortcut editor. Backed by `HotkeysService` (see [`hotkeys.md`](hotkeys.md)); the screen shows current bindings, surfaces conflicts, and offers a confirmation dialog on save.
+
+### `/settings/sync`
+
+Cloud metadata sync status (see [`sync.md`](sync.md)). Shows the queue, last sync time, per-target progress, and a manual sync button. Read-only; the user cannot change sync configuration from this screen (that's in the [ADR-0010](../decisions/0010-cloud-sync-mvp.md) cloud-sync MVP scope).
+
+## Account hero states
+
+- **Signed in** → avatar + display name + email, plus overflow menu with **Sign out** (with confirmation dialog that warns about cloud data).
+- **Loading** → `_AccountHeroSkeleton` shimmer.
+- **Signed out** → guest chip with **Sign in** CTA pointing at `/sign-in?from=/settings`.
+
+## Sign-out flow
+
+Confirmation dialog explains cloud-side consequences (per-target recordings will remain on the server, scoped to the account). On confirm: `authCtrlProvider.signOut()` clears the secure token store, closes the per-user SQLite, and routes back to `/sign-in`.
+
+## Code map
+
+| Area | Path |
+|------|------|
+| Hub screen | [`lib/features/settings/presentation/settings_screen.dart`](../../lib/features/settings/presentation/settings_screen.dart) |
+| Language picker sheet | [`lib/features/settings/presentation/widgets/language_choice_sheet.dart`](../../lib/features/settings/presentation/widgets/language_choice_sheet.dart) |
+| About card | [`lib/features/settings/presentation/widgets/about_section_card.dart`](../../lib/features/settings/presentation/widgets/about_section_card.dart) |
+| Hotkeys sub-screen | [`lib/features/settings/presentation/hotkeys_settings_screen.dart`](../../lib/features/settings/presentation/hotkeys_settings_screen.dart) |
+| Sync sub-screen | [`lib/features/settings/presentation/sync_status_screen.dart`](../../lib/features/settings/presentation/sync_status_screen.dart) |
+
+## Related
+
+- Auth: [`docs/features/auth.md`](auth.md)
+- Hotkeys: [`docs/features/hotkeys.md`](hotkeys.md)
+- Sync: [`docs/features/sync.md`](sync.md)
+- App updates: [`docs/features/update.md`](update.md)
+- Production diagnostics: [`docs/features/diagnostics.md`](diagnostics.md)

--- a/docs/features/shadow-reading.md
+++ b/docs/features/shadow-reading.md
@@ -1,0 +1,47 @@
+# Feature: Shadow reading (echo)
+
+## Summary
+
+Shadow reading is the **record-while-you-listen** flow that lives below the **echo region** in the expanded player. The user listens to a cue, records themselves reading it back via the **shadow reading panel**, optionally runs **Azure pronunciation assessment** on the take, and (now) can **export a shareable practice poster** (see [`echo-mode.md`](echo-mode.md) and [`share-poster.md`](share-poster.md)).
+
+The panel is mounted only when **echo mode is active** and the current media has a usable transcript.
+
+## Recording bus
+
+The recording bus is the single source of truth for "is the user recording right now":
+
+- `ShadowReadingHotkeyBus` (a singleton bus, generated from `shadow_reading_hotkey_bus.dart`) emits typed events (`ShadowRecordingHotkeyEvent`) when the user presses the global shortcut, toggling the panel's idle toolbar state. The bus decouples the hotkey layer (which knows nothing about the panel) from the UI.
+- Mic selection is persisted in `SettingsKeys.prefsRecordingInputDeviceId` and re-read on every take via `recordingInputDeviceCtrlProvider`. Unknown / virtual devices are skipped by `pickPreferredInputDeviceId` (GlideX Shared Audio, VoiceMeeter, VB-Audio CABLE, NVIDIA Broadcast, etc.) so Windows defaults don't silently capture only zeros.
+
+## Idle toolbar (centered FAB)
+
+- The panel shows an **idle toolbar** with the **pitch icon**, a centered **FAB** (start recording), **play**, and **pronunciation assess**. Delete moves into a **more** menu gated by a confirmation dialog.
+- When recording is in flight, the panel swaps to **recording-only focus**: FAB + countdown vs the active echo segment, with the pitch chart and takes list hidden until the take is committed.
+- All idle toolbar controls use **≥44×44** hit targets where possible; the assessment badge control is **44×44** with explicit `Semantics(label, button)` so VoiceOver / TalkBack see it as a control, not only a tooltip.
+
+## Pitch contour
+
+When the user opts in, the panel runs **pitch contour** analysis on the take:
+
+1. `echo_segment_pcm_extractor.dart` extracts the relevant echo segment as PCM via **FFmpeg**.
+2. `yin_pitch.dart` runs the **YIN** algorithm over the PCM to produce a pitch envelope.
+3. `pitch_contour_chart.dart` renders the envelope; `pitch_contour_section.dart` exposes it as a collapsible section that can be **parent-driven** (`expanded`, `showHeader: false` for chart-only body).
+
+## Pronunciation assessment (Azure)
+
+The optional **pronunciation assessment** path runs after a take lands:
+
+1. `recording_assessment_controller.dart` requests a **Worker Azure speech token** from Enjoy (`POST /ai/pronunciation/token`) and passes it to the native `azure_speech` plugin.
+2. The plugin returns a JSON `pronunciationScore` / `accuracyScore` / `fluencyScore` / `completenessScore` plus per-word detail. The result is persisted to the recording row (`pronunciation_score`, `assessment_json`).
+3. `AssessmentResultDialog` / sheet reopens the score when the user taps the score badge. The wide layout uses the **rail breakpoint** (900px), not the transcript breakpoint (720px).
+4. Take menu shows per-take scores and a **Re-assess** entry when the current take already has `assessment_json`.
+
+Silent FFmpeg WAV normalize is auto-detected and the resample chain is retried (see commit history around Azure assessment). Zero-score runs are persisted and logged.
+
+## Related
+
+- Echo mode (parent context): [`docs/features/echo-mode.md`](echo-mode.md)
+- Share practice poster (echo-tailored export): [`docs/features/share-poster.md`](share-poster.md)
+- AI capability routes (assessment, chat, translation): [`docs/features/ai.md`](ai.md)
+- Native speech package: `packages/azure_speech/`
+- ADR: [`docs/decisions/0005-mvp-scope-local-only.md`](../decisions/0005-mvp-scope-local-only.md) (echo + shadow reading scope)

--- a/docs/features/update.md
+++ b/docs/features/update.md
@@ -1,0 +1,74 @@
+# Feature: App updates (direct distribution)
+
+## Summary
+
+Enjoy Player distributes **direct** updates (not via a store) on **Windows** and **macOS**, and falls back to **NoOp** on iOS / Android (the store handles updates there). The flow fetches a remote **version manifest**, compares against the running version, and either **silently logs up-to-date**, shows an **optional** prompt, or blocks on a **mandatory** update. Snooze is honored until a per-release deadline.
+
+## Channel split
+
+| Channel | Platforms | Strategy |
+|---------|-----------|----------|
+| Direct | Windows, macOS | `DirectUpdateStrategy` — fetches the remote `latest.json`, evaluates, prompts. |
+| Store | iOS, Android | `NoOpUpdateStrategy` — store handles updates; we don't prompt. |
+
+The channel is resolved by `DISTRIBUTION_CHANNEL` env / build flag (see [ADR-0023](../decisions/0023-app-update-distribution.md)).
+
+## Manifest schema
+
+`latest.json` is fetched from the project's CDN; the schema is parsed by `version_manifest_repository.dart` into a `ReleaseManifest`:
+
+```json
+{
+  "version": "0.2.4",
+  "build": 5,
+  "minSupportedVersion": "0.2.0",
+  "notes": "...",
+  "assets": {
+    "windows": { "url": "...", "sha256": "...", "file": "EnjoyPlayer-0.2.4.exe" },
+    "macos":   { "url": "...", "sha256": "...", "file": "EnjoyPlayer-0.2.4.dmg" }
+  }
+}
+```
+
+`checksum_verifier.dart` validates `sha256` against the downloaded asset before install.
+
+## Evaluator rules (`UpdateEvaluator.evaluateUpdate`)
+
+- If `currentVersion >= manifest.version` → `upToDate`.
+- Else if `currentVersion < manifest.minSupportedVersion` → `mandatoryUpdate`.
+- Else if `snoozedVersion == manifest.version` and `clock < snoozeUntil` → `upToDate`.
+- Else → `updateAvailable`.
+
+`semver_compare.dart` provides `isVersionLessThan` (numeric component compare, ignoring pre-release tags; matches web `semverLessThan`).
+
+## Prompt UX
+
+`update_prompt_dialog.dart` is rendered by `update_prompt_host.dart` from inside the app shell (not a separate route), so it floats above whatever is on screen:
+
+- **Optional**: **Update now** / **Later** / **Snooze until tomorrow**. The user's choice is persisted in `SettingsKeys.prefsSnoozedVersion` + `prefsSnoozeUntil`.
+- **Mandatory**: **Update now** is the only available action; the dialog blocks interaction until the user accepts (or the install completes / fails). On Windows, the dialog drives the in-app installer handoff; on macOS, the dialog opens the downloaded `.dmg`.
+
+## Failure modes
+
+- **Manifest fetch fails** → swallow the error (logged). The user is not prompted; the next app launch retries.
+- **Checksum mismatch** → the download is discarded and an error toast is shown.
+- **Install handoff fails** (e.g. permission) → the prompt reappears on next launch.
+- **Out-of-date without mandatory** → the prompt can be permanently dismissed by the user (snooze is the lighter-weight path; **dismiss** is reserved for the support contact path).
+
+## Code map
+
+| Area | Path |
+|------|------|
+| Manifest repository | [`lib/features/update/data/version_manifest_repository.dart`](../../lib/features/update/data/version_manifest_repository.dart) |
+| Checksum verifier | [`lib/features/update/data/checksum_verifier.dart`](../../lib/features/update/data/checksum_verifier.dart) |
+| Evaluator | [`lib/features/update/application/update_evaluator.dart`](../../lib/features/update/application/update_evaluator.dart) |
+| Direct strategy | [`lib/features/update/application/direct_update_strategy.dart`](../../lib/features/update/application/direct_update_strategy.dart) |
+| No-op strategy | [`lib/features/update/application/noop_update_strategy.dart`](../../lib/features/update/application/noop_update_strategy.dart) |
+| Controller | [`lib/features/update/application/update_controller.dart`](../../lib/features/update/application/update_controller.dart) |
+| Prompt UI | [`lib/features/update/presentation/update_prompt_dialog.dart`](../../lib/features/update/presentation/update_prompt_dialog.dart) |
+
+## Related
+
+- ADR: [`docs/decisions/0023-app-update-distribution.md`](../decisions/0023-app-update-distribution.md)
+- Production diagnostics: [`docs/features/diagnostics.md`](diagnostics.md) (update failures feed diagnostic log)
+- Packaging: [`docs/packaging.md`](../packaging.md)


### PR DESCRIPTION
## Summary

Closes the documentation gap for four features that previously had no entry in `docs/features/` even though they have a first-class `lib/features/<name>/` directory:

- **`community/`** — signed-in Home community activity card (`ActiveUsersResponse`, signed-in gating, `CommunityActivityCard` variants, loading/error states, sizing constants).
- **`settings/`** — Settings screen hub + `/settings/hotkeys` + `/settings/sync` sub-screens + the About / update entry. Documents sections, account hero states, sign-out flow, language and microphone pickers, the developer (API / AI base URL) editors.
- **`shadow_reading/`** — shadow reading panel, recording bus, pitch contour (FFmpeg PCM extract + YIN envelope), Azure pronunciation assessment.
- **`update/`** — channel split (`NoOp` for iOS/Android, `Direct` for Windows/macOS), `latest.json` schema, `UpdateEvaluator` rules, prompt UX, snooze + mandatory semantics, platform install hooks.

Each new doc follows the same shape as the existing feature specs (Summary, MVP behavior / UX rules, Code map, Related cross-links / ADRs).

## Files

- ➕ `docs/features/community.md`
- ➕ `docs/features/settings.md`
- ➕ `docs/features/shadow-reading.md`
- ➕ `docs/features/update.md`
- ✏️ `docs/README.md` — registers the four new entries in the documentation index so maintainers know when to update them.

## Why a PR

Per the AGENTS.md rule "Documentation hygiene: ... Feature behavior changes → update `docs/features/<feature>.md`", these additions satisfy an existing red-build gap. No code change accompanies them.

## Verification

- ✅ Files render correctly as Markdown.
- ✅ All cross-references point at existing files (`docs/features/...`, `docs/decisions/...`, `lib/features/...`).
- ✅ No new code, so `flutter analyze` / `flutter test` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #4