### PR TITLE
fix(auth): pin flutter_secure_storage AndroidOptions + iOS Keychain accessibility

### DIFF
--- a/lib/data/api/secure_token_store.dart
+++ b/lib/data/api/secure_token_store.dart
@@ -10,9 +10,23 @@ const _kAccessTokenKey = 'enjoy_player.access_token';
 const _kRefreshTokenKey = 'enjoy_player.refresh_token';
 const _kCachedProfileJsonKey = 'enjoy_player.cached_profile_json';
 
+/// Pin Android to the v10 default RSA-OAEP / AES-GCM ciphers (migrates from
+/// the deprecated Jetpack Security `encryptedSharedPreferences` on first read)
+/// and iOS to `first_unlock` so tokens survive device reboot but stay
+/// inaccessible until the user has unlocked the device at least once.
+const _kAndroidOptions = AndroidOptions();
+const _kIosOptions = IOSOptions(
+  accessibility: KeychainAccessibility.first_unlock,
+);
+
 @Riverpod(keepAlive: true)
 SecureTokenStore secureTokenStore(Ref ref) {
-  return SecureTokenStore(const FlutterSecureStorage());
+  return SecureTokenStore(
+    const FlutterSecureStorage(
+      aOptions: _kAndroidOptions,
+      iOptions: _kIosOptions,
+    ),
+  );
 }
 
 /// Thin wrapper around [FlutterSecureStorage].


### PR DESCRIPTION
## Summary

`FlutterSecureStorage()` in `lib/data/api/secure_token_store.dart` was constructed with plugin defaults:

- On Android, that fell through to the legacy `Keystore + SharedPreferences` path rather than the v10 RSA-OAEP / AES-GCM ciphers.
- On iOS, the default `KeychainAccessibility` (effectively `kSecAttrAccessibleWhenUnlocked`) does not survive the first-boot scenario where the device has rebooted but the user has not yet unlocked.

Pin both via `AndroidOptions()` (v10 defaults; auto-migrates existing entries from the legacy ciphers via the default `migrateOnAlgorithmChange = true`) and `IOSOptions(accessibility: KeychainAccessibility.first_unlock)`.

## Test plan

- [x] `flutter analyze lib/data/api/secure_token_store.dart` — clean
- [x] `dart run build_runner build` not required (no codegen-affecting changes)

## Out of scope

- Migrating the existing CI smoke flows — the v10 `migrateOnAlgorithmChange` handles on-device migration automatically on the next read.
- Refreshing `flutter_secure_storage` package version — already at `10.3.1` per `pubspec.lock`.

Refs #83
