### PR TITLE
chore: fix README SDK drift + pin intl

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cross-platform **language-learning player** (Android, iOS, Windows, macOS; Linux
 ## Prerequisites
 
 - Flutter SDK (stable, 3.x)
-- Dart SDK ^3.9
+- Dart SDK ^3.12 (matches `pubspec.yaml` and `.github/flutter-version`)
 - **Apple (iOS + macOS)**: **Xcode**, **CocoaPods**, Apple Developer Program access for team **`46X685R747`**. See [packaging.md](docs/packaging.md#one-time-setup) for signing, TestFlight, and notarization.
 - **macOS desktop builds**: [Homebrew](https://brew.sh) plus FFmpeg kit deps — `brew bundle install --file=macos/Brewfile` (see [packaging.md](docs/packaging.md#troubleshooting)). Without this, `flutter run -d macos` can fail at launch with a missing `libz.1.dylib` / DYLD error.
 - **Windows desktop builds**: [NuGet CLI](https://learn.microsoft.com/en-us/nuget/install-nuget-client-tools?tabs=windows#nugetexe-cli) on your `PATH` (`nuget` / `nuget.exe`). Required by [`flutter_inappwebview`](https://inappwebview.dev/docs/intro#setup-windows) to pull WebView2 native dependencies during CMake/MSBuild. After installing, open a **new** terminal and run `nuget` to verify.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   go_router: ^17.2.3
   http: ^1.4.0
   google_fonts: ^8.1.0
-  intl: any
+  intl: ^0.20.2
   json_annotation: ^4.11.0
   logging: ^1.3.0
   meta: ^1.16.0


### PR DESCRIPTION
## Summary

Two small hygiene fixes flagged in #83:

### `README.md` SDK drift

Line 8 claimed `Dart SDK ^3.9` but `pubspec.yaml` requires `sdk: ^3.12.0` and `.github/flutter-version` pins Flutter `3.44.0` (Dart ~3.12). A contributor on Dart 3.10 or 3.11 would see the README say "fine" but `flutter pub get` would fail. Update the line to point at the actual constraint.

### `pubspec.yaml` `intl: any` pin

`intl: any` lets `flutter pub get` resolve any version. The lockfile pins `0.20.2` today, but a fresh machine could pull a different version (including `1.0.0` when it lands). Pin to `^0.20.2` to match the resolved version.

`dart pub get` confirms the lockfile is unchanged (no transitive bumps).

## Test plan

- [x] `dart analyze` — same 16 pre-existing issues, no new ones
- [x] `dart pub get` — clean, lockfile unchanged
- [x] `pubspec.lock` diff after `pub get` — empty

## Human follow-up

None. The pubspec constraints match the source of truth (lockfile + CI Flutter version).
