### PR TITLE
fix(auth): typed AuthFailure codes + keep session on transient refresh errors (#104)

### DIFF
--- a/lib/core/errors/app_failure.dart
+++ b/lib/core/errors/app_failure.dart
@@ -32,8 +32,40 @@ final class NetworkFailure extends AppFailure {
   final int? statusCode;
 }
 
+/// Categorizes auth failures so the UI can render distinct messages
+/// (e.g. "invalid credentials" vs "rate limited" vs "network down") and
+/// the auth repository can decide whether to keep the existing session.
+enum AuthFailureCode {
+  /// User supplied bad credentials (bad OTP, bad email, expired PKCE).
+  invalidCredentials,
+
+  /// The server explicitly rejected the session (HTTP 401 or 403). The
+  /// refresh-token grant is no longer valid; the local session should
+  /// be cleared.
+  sessionRevoked,
+
+  /// The server asked the caller to slow down (HTTP 429).
+  rateLimited,
+
+  /// The request never reached the server, or the server did not respond
+  /// in time. The local session is presumed still valid and must be kept
+  /// so the next call can retry.
+  networkUnreachable,
+
+  /// The server returned a 5xx that the client cannot classify further.
+  /// The local session is presumed still valid; retry later.
+  serverError,
+
+  /// Catch-all for unclassified auth errors.
+  unknown,
+}
+
 final class AuthFailure extends AppFailure {
-  const AuthFailure(super.message);
+  const AuthFailure(super.message, {this.code = AuthFailureCode.unknown});
+
+  final AuthFailureCode code;
+
+  bool get isSessionRevoked => code == AuthFailureCode.sessionRevoked;
 }
 
 /// Worker returned HTTP 402 (AI credits exhausted or billing block).

--- a/lib/features/ai/application/ai_api_failures.dart
+++ b/lib/features/ai/application/ai_api_failures.dart
@@ -3,7 +3,7 @@ import 'package:enjoy_player/data/api/api_exception.dart';
 
 AppFailure mapApiExceptionToAppFailure(ApiException e) {
   if (e.isUnauthorized) {
-    return AuthFailure(e.message);
+    return AuthFailure(e.message, code: AuthFailureCode.sessionRevoked);
   }
   if (e.statusCode == 402) {
     return CreditsFailure(e.message);

--- a/lib/features/auth/application/auth_controller.dart
+++ b/lib/features/auth/application/auth_controller.dart
@@ -82,7 +82,7 @@ class AuthCtrl extends _$AuthCtrl {
     } catch (e, st) {
       if (gen != _flowGeneration) return;
       _log.warning('google sign-in failed', e, st);
-      throw AuthFailure('$e');
+      throw AuthFailure('$e', code: AuthFailureCode.unknown);
     }
   }
 
@@ -104,13 +104,16 @@ class AuthCtrl extends _$AuthCtrl {
     } on SignInWithAppleAuthorizationException catch (e) {
       if (e.code == AuthorizationErrorCode.canceled) return;
       if (gen != _flowGeneration) return;
-      throw AuthFailure(e.message);
+      throw AuthFailure(
+        e.message,
+        code: AuthFailureCode.invalidCredentials,
+      );
     } on AuthFailure {
       rethrow;
     } catch (e, st) {
       if (gen != _flowGeneration) return;
       _log.warning('apple sign-in failed', e, st);
-      throw AuthFailure('$e');
+      throw AuthFailure('$e', code: AuthFailureCode.unknown);
     }
   }
 

--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -69,7 +69,7 @@ class AuthRepository {
       final m = await _authApi.sendOtp(email: email.trim());
       return OtpSendResponse.fromJson(m);
     } on ApiException catch (e) {
-      throw AuthFailure(e.message);
+      throw AuthFailure(e.message, code: authFailureCodeForApiException(e));
     }
   }
 
@@ -126,13 +126,23 @@ class AuthRepository {
       return true;
     } on ApiException catch (e) {
       _log.warning('refresh session failed', e);
-      await clearSession();
+      if (_shouldRevokeSessionOnApiException(e)) {
+        await clearSession();
+      }
       return false;
     } catch (e, st) {
       _log.warning('refresh session failed', e, st);
-      await clearSession();
       return false;
     }
+  }
+
+  /// Server explicitly told us the session is no longer valid; we must
+  /// wipe local tokens. Transient 5xx / network errors keep the session
+  /// so the next request can retry.
+  static bool _shouldRevokeSessionOnApiException(ApiException e) {
+    final status = e.statusCode;
+    if (status == 401 || status == 403) return true;
+    return false;
   }
 
   Future<UserProfile> fetchProfile() async {
@@ -145,7 +155,7 @@ class AuthRepository {
       if (e.isUnauthorized) {
         await clearSession();
       }
-      throw AuthFailure(e.message);
+      throw AuthFailure(e.message, code: authFailureCodeForApiException(e));
     }
   }
 
@@ -163,7 +173,7 @@ class AuthRepository {
       if (e.isUnauthorized) {
         await clearSession();
       }
-      throw AuthFailure(e.message);
+      throw AuthFailure(e.message, code: authFailureCodeForApiException(e));
     }
   }
 
@@ -223,9 +233,9 @@ class AuthRepository {
       }
       return fetchProfile();
     } on ApiException catch (e) {
-      throw AuthFailure(e.message);
+      throw AuthFailure(e.message, code: authFailureCodeForApiException(e));
     } on FormatException catch (e) {
-      throw AuthFailure(e.message);
+      throw AuthFailure(e.message, code: AuthFailureCode.invalidCredentials);
     }
   }
 
@@ -244,4 +254,18 @@ class AuthRepository {
     }
     return url;
   }
+}
+
+/// Maps an [ApiException] thrown by the auth API to an [AuthFailureCode] so
+/// the UI can distinguish "you typed the wrong code" from "the server is down"
+/// from "your session expired and we logged you out".
+AuthFailureCode authFailureCodeForApiException(ApiException e) {
+  final status = e.statusCode;
+  if (status == 401 || status == 403) return AuthFailureCode.sessionRevoked;
+  if (status == 429) return AuthFailureCode.rateLimited;
+  if (status != null && status >= 500) return AuthFailureCode.serverError;
+  if (status == 400 || status == 404 || status == 422) {
+    return AuthFailureCode.invalidCredentials;
+  }
+  return AuthFailureCode.unknown;
 }

--- a/test/features/auth/auth_repository_test.dart
+++ b/test/features/auth/auth_repository_test.dart
@@ -1,0 +1,215 @@
+import 'dart:io';
+
+import 'package:enjoy_player/core/errors/app_failure.dart';
+import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/api_exception.dart';
+import 'package:enjoy_player/data/api/secure_token_store.dart';
+import 'package:enjoy_player/data/api/services/auth_api.dart';
+import 'package:enjoy_player/features/auth/data/auth_repository.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AuthRepository.refreshSession', () {
+    late Directory tempDir;
+    late FlutterSecureStorage storage;
+    late SecureTokenStore tokenStore;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('auth_repo_test_');
+      FlutterSecureStorage.setMockInitialValues({});
+      storage = const FlutterSecureStorage();
+      tokenStore = SecureTokenStore(storage);
+      await tokenStore.writeAccessToken('access-1');
+      await tokenStore.writeRefreshToken('refresh-1');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    AuthRepository build(http.Client client) {
+      final api = AuthApi(
+        ApiClient(
+          httpClient: client,
+          getBaseUrl: () async => 'https://enjoy.bot',
+          getAccessToken: () async => null,
+        ),
+      );
+      return AuthRepository(
+        authApi: api,
+        tokenStore: tokenStore,
+        getBaseUrl: () async => 'https://enjoy.bot',
+      );
+    }
+
+    test('returns true and persists new tokens on success', () async {
+      final client = MockClient((request) async {
+        expect(request.url.path, '/api/v1/auth/refresh');
+        return http.Response(
+          '{"accessToken":"a2","refreshToken":"r2","expiresIn":3600}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isTrue);
+      expect(await tokenStore.readAccessToken(), 'a2');
+      expect(await tokenStore.readRefreshToken(), 'r2');
+    });
+
+    test('returns false but keeps session on transient network error',
+        () async {
+      final client = MockClient((_) async {
+        throw const SocketException('Connection reset by peer');
+      });
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isFalse);
+      expect(await tokenStore.readAccessToken(), 'access-1');
+      expect(await tokenStore.readRefreshToken(), 'refresh-1');
+    });
+
+    test('returns false and keeps session on HTTP 500', () async {
+      final client = MockClient((_) async => http.Response('boom', 500));
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isFalse);
+      expect(await tokenStore.readAccessToken(), 'access-1');
+      expect(await tokenStore.readRefreshToken(), 'refresh-1');
+    });
+
+    test('returns false and keeps session on HTTP 429', () async {
+      final client = MockClient((_) async => http.Response('slow down', 429));
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isFalse);
+      expect(await tokenStore.readAccessToken(), 'access-1');
+      expect(await tokenStore.readRefreshToken(), 'refresh-1');
+    });
+
+    test('returns false and clears session on HTTP 401', () async {
+      final client = MockClient((_) async => http.Response('expired', 401));
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isFalse);
+      expect(await tokenStore.readAccessToken(), isNull);
+      expect(await tokenStore.readRefreshToken(), isNull);
+    });
+
+    test('returns false and clears session on HTTP 403', () async {
+      final client = MockClient((_) async => http.Response('forbidden', 403));
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isFalse);
+      expect(await tokenStore.readAccessToken(), isNull);
+      expect(await tokenStore.readRefreshToken(), isNull);
+    });
+
+    test(
+        'returns false and keeps session on HTTP 400 (malformed request, not auth revocation)',
+        () async {
+      final client = MockClient((_) async => http.Response('bad', 400));
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isFalse);
+      expect(await tokenStore.readAccessToken(), 'access-1');
+      expect(await tokenStore.readRefreshToken(), 'refresh-1');
+    });
+
+    test('returns false when no refresh token is stored', () async {
+      await tokenStore.clearAllAuthSecrets();
+      final client = MockClient((_) async => http.Response('{}', 200));
+      final repo = build(client);
+
+      final ok = await repo.refreshSession();
+
+      expect(ok, isFalse);
+    });
+  });
+
+  group('AuthFailure', () {
+    test('default code is unknown', () {
+      const f = AuthFailure('oops');
+      expect(f.code, AuthFailureCode.unknown);
+      expect(f.isSessionRevoked, isFalse);
+    });
+
+    test('sessionRevoked marker is exposed', () {
+      const f = AuthFailure('revoked', code: AuthFailureCode.sessionRevoked);
+      expect(f.isSessionRevoked, isTrue);
+    });
+  });
+
+  group('ApiException mapping in auth flows', () {
+    test('ApiException 401 maps to AuthFailure.sessionRevoked', () {
+      const e = ApiException(message: 'unauthorized', statusCode: 401);
+      expect(authFailureCodeForApiException(e), AuthFailureCode.sessionRevoked);
+    });
+
+    test('ApiException 403 maps to AuthFailure.sessionRevoked', () {
+      const e = ApiException(message: 'forbidden', statusCode: 403);
+      expect(authFailureCodeForApiException(e), AuthFailureCode.sessionRevoked);
+    });
+
+    test('ApiException 429 maps to AuthFailure.rateLimited', () {
+      const e = ApiException(message: 'slow down', statusCode: 429);
+      expect(authFailureCodeForApiException(e), AuthFailureCode.rateLimited);
+    });
+
+    test('ApiException 500+ maps to AuthFailure.serverError', () {
+      const e5 = ApiException(message: 'oops', statusCode: 500);
+      const e503 = ApiException(message: 'unavailable', statusCode: 503);
+      expect(authFailureCodeForApiException(e5), AuthFailureCode.serverError);
+      expect(
+        authFailureCodeForApiException(e503),
+        AuthFailureCode.serverError,
+      );
+    });
+
+    test('ApiException 400/404/422 maps to AuthFailure.invalidCredentials',
+        () {
+      const e400 = ApiException(message: 'bad', statusCode: 400);
+      const e404 = ApiException(message: 'missing', statusCode: 404);
+      const e422 = ApiException(message: 'unprocessable', statusCode: 422);
+      expect(
+        authFailureCodeForApiException(e400),
+        AuthFailureCode.invalidCredentials,
+      );
+      expect(
+        authFailureCodeForApiException(e404),
+        AuthFailureCode.invalidCredentials,
+      );
+      expect(
+        authFailureCodeForApiException(e422),
+        AuthFailureCode.invalidCredentials,
+      );
+    });
+
+    test('ApiException with no status code maps to AuthFailure.unknown', () {
+      const e = ApiException(message: 'no status');
+      expect(authFailureCodeForApiException(e), AuthFailureCode.unknown);
+    });
+  });
+}


### PR DESCRIPTION
Closes #104.

## Problem

- `AuthRepository.refreshSession` cleared the local session on **any** exception, including transient network errors and 5xx. A flaky connection mid-refresh would log the user out and discard a perfectly good access token.
- `AuthFailure` carried only a `String message`. Consumers had no way to distinguish "you typed the wrong OTP" from "the server is rate-limiting you" from "the network is down".

## Fix

- `AuthFailure` now carries a typed `AuthFailureCode` enum:
  - `invalidCredentials` — bad OTP / email / PKCE (4xx-shaped)
  - `sessionRevoked` — server told us the session is dead (HTTP 401 / 403)
  - `rateLimited` — HTTP 429
  - `networkUnreachable` — request never reached the server
  - `serverError` — 5xx
  - `unknown` — catch-all
- `AuthRepository.refreshSession` now only calls `clearSession()` on `ApiException` with `statusCode == 401 || statusCode == 403`. Network errors, 5xx, and 429 all keep the session so the next request can retry.
- `authFailureCodeForApiException(ApiException)` (top-level, public so tests can verify it) is reused by `sendOtp`, `fetchProfile`, `updateProfile`, `_completeSignIn`, and the AI failure mapper.
- Explicit codes added to `AuthFailure` constructions in `auth_controller.dart` (Apple sign-in error path, generic unknown catches) and `ai_api_failures.dart`.

## Tests

New `test/features/auth/auth_repository_test.dart` with 16 cases covering:

- Success path (new tokens persisted)
- Network error → session kept
- HTTP 500 → session kept
- HTTP 429 → session kept
- HTTP 401 → session cleared
- HTTP 403 → session cleared
- HTTP 400 (malformed request) → session kept
- Missing refresh token → false returned
- `AuthFailure` defaults / `isSessionRevoked`
- `authFailureCodeForApiException` mapping for 400 / 401 / 403 / 404 / 422 / 429 / 500 / 503 / unknown

## Verification

```
flutter analyze (lib/features/auth lib/core/errors)  # 0 new issues
flutter test test/features/auth test/data/api         # 67/67 pass
flutter test test/features/auth/auth_repository_test  # 16/16 pass
```

The two pre-existing failures (`library_media_provider_test.dart` and `recommended_channels_test.dart`) also fail on `main`; they are unrelated to this change.
