### PR TITLE
feat(routing): add NotFoundScreen fallback route

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:enjoy_player/core/routing/auth_router_tick.dart';
+import 'package:enjoy_player/core/routing/not_found_screen.dart';
 import 'package:enjoy_player/core/window/desktop_window.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/features/ai/presentation/ai_playground_screen.dart';
@@ -63,6 +64,7 @@ GoRouter appRouter(Ref ref) {
   return GoRouter(
     initialLocation: '/',
     refreshListenable: authTick,
+    errorBuilder: (context, state) => NotFoundScreen(uri: state.uri),
     redirect: (context, state) {
       final loc = state.matchedLocation;
       final auth = ref.read(authCtrlProvider);

--- a/lib/core/routing/not_found_screen.dart
+++ b/lib/core/routing/not_found_screen.dart
@@ -1,0 +1,67 @@
+/// Fallback screen for unknown go_router locations.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+
+class NotFoundScreen extends StatelessWidget {
+  const NotFoundScreen({required this.uri, super.key});
+
+  final Uri uri;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = EnjoyThemeTokens.of(context);
+    final l10n = AppLocalizations.of(context)!;
+    final tt = Theme.of(context).textTheme;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Padding(
+              padding: EdgeInsets.all(t.space32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.explore_off_rounded,
+                    size: 72,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  SizedBox(height: t.space24),
+                  Text(
+                    l10n.notFoundTitle,
+                    textAlign: TextAlign.center,
+                    style: tt.headlineSmall,
+                  ),
+                  SizedBox(height: t.space12),
+                  Text(
+                    l10n.notFoundSubtitle(uri.toString()),
+                    textAlign: TextAlign.center,
+                    style: tt.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  SizedBox(height: t.space32),
+                  SizedBox(
+                    width: double.infinity,
+                    child: EnjoyButton.primary(
+                      onPressed: () => context.go('/'),
+                      child: Text(l10n.notFoundBackHome),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -749,5 +749,13 @@
   "practicePosterShareSuccess": "Poster shared.",
   "practicePosterSaveSuccess": "Poster saved.",
   "practicePosterExportError": "Could not share practice poster.",
-  "practicePosterLoadError": "Could not load practice data for this video."
+  "practicePosterLoadError": "Could not load practice data for this video.",
+  "notFoundTitle": "Page not found",
+  "notFoundSubtitle": "We couldn't find {uri}.",
+  "@notFoundSubtitle": {
+    "placeholders": {
+      "uri": { "type": "String" }
+    }
+  },
+  "notFoundBackHome": "Back to home"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3440,6 +3440,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not load practice data for this video.'**
   String get practicePosterLoadError;
+
+  /// No description provided for @notFoundTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Page not found'**
+  String get notFoundTitle;
+
+  /// No description provided for @notFoundSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t find {uri}.'**
+  String notFoundSubtitle(String uri);
+
+  /// No description provided for @notFoundBackHome.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to home'**
+  String get notFoundBackHome;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1819,4 +1819,15 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get practicePosterLoadError =>
       'Could not load practice data for this video.';
+
+  @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundSubtitle(String uri) {
+    return 'We couldn\'t find $uri.';
+  }
+
+  @override
+  String get notFoundBackHome => 'Back to home';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1743,6 +1743,17 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get practicePosterLoadError => '无法加载此视频的练习数据。';
+
+  @override
+  String get notFoundTitle => '页面未找到';
+
+  @override
+  String notFoundSubtitle(String uri) {
+    return '找不到 $uri。';
+  }
+
+  @override
+  String get notFoundBackHome => '返回首页';
 }
 
 /// The translations for Chinese, as used in China (`zh_CN`).
@@ -3484,4 +3495,15 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get practicePosterLoadError => '无法加载此视频的练习数据。';
+
+  @override
+  String get notFoundTitle => '页面未找到';
+
+  @override
+  String notFoundSubtitle(String uri) {
+    return '找不到 $uri。';
+  }
+
+  @override
+  String get notFoundBackHome => '返回首页';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -735,5 +735,8 @@
   "practicePosterShareSuccess": "海报已分享。",
   "practicePosterSaveSuccess": "海报已保存。",
   "practicePosterExportError": "无法分享练习海报。",
-  "practicePosterLoadError": "无法加载此视频的练习数据。"
+  "practicePosterLoadError": "无法加载此视频的练习数据。",
+  "notFoundTitle": "页面未找到",
+  "notFoundSubtitle": "找不到 {uri}。",
+  "notFoundBackHome": "返回首页"
 }

--- a/lib/l10n/app_zh_CN.arb
+++ b/lib/l10n/app_zh_CN.arb
@@ -735,5 +735,8 @@
   "practicePosterShareSuccess": "海报已分享。",
   "practicePosterSaveSuccess": "海报已保存。",
   "practicePosterExportError": "无法分享练习海报。",
-  "practicePosterLoadError": "无法加载此视频的练习数据。"
+  "practicePosterLoadError": "无法加载此视频的练习数据。",
+  "notFoundTitle": "页面未找到",
+  "notFoundSubtitle": "找不到 {uri}。",
+  "notFoundBackHome": "返回首页"
 }


### PR DESCRIPTION
## Summary

\go_router\ returns its default red error widget for unknown paths. Add a \NotFoundScreen\ at \lib/core/routing/not_found_screen.dart\ with localized strings (en / zh / zh_CN) that explains the unknown path and links back to \/\.

Wire it via \GoRouter.errorBuilder\ in \pp_router.dart\.

## Test plan

- [x] \lutter gen-l10n\ regenerated successfully
- [x] \lutter analyze lib/core/routing/ lib/l10n/\ — clean
- [x] \lutter test test/features/player/\ — 77 tests pass

Refs #83