### PR TITLE
docs: sync Dart SDK, fix i18n link, inappwebview status, feature index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,9 @@ Maintainers and agents should keep these files **accurate** when behavior or arc
 | [features/shadow-reading.md](features/shadow-reading.md) | Product + dev | Shadow reading panel, recording bus, pitch contour, or Azure pronunciation assessment behavior changes |
 | [features/update.md](features/update.md) | Product + dev | App update strategy (NoOp / Direct), manifest schema, evaluator rules, or prompt UX change |
 | [features/share-poster.md](features/share-poster.md) | Product + dev | Shareable practice poster (echo-tailored cover + quote) behavior changes |
+| [features/player.md](features/player.md) | Product + dev | Player engine binding, expand/collapse, transport, echo enforcement, or wide-layout behavior changes |
+| [features/transcript.md](features/transcript.md) | Product + dev | Transcript loading, line navigation, auto-scroll, or cloud fetch behavior changes |
+| [features/echo-mode.md](features/echo-mode.md) | Product + dev | Echo region, shadow-reading, pronunciation assessment, or share practice poster behavior changes |
 
 ## How to add an ADR
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -2,7 +2,7 @@
 
 | Concern | Choice | Notes |
 |---------|--------|-------|
-| Language | Dart ^3.9 | Strict analysis |
+| Language | Dart ^3.12 | Strict analysis; matches `sdk: ^3.12.0` in `pubspec.yaml`. Flutter pinned in [`.github/flutter-version`](../.github/flutter-version). |
 | UI | Flutter 3.x / Material 3 + `google_fonts` | Dark-only `buildAppTheme()` + `EnjoyThemeTokens` in `lib/core/theme/` |
 | State | `flutter_riverpod` + `riverpod_annotation` | `@Riverpod` notifiers, `build_runner` |
 | Navigation | `go_router` | Shell route for persistent mini player |
@@ -15,8 +15,10 @@
 | Secure storage | `flutter_secure_storage` | Access token only |
 | Browser / deep links | `url_launcher` | OAuth `start_auth` browser step |
 | Markdown (AI explanations) | `flutter_markdown` | Contextual translation in transcript lookup sheet |
-| i18n | `flutter_localizations` + ARB | `lib/l10n/app_en.arb`, `app_zh.arb`, `app_zh_CN.arb`; default display locale `zh-CN` ([`kAppDefaultDisplayLocale`](../lib/core/application/app_preferences_provider.dart)) |
+| i18n | `flutter_localizations` + ARB | `lib/l10n/app_en.arb`, `app_zh.arb`, `app_zh_CN.arb`; default display locale `zh-CN` ([`kAppDefaultDisplayLocale`](../lib/core/application/app_language_catalog.dart)) |
 | Codegen | `build_runner`, `drift_dev`, `riverpod_generator` | Run after schema/provider edits |
 | Lint | `flutter_lints` | `analysis_options.yaml` (no `custom_lint`: incompatible analyzer range vs `drift_dev` / codegen) |
 
-Deferred (ADR-0005): `flutter_inappwebview`, URL streaming UX polish. Library/recording **cloud sync** remains deferred; see [ADR-0006](decisions/0006-auth-and-profile-sync.md) for optional auth + profile scope.
+Deferred (ADR-0005): URL streaming UX polish. Library/recording **cloud sync** remains deferred; see [ADR-0006](decisions/0006-auth-and-profile-sync.md) for optional auth + profile scope.
+
+> Note: `flutter_inappwebview` is **active** (not deferred) — it powers the YouTube player per [ADR-0015](decisions/0015-youtube-playback.md) and the in-app Enjoy sign-in WebView per [ADR-0027](decisions/0027-native-auth-v2.md).


### PR DESCRIPTION
## Summary

Four documentation drift fixes uncovered while auditing the docs against the current code.

## Changes

- **`docs/tech-stack.md`** — Sync the Dart SDK requirement to `^3.12` to match `pubspec.yaml` (`sdk: ^3.12.0`). The previous `^3.9` was stale. Also link the Flutter pin to [`.github/flutter-version`](../.github/flutter-version).
- **`docs/tech-stack.md`** — Fix the `kAppDefaultDisplayLocale` link to point at `lib/core/application/app_language_catalog.dart` (the actual definition), not `app_preferences_provider.dart`.
- **`docs/tech-stack.md`** — Remove `flutter_inappwebview` from the *deferred* list. It is an active dependency for the YouTube player ([ADR-0015](../decisions/0015-youtube-playback.md)) and in-app sign-in ([ADR-0027](../decisions/0027-native-auth-v2.md)).
- **`docs/README.md`** — Add the three missing feature docs to the index: `features/player.md`, `features/transcript.md`, and `features/echo-mode.md`. The `echo-mode.md` entry covers `lib/features/shadow_reading/` since that feature folder has a non-obvious name.

## Why

Documentation gaps were treated like failing tests. Each of these would have misled a new contributor (wrong SDK, 404 link, missing index entries, mis-categorized active dependency).

## Verification

- ✅ `Dart ^3.12` matches `pubspec.yaml`'s `sdk: ^3.12.0` and Flutter 3.44.2's bundled Dart 3.12.2.
- ✅ `kAppDefaultDisplayLocale` is defined in `lib/core/application/app_language_catalog.dart`.
- ✅ `flutter_inappwebview: ^6.1.5` is a direct dependency in `pubspec.yaml` and referenced in ADR-0015 / ADR-0027.
- ✅ All three index entries (`player.md`, `transcript.md`, `echo-mode.md`) exist in `docs/features/`.

Closes #54