### PR TITLE
fix(auth): cancel deep-link stream subscription + handle initial link errors

### DIFF
--- a/lib/features/auth/application/auth_deep_link_listener.dart
+++ b/lib/features/auth/application/auth_deep_link_listener.dart
@@ -1,6 +1,8 @@
 /// Listens for OAuth PKCE deep-link callbacks and forwards them to [AuthCtrl].
 library;
 
+import 'dart:async';
+
 import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -25,12 +27,24 @@ class AuthDeepLinkListener extends ConsumerStatefulWidget {
 
 class _AuthDeepLinkListenerState extends ConsumerState<AuthDeepLinkListener> {
   final AppLinks _appLinks = AppLinks();
+  StreamSubscription<Uri>? _streamSub;
 
   @override
   void initState() {
     super.initState();
-    _appLinks.getInitialLink().then(_onUri);
-    _appLinks.uriLinkStream.listen(_onUri);
+    _appLinks.getInitialLink().then(_onUri, onError: _onInitialLinkError);
+    _streamSub = _appLinks.uriLinkStream.listen(_onUri);
+  }
+
+  @override
+  void dispose() {
+    _streamSub?.cancel();
+    _streamSub = null;
+    super.dispose();
+  }
+
+  void _onInitialLinkError(Object error, StackTrace stack) {
+    _log.warning('app_links.getInitialLink failed', error, stack);
   }
 
   Future<void> _onUri(Uri? uri) async {


### PR DESCRIPTION
## Summary

`AuthDeepLinkListener` registered a deep-link stream subscription without storing it, and called `_appLinks.getInitialLink().then(_onUri)` without an `onError` handler.

### Changes

- Store `StreamSubscription<Uri>? _streamSub` on the state and cancel it in `dispose()`. The widget is mounted at the top of `EnjoyApp` and never disposes during normal app lifetime, so this is a leak rather than a functional bug — but it now disposes cleanly on hot reload during development.
- Add `onError` to `getInitialLink().then(_onUri, onError: _onInitialLinkError)`. A missing plugin on a platform variant throws and previously escaped to the global zone (now caught by PR4's `runZonedGuarded`); this surfaces it through the existing logging pipeline before the catch-all runs.

## Test plan

- [x] `flutter analyze lib/features/auth/application/auth_deep_link_listener.dart` — clean
- [x] `flutter test test/features/auth/` — 21 tests pass

## Out of scope (flagged in #83)

- `flutter_secure_storage` Android `EncryptedSharedPreferences` option pinning — security PR
- `refreshSession` clears session on ANY exception (transient network → sign-out) — needs human review of the auth flow
- `AuthFailure` enum-based error codes — refactor of error handling across multiple features
