### PR TITLE
chore: add GitHub issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Report broken behavior in Enjoy Player (Flutter app)
+title: "[bug] "
+labels: ["bug", "needs triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. The agentic workflows in this repo (issue-triage,
+        duplicate-code, perf-improver, test-improver) rely on the structured fields
+        below — please fill them in to help us route and reproduce quickly.
+
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      description: From Settings → About, or `flutter run --version` output.
+      placeholder: "0.2.3+4"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: false
+      options:
+        - Android
+        - iOS
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
+    id: distribution
+    attributes:
+      label: Distribution channel
+      multiple: false
+      options:
+        - Store / TestFlight / release
+        - Direct (sideload / OTA)
+        - Debug / dev build
+    validations:
+      required: false
+
+  - type: dropdown
+    id: signed_in
+    attributes:
+      label: Signed in to Enjoy account?
+      multiple: false
+      options:
+        - No (guest)
+        - Yes
+        - N/A
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of actions leading to the bug.
+      placeholder: |
+        1. Open the library
+        2. Tap ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: From `~/.config/EnjoyPlayer/logs/` or in-app diagnostics export.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Media kind, file size, language, transcript presence, echo mode active, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,36 @@
+name: Chore / refactor / docs
+description: Maintenance work that does not change user-visible behavior
+title: "[chore] "
+labels: ["needs triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for refactors, dependency bumps, CI changes, docs, or other
+        non-user-visible work. For behavioral changes prefer the bug or feature
+        templates.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this needed? Reference an issue or ADR if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk & rollout
+      description: Backwards-incompatible? Migration needed? Feature-flagged?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a new feature for Enjoy Player
+title: "[feature] "
+labels: ["enhancement", "needs triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For significant changes, please also write an OpenSpec change under
+        `openspec/changes/YYYY-MM-DD-<name>/` (see `openspec/config.yaml` and
+        `docs/decisions/` for existing patterns).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem does this solve? Who is affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch the behavior, UI, or data flow.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Out of scope / non-goals
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform(s) affected
+      multiple: true
+      options:
+        - Android
+        - iOS
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: false
+
+  - type: textarea
+    id: adr
+    attributes:
+      label: Related ADR(s)
+      description: e.g. `docs/decisions/0007-dynamic-color-from-artwork.md`. If this needs a new ADR, note it.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+## Summary
+
+<!-- One paragraph: what does this PR change and why? Reference the issue(s) it closes. -->
+
+Fixes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Refactor / chore (no user-visible change)
+- [ ] Documentation / ADR
+
+## Platform tested
+
+- [ ] Android
+- [ ] iOS
+- [ ] macOS
+- [ ] Windows
+- [ ] Linux
+
+## Checklist
+
+- [ ] `flutter analyze` is clean
+- [ ] `flutter test` passes for affected areas
+- [ ] No new `print()` calls (use `logNamed` from `lib/core/logging/log.dart`)
+- [ ] No new `kIsWeb` branches (AGENTS.md hard rule)
+- [ ] No new SQL outside Drift DAOs (AGENTS.md hard rule)
+- [ ] No new `Player()` instances outside `PlayerController` (AGENTS.md hard rule)
+- [ ] If behavior changed: `docs/features/<feature>.md` updated
+- [ ] If architectural: new ADR in `docs/decisions/`
+- [ ] New public API symbols have doc comments (if applicable)
+
+## Test plan
+
+<!-- How was this verified? List specific scenarios, commands, and platforms. -->
+
+- [ ] ...
+- [ ] ...
+
+## Out of scope / follow-up
+
+<!-- Anything intentionally deferred; link to follow-up issues. -->
+
+- ...
+
+## Human / owner follow-up
+
+<!-- Any actions that require the repo owner (credential rotation, third-party sign-off,
+     schema decisions). Do NOT silently perform these — flag them here. -->
+
+- None / ...


### PR DESCRIPTION
## Summary

Add three issue templates (\ug\, \eature\, \chore\) and a PR template so contributors and the agentic workflows (issue-triage, duplicate-code, perf-improver, test-improver) get consistent structured signal.

### Issue templates

- \ug.yml\: app version, platform, distribution channel, signed-in state, repro steps, expected/actual behavior, logs, additional context.
- \eature.yml\: problem, proposal, alternatives, non-goals, platform(s), related ADRs (forces author to consider if a new ADR is needed).
- \chore.yml\: motivation, proposed change, risk/rollout.

### PR template

- Summary (with \Fixes #\ auto-link)
- Type of change checklist
- Platform tested checklist
- AGENTS.md hard-rule checklist (no print, no kIsWeb, no raw SQL, no new \Player()\ instances, \logNamed\, Drift DAOs)
- Behavior-change / new-ADR checklist (per AGENTS.md)
- Test plan
- Out of scope / follow-up
- Human / owner follow-up (e.g. credential rotation, third-party sign-off)

Refs #83