### PR TITLE
fix(db): bound per-user Drift database cache to 2 entries

### DIFF
--- a/lib/data/db/app_database_provider.dart
+++ b/lib/data/db/app_database_provider.dart
@@ -1,6 +1,9 @@
 /// Provides [AppDatabase] for the current auth session (per-user SQLite file).
 library;
 
+import 'dart:async';
+import 'dart:collection';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -11,9 +14,22 @@ import 'app_database.dart';
 
 part 'app_database_provider.g.dart';
 
+/// Maximum number of per-user [AppDatabase] instances kept open simultaneously.
+///
+/// Only the guest DB and the most recently used per-user DB need to be live at
+/// the same time — signing in as a new user closes the previous one. Two is
+/// enough because the guest DB is owned by [guestAppDatabaseProvider] (a
+/// separate keep-alive provider with its own onDispose), and only one
+/// per-user DB is "current" at a time. Anything older is evicted.
+const int _kMaxUserSessionDatabases = 2;
+
 /// One [AppDatabase] per signed-in session name — avoids constructing a new
 /// [AppDatabase] on every [appDatabase] rebuild (Drift multiple-instances warning).
-final Map<String, AppDatabase> _userSessionDatabases = <String, AppDatabase>{};
+///
+/// Bounded to [_kMaxUserSessionDatabases] entries; the oldest is evicted (and
+/// closed) before inserting a new one.
+final LinkedHashMap<String, AppDatabase> _userSessionDatabases =
+    LinkedHashMap<String, AppDatabase>();
 
 /// Drift file base name for the current auth session (guest vs per-user).
 ///
@@ -55,13 +71,29 @@ AppDatabase appDatabase(Ref ref) {
     return ref.watch(guestAppDatabaseProvider);
   }
 
-  return _userSessionDatabases.putIfAbsent(sessionName, () {
-    final db = AppDatabase(name: sessionName);
+  // Re-inserting an existing key moves it to the end (most recently used) so
+  // the eviction loop below drops the truly idle DBs first.
+  final existing = _userSessionDatabases.remove(sessionName);
+  if (existing != null) {
+    _userSessionDatabases[sessionName] = existing;
     ref.onDispose(() {
       _userSessionDatabases.remove(sessionName)?.close();
     });
-    return db;
+    return existing;
+  }
+
+  while (_userSessionDatabases.length >= _kMaxUserSessionDatabases) {
+    final oldestKey = _userSessionDatabases.keys.first;
+    final oldest = _userSessionDatabases.remove(oldestKey);
+    unawaited(oldest?.close());
+  }
+
+  final db = AppDatabase(name: sessionName);
+  _userSessionDatabases[sessionName] = db;
+  ref.onDispose(() {
+    _userSessionDatabases.remove(sessionName)?.close();
   });
+  return db;
 }
 
 String _sanitizeUserIdForDbName(String id) =>


### PR DESCRIPTION
## Summary

Fixes `lib/data/db/app_database_provider.dart`: the module-level `_userSessionDatabases` map was effectively unbounded — `ref.onDispose` only fires when the `ProviderContainer` is disposed (i.e. process exit in normal flow), so per-user Drift databases never closed during the app lifetime. With Drift using file-based SQLite, each entry holds a file descriptor plus a worker isolate executor; Windows has a 512-handle per-process cap (`CreateFileW`) and Linux defaults to `ulimit -n 1024`.

### Change

- Switch `_userSessionDatabases` from `Map` to `LinkedHashMap` ordered by recency.
- When a previously-seen session name is re-requested, move it to the end (most recently used).
- Before inserting a new entry, evict and `close()` the oldest until length < 2.
- Cap is `_kMaxUserSessionDatabases = 2`. Guest DB is owned separately by `guestAppDatabaseProvider` (its own keep-alive provider with its own `onDispose`), so only the most-recently-used per-user DB is "live" at any moment.

## Test plan

- [x] `flutter analyze` — clean on `lib/data/db/app_database_provider.dart`
- [x] `flutter test test/features/player/ test/features/auth/ test/data/` — 165 tests pass

## Human follow-up

None — the change is self-contained. The per-user sign-in race noted in #83 (`sync_controller.dart` may read the guest DB at the moment `authCtrlProvider` has flipped) is a separate fix and is not addressed here.
