### PR TITLE
fix(app): use ref.listen for appPreferencesCtrlProvider instead of build mutation

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -94,15 +94,23 @@ class _EnjoyAppState extends ConsumerState<EnjoyApp> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AsyncValue<AppPreferencesState>>(
+      appPreferencesCtrlProvider,
+      (prev, next) {
+        final nextPrefs = next.valueOrNull;
+        if (nextPrefs == null) return;
+        if (identical(nextPrefs, _lastResolvedPrefs)) return;
+        setState(() {
+          _lastResolvedPrefs = nextPrefs;
+        });
+      },
+    );
+
     final router = ref.watch(appRouterProvider);
     final prefsAsync = ref.watch(appPreferencesCtrlProvider);
     final theme = buildAppTheme();
 
     final live = prefsAsync.valueOrNull;
-    if (live != null) {
-      _lastResolvedPrefs = live;
-    }
-
     final effective = live ?? _lastResolvedPrefs;
 
     if (prefsAsync.hasError && effective == null) {


### PR DESCRIPTION
## Summary

`lib/app.dart` `_EnjoyAppState.build` wrote `_lastResolvedPrefs = live` as a side effect inside the build pass. Flutter tolerates this but it's an anti-pattern — `build` must be a pure function of state.

Replace with `ref.listen<AsyncValue<AppPreferencesState>>(appPreferencesCtrlProvider, ...)` inside `build`. The listener mirrors the provider into `_lastResolvedPrefs` via `setState` when a new non-null value arrives. This is the same pattern already used in `update_prompt_host.dart:44` and `shadow_reading_panel.dart:599+`.

## Test plan

- [x] `flutter analyze lib/app.dart` — clean
- [x] `flutter test test/features/player/` — 77 tests pass

## Out of scope

- Adding recovery actions to `_errorMaterialApp` (Reset library / Open logs / Copy error) — separate PR for issue #83.

Refs #83
