### PR TITLE
fix(player): centralize position bucket constants + supportsSubtitleDisabling

### DIFF
--- a/lib/features/player/application/display_position_provider.dart
+++ b/lib/features/player/application/display_position_provider.dart
@@ -4,6 +4,7 @@ library;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'player_engine_provider.dart';
+import 'position_buckets.dart';
 import 'quantized_position.dart';
 
 part 'display_position_provider.g.dart';
@@ -11,7 +12,8 @@ part 'display_position_provider.g.dart';
 @riverpod
 Stream<Duration> displayPosition(Ref ref) {
   final engine = ref.watch(playerEngineProvider);
-  // Windows accessibility bridge can get flooded when semantics-heavy widgets
-  // (slider, transcript list items) rebuild for every raw position tick.
-  return quantizedPositionStream(engine.position, bucketMs: 400);
+  return quantizedPositionStream(
+    engine.position,
+    bucketMs: kPositionBucketDisplayMs,
+  );
 }

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -148,6 +148,9 @@ class YoutubePlayerEngine implements PlayerEngine {
   bool get supportsVideoPosterCapture => false;
 
   @override
+  bool get supportsSubtitleDisabling => false;
+
+  @override
   ({bool playing, bool buffering}) get transportSnapshot =>
       (playing: _playing, buffering: _buffering);
 

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -23,6 +23,7 @@ import 'package:enjoy_player/features/player/application/player_engine_binding.d
 import 'package:enjoy_player/features/player/application/player_engine_rev.dart';
 import 'package:enjoy_player/features/player/application/player_open_side_effects.dart';
 import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
+import 'package:enjoy_player/features/player/application/position_buckets.dart';
 import 'package:enjoy_player/features/player/application/video_poster_capture_service.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'open_media_provider.dart';
@@ -154,8 +155,10 @@ class PlayerController extends _$PlayerController {
       await engine.open(playable);
       if (gen != _openGeneration) return;
 
-      await engine.disableRenderedSubtitles();
-      if (gen != _openGeneration) return;
+      if (engine.supportsSubtitleDisabling) {
+        await engine.disableRenderedSubtitles();
+        if (gen != _openGeneration) return;
+      }
 
       await ref
           .read(playerPreferencesCtrlProvider.notifier)
@@ -264,8 +267,8 @@ class PlayerController extends _$PlayerController {
     // Raw mpv position can arrive very often (notably streaming). Updating
     // [PlaybackSession] on every tick rebuilds all [playerControllerProvider]
     // listeners and can overwhelm the Windows semantics bridge — same motivation
-    // as [displayPositionProvider]'s 200ms quantization.
-    const positionBucketMs = 400;
+    // as [displayPositionProvider]'s quantization.
+    const positionBucketMs = kPositionBucketEchoApplyMs;
     _positionSub = _activeEngine.position.listen(
       (pos) {
         if (gen != _openGeneration) return;

--- a/lib/features/player/application/player_engine.dart
+++ b/lib/features/player/application/player_engine.dart
@@ -26,6 +26,10 @@ abstract class PlayerEngine {
   /// Whether [screenshot] can produce stored video thumbnails (false for WebView).
   bool get supportsVideoPosterCapture;
 
+  /// Whether [disableRenderedSubtitles] does anything. YouTube / WebView
+  /// engines have no embedded subtitle track to disable.
+  bool get supportsSubtitleDisabling;
+
   /// Current transport flags for seeding [StreamProvider]s.
   ({bool playing, bool buffering}) get transportSnapshot;
 
@@ -144,6 +148,9 @@ class MediaKitPlayerEngine implements PlayerEngine {
 
   @override
   bool get supportsVideoPosterCapture => true;
+
+  @override
+  bool get supportsSubtitleDisabling => true;
 
   @override
   ({bool playing, bool buffering}) get transportSnapshot =>

--- a/lib/features/player/application/position_buckets.dart
+++ b/lib/features/player/application/position_buckets.dart
@@ -1,0 +1,14 @@
+/// Single source of truth for player position quantization buckets.
+///
+/// See [lib/features/player/application/quantized_position.dart] for the
+/// dedup behavior and the rationale for per-bucket tuning. The transport
+/// scrubber uses finer buckets than the transcript highlight so the slider
+/// tracks finger drags while the cue highlight skips per-tick rebuilds
+/// that flood the Windows accessibility bridge (flutter/flutter#182444).
+library;
+
+const int kPositionBucketEchoApplyMs = 400;
+
+const int kPositionBucketDisplayMs = 400;
+
+const int kPositionBucketScrubberMs = 50;

--- a/lib/features/player/application/quantized_position.dart
+++ b/lib/features/player/application/quantized_position.dart
@@ -2,9 +2,8 @@
 ///
 /// Folds [PlayerEngine.position] (ADR-0015) into N-millisecond buckets and
 /// drops equal emissions, so downstream widgets only rebuild when the
-/// quantized value actually changes. Used by both the transcript cue
-/// highlight (400ms buckets) and the transport scrubber (50ms buckets);
-/// see [displayPosition] and [transportSliderPositionProvider].
+/// quantized value actually changes. Bucket sizes are centralized in
+/// `position_buckets.dart`.
 library;
 
 /// Returns a stream that emits a new [Duration] every time the input

--- a/lib/features/player/application/transport_slider_position_provider.dart
+++ b/lib/features/player/application/transport_slider_position_provider.dart
@@ -4,10 +4,13 @@ library;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'player_engine_provider.dart';
+import 'position_buckets.dart';
 import 'quantized_position.dart';
 
-/// ~50ms buckets — smooth enough for the slider without flooding semantics rebuilds.
 final transportSliderPositionProvider = StreamProvider<Duration>((ref) {
   final engine = ref.watch(playerEngineProvider);
-  return quantizedPositionStream(engine.position, bucketMs: 50);
+  return quantizedPositionStream(
+    engine.position,
+    bucketMs: kPositionBucketScrubberMs,
+  );
 });

--- a/lib/features/player/application/video_poster_capture_service.dart
+++ b/lib/features/player/application/video_poster_capture_service.dart
@@ -112,8 +112,12 @@ class VideoPosterCaptureService {
       if (soughtForPoster && gen == currentOpenGeneration()) {
         try {
           await activeEngine.seek(Duration.zero);
-        } on Object {
-          // Best-effort restore start position after poster sampling seek.
+        } on Object catch (e, st) {
+          _log.warning(
+            'video poster capture failed to restore seek-zero position',
+            e,
+            st,
+          );
         }
       }
     }

--- a/test/support/fake_player_engine.dart
+++ b/test/support/fake_player_engine.dart
@@ -56,6 +56,9 @@ class FakePlayerEngine implements PlayerEngine {
   bool get supportsVideoPosterCapture => true;
 
   @override
+  bool get supportsSubtitleDisabling => true;
+
+  @override
   ({bool playing, bool buffering}) get transportSnapshot =>
       (playing: false, buffering: false);
 


### PR DESCRIPTION
## Summary

Two small player subsystem cleanups from issue #83:

### Centralize position bucket constants

Three quantization strategies for player position streams were defined inline in three files (`player_controller.dart` 400ms, `display_position_provider.dart` 400ms, `transport_slider_position_provider.dart` 50ms). Promote to a single `lib/features/player/application/position_buckets.dart` with named constants:

- `kPositionBucketEchoApplyMs = 400` — used by `PlayerController._subscribeStreams` to throttle echo-apply + position emit rebuilds.
- `kPositionBucketDisplayMs = 400` — used by `displayPositionProvider` for transcript cue highlight.
- `kPositionBucketScrubberMs = 50` — used by `transportSliderPositionProvider` for the scrubber slider.

### `PlayerEngine.supportsSubtitleDisabling`

YouTube / WebView engines have no embedded subtitle track to disable — `YoutubePlayerEngine.disableRenderedSubtitles` was a no-op but `PlayerController.openMedia` still `await`ed it on every YouTube open. Add `bool get supportsSubtitleDisabling` to `PlayerEngine` (MediaKit → true, YouTube → false). `openMedia` gates the call on the flag.

Also: `VideoPosterCaptureService` had a nested empty `on Object {}` swallowing seek-zero restore failures. Log at warning level instead so real errors aren't hidden.

## Test plan

- [x] `dart analyze lib/features/player/application/` — clean
- [x] `flutter test test/features/player/` — 77 tests pass
- [x] `FakePlayerEngine` updated to return `supportsSubtitleDisabling = true` (test double parity)

## Out of scope

- Splitting `PlayerController` into 4 classes — multi-day refactor, separate effort.
- Splitting `YoutubePlayerEngine` (~800 lines) into `YoutubeSession` / `YoutubeWebViewController` / `YoutubeStallWatchdog` / `YoutubeStatePoller` — multi-day refactor.
- Adding a test for the new `supportsSubtitleDisabling` gate — would need a MediaKit-specific fake; out of scope for this cleanup PR.

Refs #83
