### PR TITLE
chore(deps): pin pre-release deps exactly + forbid new local-path packages (#108)

### DIFF
--- a/.github/scripts/check_no_new_path_deps.sh
+++ b/.github/scripts/check_no_new_path_deps.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Fails CI when a new local-path package is added to pubspec.yaml.
+# Existing path: packages (azure_speech, ffmpeg_kit_flutter_new) are
+# allowlisted in docs/decisions/0029-supply-chain-risk.md and tracked
+# via this script's allowlist array.
+#
+# Usage: bash .github/scripts/check_no_new_path_deps.sh
+
+set -euo pipefail
+
+ALLOWLIST=(
+  "packages/azure_speech"
+  "packages/ffmpeg_kit_flutter_new"
+)
+
+if [ ! -f pubspec.yaml ]; then
+  echo "check_no_new_path_deps.sh: pubspec.yaml not found at $(pwd)" >&2
+  exit 1
+fi
+
+# Extract `path:` values under dependencies: / dev_dependencies: blocks.
+# Grep is intentionally narrow (matches only `  <key>:` followed by
+# `    path: <value>` on the next line) to avoid false positives.
+mapfile -t found < <(
+  awk '
+    /^(dev_)?dependencies:/ { in_block = 1; next }
+    in_block && /^[^ ]/ { in_block = 0 }
+    in_block && /^  [a-zA-Z0-9_]+:$/ {
+      key = $1; sub(/:$/, "", key); getline next_line;
+      if (match(next_line, /^    path:[ \t]+/)) {
+        path = substr(next_line, RSTART + RLENGTH);
+        print key "|" path;
+      }
+    }
+  ' pubspec.yaml
+)
+
+if [ "${#found[@]}" -eq 0 ]; then
+  echo "check_no_new_path_deps: no path: dependencies found."
+  exit 0
+fi
+
+violations=0
+for entry in "${found[@]}"; do
+  pkg="${entry%%|*}"
+  path="${entry#*|}"
+  allowed=false
+  for a in "${ALLOWLIST[@]}"; do
+    if [ "$path" = "$a" ]; then allowed=true; break; fi
+  done
+  if [ "$allowed" = true ]; then
+    echo "  allowlisted: $pkg -> $path"
+  else
+    echo "  ERROR: $pkg -> $path is a NEW local-path dependency." >&2
+    echo "         Add it to docs/decisions/0029-supply-chain-risk.md" >&2
+    echo "         and to ALLOWLIST in this script, or convert it to a" >&2
+    echo "         git: / pub.dev reference." >&2
+    violations=$((violations + 1))
+  fi
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo "check_no_new_path_deps: $violations unapproved path: dep(s)." >&2
+  exit 1
+fi
+
+echo "check_no_new_path_deps: all path: deps are allowlisted."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Flutter pub get
         run: flutter pub get
 
+      - name: Forbid new local-path packages
+        run: bash .github/scripts/check_no_new_path_deps.sh
+
       - name: Dart format
         run: |
           set -euo pipefail

--- a/docs/decisions/0029-supply-chain-risk.md
+++ b/docs/decisions/0029-supply-chain-risk.md
@@ -1,0 +1,88 @@
+# ADR-0029: Supply-chain risk for pre-release and local-path dependencies
+
+## Status
+
+Accepted — 2026-06-28.
+
+## Context
+
+Issue #83 flagged three categories of dependency-hygiene risk in
+`pubspec.yaml`:
+
+1. **Pre-release / single-publisher deps** that are central to the
+   release pipeline but have no functional test coverage in this
+   repository.
+2. **Local-path packages** under `packages/` that are not published to
+   pub.dev and are pinned to whatever the working tree happens to
+   contain.
+3. **Documented fragility** — the `azure_speech` plugin declares
+   `sdk: ^3.9.0` while the root requires `^3.12.0`, and the
+   `ffmpeg_kit_flutter_new` plugin ships no Windows implementation
+   even though the app must run on Windows.
+
+`flutter_secure_storage: ^10.2.0` was also flagged as a "typo" in the
+review, but is in fact a valid caret range: 10.x is the current
+pre-release → 10.3.1 stable series on pub.dev and `pubspec.lock` already
+resolves to `10.3.1`. The caret range is intentional. The next stable
+major (11.x) is currently a `11.0.0-beta.1` pre-release; we will
+upgrade explicitly when the maintainer stabilizes the API.
+
+## Decision
+
+### Pre-release / single-publisher deps
+
+Pin **exactly** (no caret) so a fresh `pub get` on a different machine
+cannot silently upgrade. Bumps go through normal PR review. Current
+pins:
+
+| Package | Pin | Used for | Risk |
+|---------|-----|----------|------|
+| `file_picker` | `12.0.0-beta.4` | Library / import flows | Beta; single publisher (miguelpruivo) |
+| `auto_updater` | `0.2.1` | Sparkle / WinSparkle auto-update on macOS / Windows | Single publisher (leocavalcante) |
+| `ota_update` | `7.1.0` | Direct-channel Android APK auto-update | Single publisher (heroims GobeToolkit) |
+
+We accept the single-publisher risk because there is no widely-used
+multi-publisher alternative that meets the platform requirements
+(Sparkle for macOS, WinSparkle for Windows, APK streaming for Android).
+We mitigate by:
+
+- Pinning exactly so a compromised publisher cannot move our builds
+  forward without a code review.
+- Running CI (`flutter analyze`, `flutter test`) on every PR so a
+  malicious update that breaks the build is caught before merge.
+- Re-evaluating alternatives at the next major version bump.
+
+### Local-path packages
+
+The two path: deps in `pubspec.yaml` are deliberately in-tree and are
+tracked by `bash .github/scripts/check_no_new_path_deps.sh` in CI
+(see `ci.yml`). New path: deps must be added to the script's
+`ALLOWLIST` and to this ADR, or converted to a `git:` ref / pub.dev
+package.
+
+Current allowlist:
+
+| Path | Reason | Follow-up |
+|------|--------|-----------|
+| `packages/azure_speech` | First-party Flutter plugin wrapping Microsoft Azure Cognitive Services Speech SDK for pronunciation assessment (Android / iOS / macOS / Windows). Forked from a private internal fork to control the small subset of API surface we need. | Track upstream `microsoft/cognitive-services-speech-sdk` releases; re-evaluate at next major. |
+| `packages/ffmpeg_kit_flutter_new` | Vendored from `sk3llo/ffmpeg_kit_flutter` because the upstream `arthenica/ffmpeg-kit` was archived in 2025. We need Android / iOS / macOS bindings. Windows is **not** implemented by this plugin — see packaging.md. | Watch the new community fork; re-evaluate when a Windows-capable plugin emerges. |
+
+### `azure_speech` SDK constraint
+
+Bumped from `sdk: ^3.9.0` → `sdk: ^3.12.0` to match the root
+constraint. The plugin's own deps (`json_annotation: ^4.11.0`,
+`meta: ^1.16.0`, `plugin_platform_interface: ^2.1.8`) all resolve
+under Dart 3.12, so this is a safe tightening that prevents the
+plugin from silently constraining the root to an older Dart.
+
+## Consequences
+
+- `pub get` is now reproducible: the only deps that can move on a
+  fresh checkout are the caret-pinned, stable ones we trust.
+- CI gates new path: deps behind an explicit PR. A maintainer who
+  wants to add one must edit both `check_no_new_path_deps.sh` and this
+  ADR in the same PR, which forces a conversation.
+- We are still vulnerable to a publisher compromise between two
+  intentional upgrades. We accept this in exchange for staying on
+  actively-maintained packages; the alternative (vendoring everything)
+  is out of scope for the team.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -52,3 +52,4 @@ Trade-offs, follow-up work, risks.
 | [0026](0026-local-production-diagnostics.md) | Local production diagnostics — rotating logs, opt-in verbose, zip export |
 | [0027](0027-native-auth-v2.md) | Native auth v2 — Google, Apple, email OTP, PKCE fallback (supersedes 0016 WebView-primary) |
 | [0028](0028-agentic-engine-choice.md) | Agentic workflow engine choice — third-party Anthropic-compatible proxy (proposed) |
+| [0029](0029-supply-chain-risk.md) | Supply-chain risk for pre-release and local-path dependencies |

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -325,6 +325,27 @@ Platform CI setup (secrets, runners):
 - **Missing FFmpeg features**: run `pwsh windows/scripts/fetch_ffmpeg.ps1` before build.
 - **WebView2**: required at runtime for YouTube / in-app WebView.
 
+#### Windows FFmpeg provisioning
+
+`ffmpeg_kit_flutter_new` (under `packages/`) ships Android / iOS / macOS
+platform implementations but **no Windows implementation**. The Windows
+build does not bundle ffmpeg via a Flutter plugin; instead the release
+script downloads a GPL `ffmpeg.exe` into `windows/ffmpeg/` before
+`flutter build windows --release`.
+
+| Step | Script | Source | Verified by |
+|------|--------|--------|-------------|
+| Download | [`windows/scripts/fetch_ffmpeg.ps1`](../windows/scripts/fetch_ffmpeg.ps1) | Gyan.dev `ffmpeg-release-essentials.zip` | SHA-256 from `*.sha256` sidecar |
+| Bundle | `flutter build windows` includes `windows/ffmpeg/ffmpeg.exe` in the build output | n/a | Inno Setup packs the binary |
+| License | `windows/ffmpeg/README.md` | n/a | Reviewed before each public release |
+
+The downloader is idempotent (skips if `ffmpeg.exe -version` already
+succeeds) and fails closed on SHA-256 mismatch. The script does **not**
+run automatically as part of `flutter pub get`; trigger it explicitly
+when setting up a fresh Windows machine or when you need to bump the
+bundled FFmpeg. Do not commit `windows/ffmpeg/ffmpeg.exe` — it is
+git-ignored.
+
 ### Apple
 
 - **macOS DYLD / missing `libz.1.dylib`**: run `brew bundle install --file=macos/Brewfile` and rebuild.

--- a/packages/azure_speech/pubspec.yaml
+++ b/packages/azure_speech/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 publish_to: "none"
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.12.0
   flutter: ">=3.41.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,9 @@ dependencies:
     path: packages/azure_speech
   drift: ^2.31.0
   drift_flutter: ^0.2.8
-  file_picker: ^12.0.0-beta.2
+  # Pre-release dep (single-publisher supply chain) — pinned exactly so a
+  # fresh `pub get` cannot upgrade without an explicit PR. See ADR-0029.
+  file_picker: 12.0.0-beta.4
   freezed_annotation: ^3.0.0
   flutter_riverpod: ^3.3.1
   flutter_secure_storage: ^10.2.0
@@ -41,8 +43,11 @@ dependencies:
   path: ^1.9.1
   path_provider: ^2.1.5
   package_info_plus: ^10.1.0
-  auto_updater: ^0.2.1
-  ota_update: ^7.0.2
+  # Pre-release / single-publisher deps (Windows + mobile auto-update flow).
+  # Pinned exactly so `pub get` cannot silently upgrade; bump via PR. See
+  # ADR-0029.
+  auto_updater: 0.2.1
+  ota_update: 7.1.0
   record: ^7.0.0
   riverpod_annotation: ^4.0.2
   sqlite3_flutter_libs: ^0.5.28


### PR DESCRIPTION
Closes #108.

## Summary

Locks down supply-chain risk for the three pre-release / single-publisher deps that gate the release pipeline, and adds a CI gate that prevents anyone from quietly adding new local-path packages.

## Changes

- **`pubspec.yaml`** — pin `file_picker`, `auto_updater`, `ota_update` to exact versions (`12.0.0-beta.4` / `0.2.1` / `7.1.0`) with comments pointing to the new ADR.
- **`packages/azure_speech/pubspec.yaml`** — tighten `sdk: ^3.9.0` → `^3.12.0` to match the root constraint.
- **`.github/scripts/check_no_new_path_deps.sh`** — new CI script. Parses `pubspec.yaml`, lists every `path:` dep, and fails the build if any path is not in the `ALLOWLIST` array. Tested locally: 0 violations with the current pubspec, 1 violation when a fake `fake_pkg` is added.
- **`.github/workflows/ci.yml`** — runs the new script right after `flutter pub get` so a new path: dep is caught before `dart format` even runs.
- **`docs/decisions/0029-supply-chain-risk.md`** — new ADR documenting the risk for the three pinned deps (no multi-publisher alternative meets our platform requirements), the rationale for the two allowlisted path: deps (`azure_speech`, `ffmpeg_kit_flutter_new`), and the follow-up triggers.
- **`docs/decisions/README.md`** — index entry for ADR-0029.
- **`docs/packaging.md`** — new "Windows FFmpeg provisioning" subsection explaining that `ffmpeg_kit_flutter_new` ships no Windows implementation and that `windows/scripts/fetch_ffmpeg.ps1` fills the gap (idempotent, SHA-256 verified, GPL license tracked in `windows/ffmpeg/README.md`).

## `flutter_secure_storage: ^10.2.0`

The review claimed this was a typo (latest 9.x on pub.dev). It is in fact a valid caret range: pub.dev's current stable line is 10.x and `pubspec.lock` resolves to `10.3.1`. The next major (11.x) is still `11.0.0-beta.1`; we will upgrade explicitly. This is now called out in ADR-0029 so the next reviewer doesn't re-flag it.

## Verification

```
bash .github/scripts/check_no_new_path_deps.sh  # passes (0 violations)
flutter pub get                                  # resolves to same versions
flutter analyze                                  # 0 new issues
flutter test                                     # same 2 pre-existing failures as main
```
