### PR TITLE
fix(bootstrap): install error handlers and runZonedGuarded

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,29 @@
+import 'dart:async';
+import 'dart:ui';
+
 import 'package:drift/drift.dart' show driftRuntimeOptions;
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kDebugMode, kProfileMode, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'app.dart';
 import 'core/logging/diagnostic_log_config.dart';
 import 'core/logging/diagnostic_session_header.dart';
+import 'core/logging/log.dart';
 import 'core/logging/setup_logging.dart';
 import 'core/webview/platform_webview_environment.dart';
 
 Future<void> main() async {
+  await runZonedGuarded<Future<void>>(_bootstrap, _onZoneError);
+}
+
+final Logger _bootstrapLog = logNamed('bootstrap');
+
+Future<void> _bootstrap() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Two AppDatabase instances are expected: the device-global `guest` DB
   // (settings such as API base URL) and the per-user signed-in DB. They use
@@ -21,10 +32,15 @@ Future<void> main() async {
   driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
   await DiagnosticLogConfig.loadFromGuestSettings();
   await setupAppLogging();
+  _installFrameworkErrorHandlers();
   if (defaultTargetPlatform == TargetPlatform.windows) {
     await ensureWindowsWebViewEnvironment();
   }
-  await writeDiagnosticSessionHeader();
+  try {
+    await writeDiagnosticSessionHeader();
+  } on Object catch (e, st) {
+    _bootstrapLog.warning('writeDiagnosticSessionHeader failed', e, st);
+  }
   MediaKit.ensureInitialized();
 
   if (defaultTargetPlatform == TargetPlatform.windows ||
@@ -48,4 +64,23 @@ Future<void> main() async {
     app = const ExcludeSemantics(child: root);
   }
   runApp(app);
+}
+
+void _installFrameworkErrorHandlers() {
+  FlutterError.onError = (FlutterErrorDetails details) {
+    _bootstrapLog.severe(
+      'FlutterError: ${details.exceptionAsString()}',
+      details.exception,
+      details.stack,
+    );
+    FlutterError.presentError(details);
+  };
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    _bootstrapLog.severe('PlatformDispatcher error', error, stack);
+    return true;
+  };
+}
+
+void _onZoneError(Object error, StackTrace stack) {
+  _bootstrapLog.severe('Uncaught zone error', error, stack);
 }


### PR DESCRIPTION
## Summary

`lib/main.dart` has no `runZonedGuarded`, `FlutterError.onError`, or `PlatformDispatcher.onError` handlers. A throw from `ensureWindowsWebViewEnvironment`, `MediaKit.ensureInitialized`, `windowManager.waitUntilReadyToShow`, or `writeDiagnosticSessionHeader` (which itself calls `PackageInfo.fromPlatform()` and can throw on macOS sandbox first run) crashes startup with no diagnostic capture.

### Changes

- Wrap the entire bootstrap in `runZonedGuarded`. The zone's error callback logs to the `bootstrap` logger and is routed through the existing logging pipeline (which writes to `LogFileSink` if initialized).
- Install `FlutterError.onError` so framework errors during the first frame are logged before `FlutterError.presentError` is called (debug builds still see the standard red screen).
- Install `PlatformDispatcher.instance.onError` for errors that escape both the framework and the zone.
- Wrap `writeDiagnosticSessionHeader()` in a try/catch — it is purely diagnostic and must never block startup.

## Test plan

- [x] `flutter analyze lib/main.dart` — clean
- [x] `flutter test` — only the 2 pre-existing failures remain (`library_media_provider_test.dart`, `recommended_channels_test.dart`, both unrelated and broken on `main`)

## Behavioral notes

- Errors routed through the `bootstrap` logger use the same `setupAppLogging()` pipeline as everything else. The `LogFileSink` redaction rules already strip credentials and PII before writing to disk.
- `_installFrameworkErrorHandlers` is called after `setupAppLogging()` so the `Logger` is hooked before any handler logs.
- No changes to existing debug behavior (red error widget still shows in debug).

## Out of scope (flagged in #83)

- `lib/app.dart` recovery UI for a corrupt DB (no "Clear local data" button) — separate PR
- `app.dart _lastResolvedPrefs` state mutation during build — separate cleanup
