### PR TITLE
chore: remove kIsWeb branches (AGENTS.md hard rule)

### DIFF
--- a/lib/core/logging/log_file_sink.dart
+++ b/lib/core/logging/log_file_sink.dart
@@ -3,7 +3,6 @@ library;
 
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -28,9 +27,6 @@ class LogFileSink {
 
   static Future<LogFileSink?> ensureInitialized() async {
     if (_instance != null) return _instance;
-    if (kIsWeb) {
-      return null;
-    }
     try {
       final support = await getApplicationSupportDirectory();
       final dir = Directory(p.join(support.path, 'logs'));

--- a/lib/features/share_poster/application/practice_poster_export.dart
+++ b/lib/features/share_poster/application/practice_poster_export.dart
@@ -2,10 +2,10 @@
 library;
 
 import 'dart:io';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
@@ -36,10 +36,8 @@ Future<Uint8List?> captureRepaintBoundaryPng(
   return byteData?.buffer.asUint8List();
 }
 
-bool get _isMobileSharePlatform {
-  if (kIsWeb) return false;
-  return Platform.isIOS || Platform.isAndroid;
-}
+bool get _isMobileSharePlatform =>
+    Platform.isIOS || Platform.isAndroid;
 
 Future<void> sharePracticePosterPng(Uint8List pngBytes) async {
   final file = XFile.fromData(


### PR DESCRIPTION
## Summary

`AGENTS.md` hard rule: *"Do not add Flutter web targets, `web/` scaffolding, or `kIsWeb` branches — native desktop/mobile only."*

Two production files had unreachable `kIsWeb` guards for a never-taken path:

### `lib/core/logging/log_file_sink.dart`

The `if (kIsWeb) return null;` guard inside `LogFileSink.ensureInitialized` is unreachable on the supported native targets. The existing `try/catch` already handles the case where `getApplicationSupportDirectory()` fails. Removes the `flutter/foundation.dart` import too (was only used for `kIsWeb`).

### `lib/features/share_poster/application/practice_poster_export.dart`

The `if (kIsWeb) return false;` guard inside `_isMobileSharePlatform` was unreachable. Collapses to a direct `Platform.isIOS || Platform.isAndroid` expression.

### Not touched: `lib/data/api/recording_client_platform_stub.dart`

This file is a `dart.library.io` conditional-import fallback (`String recordingClientPlatformValue() => 'web';`). On supported targets Dart selects `recording_client_platform_io.dart` instead. The `'web'` default is only reached if the app were compiled for web, which `AGENTS.md` forbids — so it's unreachable by construction but required for the conditional import to resolve at compile time. Leaving as-is.

## Test plan

- [x] `flutter analyze lib/core/logging/log_file_sink.dart lib/features/share_poster/application/practice_poster_export.dart` — clean
- [x] `flutter test test/features/share_poster/` — 17 tests pass

## Human follow-up

None. Mechanical removal of unreachable code paths.
