### PR TITLE
fix(auth): always cancel auth flow on email screen BackButton

### DIFF
--- a/lib/features/auth/presentation/sign_in_screen.dart
+++ b/lib/features/auth/presentation/sign_in_screen.dart
@@ -262,15 +262,12 @@ class EmailEntryScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
-    final auth = ref.watch(authCtrlProvider).valueOrNull;
 
     return SignInFlowScaffold(
       appBar: AppBar(
         leading: BackButton(
           onPressed: () {
-            if (auth is AuthAwaitingOtp) {
-              ref.read(authCtrlProvider.notifier).cancelSignIn();
-            }
+            ref.read(authCtrlProvider.notifier).cancelSignIn();
             if (context.canPop()) {
               context.pop();
             } else {


### PR DESCRIPTION
## Summary

\EmailEntryScreen.BackButton\ in \lib/features/auth/presentation/sign_in_screen.dart\ only called \cancelSignIn()\ when state was \AuthAwaitingOtp\. If a Web PKCE flow was somehow running while the user was on \/sign-in/email\ (e.g. via deep link / state race), pressing Back would pop without cancelling the PKCE timeout timer set in \AuthCtrl.startWebPkceSignIn\.

\cancelSignIn()\ is a safe no-op when no flow is in progress — it always increments \_flowGeneration\ and calls \_cancelPkceTimeout()\, and only resets state when \uthFlowInProgress\ is true. Always call it on Back so any in-flight flow is dropped.

Drop the now-unused \uth\ local and the redundant \ef.watch(authCtrlProvider)\ (the only consumer of state was the conditional cancel).

## Test plan

- [x] \lutter analyze lib/features/auth/presentation/sign_in_screen.dart\ — clean
- [x] \lutter test test/features/auth/\ — 21 tests pass

Refs #83