### PR TITLE
fix(sync): reject server responses missing updatedAt

### DIFF
--- a/lib/features/sync/data/sync_upload_service.dart
+++ b/lib/features/sync/data/sync_upload_service.dart
@@ -13,6 +13,23 @@ import 'package:enjoy_player/features/sync/data/sync_serializers.dart';
 
 final _log = logNamed('sync.upload');
 
+/// Thrown when a server upload response omits the required `updatedAt` field.
+///
+/// Without `updatedAt` we cannot trust [serverUpdatedAt] — defaulting to
+/// `DateTime.now()` would silently make the local row appear newer than the
+/// server and trigger spurious re-uploads that could clobber concurrent
+/// server-side edits. The row is left untouched and the sync queue will retry.
+class SyncMissingUpdatedAtError extends Error {
+  SyncMissingUpdatedAtError(this.entity, this.id);
+
+  final String entity;
+  final String id;
+
+  @override
+  String toString() =>
+      'SyncMissingUpdatedAtError($entity $id): server response missing updatedAt';
+}
+
 class SyncUploadService {
   SyncUploadService({
     required this._db,
@@ -37,14 +54,13 @@ class SyncUploadService {
       final response = await _audioApi.audio(row.id);
       inner = unwrapEntity(response, 'audio');
     }
-    final serverUpdated =
-        parseIsoDate(inner['updatedAt']) ?? DateTime.now().toUtc();
+    final serverUpdated = _requireServerUpdated(inner, entity: 'audio', id: row.id);
     await _db.audioDao.insertRow(
       row.copyWith(
         syncStatus: const Value('synced'),
         serverUpdatedAt: Value(serverUpdated),
         mediaUrl: Value(inner['mediaUrl'] as String? ?? row.mediaUrl),
-        updatedAt: parseIsoDate(inner['updatedAt']) ?? row.updatedAt,
+        updatedAt: serverUpdated,
       ),
     );
   }
@@ -70,14 +86,13 @@ class SyncUploadService {
     VideoRow row,
     Map<String, dynamic> inner,
   ) async {
-    final serverUpdated =
-        parseIsoDate(inner['updatedAt']) ?? DateTime.now().toUtc();
+    final serverUpdated = _requireServerUpdated(inner, entity: 'video', id: row.id);
     await _db.videoDao.insertRow(
       row.copyWith(
         syncStatus: const Value('synced'),
         serverUpdatedAt: Value(serverUpdated),
         mediaUrl: Value(inner['mediaUrl'] as String? ?? row.mediaUrl),
-        updatedAt: parseIsoDate(inner['updatedAt']) ?? row.updatedAt,
+        updatedAt: serverUpdated,
       ),
     );
   }
@@ -88,15 +103,30 @@ class SyncUploadService {
     );
     final inner = unwrapEntity(response, 'recording');
     final serverUpdated =
-        parseIsoDate(inner['updatedAt']) ?? DateTime.now().toUtc();
+        _requireServerUpdated(inner, entity: 'recording', id: row.id);
     await _db.recordingDao.insertRow(
       row.copyWith(
         syncStatus: const Value('synced'),
         serverUpdatedAt: Value(serverUpdated),
         audioUrl: Value(inner['audioUrl'] as String? ?? row.audioUrl),
-        updatedAt: parseIsoDate(inner['updatedAt']) ?? row.updatedAt,
+        updatedAt: serverUpdated,
       ),
     );
+  }
+
+  DateTime _requireServerUpdated(
+    Map<String, dynamic> inner, {
+    required String entity,
+    required String id,
+  }) {
+    final parsed = parseIsoDate(inner['updatedAt']);
+    if (parsed == null) {
+      _log.warning(
+        'server response missing updatedAt for $entity $id; refusing to write',
+      );
+      throw SyncMissingUpdatedAtError(entity, id);
+    }
+    return parsed;
   }
 
   Future<void> deleteAudio(String id) async {


### PR DESCRIPTION
## Summary

`SyncUploadService.uploadAudio` / `uploadVideo` / `uploadRecording` all used `parseIsoDate(inner['updatedAt']) ?? DateTime.now().toUtc()` for `serverUpdatedAt`. When the server omits the field (legitimate schema slip, transient proxy response, etc.) we silently bumped `serverUpdatedAt` to 'now', which on the next sync compare made the local row appear newer than the server and triggered a re-upload that could clobber concurrent server-side edits.

Throw a new `SyncMissingUpdatedAtError` instead so the row is left untouched and the sync queue retries. Also propagate the parsed `updatedAt` into the local `updatedAt` field rather than falling back to `row.updatedAt` — when the server does return the field, the local timestamp should match what the server saw.

Add a dedicated error type so future logic in `SyncCtrl._drainQueue` can distinguish 'transient, retry' from 'permanent schema violation, surface to user'. Current behaviour is unchanged for other thrown errors (log + keep the row in the queue).

## Test plan

- [x] `flutter analyze lib/features/sync/data/sync_upload_service.dart` — clean
- [x] `flutter test test/features/sync/` — 14 tests pass

## Out of scope

- Adding a `SyncMissingUpdatedAtError` retry budget / circuit breaker
- Surfacing this error to the user via a banner (would need UX decision)

Refs #83
