### PR TITLE
fix(sync): preserve retryCount on addOrUpsert + cooldown per-target recording pull (#107)

### DIFF
--- a/lib/data/db/settings_keys.dart
+++ b/lib/data/db/settings_keys.dart
@@ -24,6 +24,15 @@ abstract final class SettingsKeys {
   static String syncCursorRecordingTarget(String targetType, String targetId) =>
       'sync.cursor.recording.$targetType.$targetId';
 
+  /// ISO-8601 UTC timestamp of the last pull attempt for a given
+  /// recording target, used as a cooldown to avoid hammering the
+  /// server on every media open
+  /// (`sync.last_pull_at.recording.{targetType}.{targetId}`).
+  static String syncLastPullAtRecordingTarget(
+    String targetType,
+    String targetId,
+  ) => 'sync.last_pull_at.recording.$targetType.$targetId';
+
   /// ISO-8601 UTC timestamp of last fully successful full sync (downloads + queue).
   static const String syncLastFullSyncAt = 'sync.last_full_sync_at';
 

--- a/lib/features/sync/data/recording_target_sync_service.dart
+++ b/lib/features/sync/data/recording_target_sync_service.dart
@@ -1,11 +1,14 @@
 /// Pull recording metadata for one library media target (lazy sync).
 library;
 
+import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/data/api/services/recording_api.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/settings_keys.dart';
 import 'package:enjoy_player/features/sync/data/sync_serializers.dart';
 import 'package:enjoy_player/features/sync/domain/sync_types.dart';
+
+final _log = logNamed('recordingTargetSync');
 
 class RecordingTargetSyncService {
   RecordingTargetSyncService({required this._db, required this._recordingApi});
@@ -13,20 +16,56 @@ class RecordingTargetSyncService {
   final AppDatabase _db;
   final RecordingApi _recordingApi;
 
+  /// Page size for the upstream recordings API. Each request returns at
+  /// most this many rows; the consumer paginates with a cursor.
   static const _pageSize = 50;
+
+  /// Hard cap on pages per call. A user with thousands of recordings
+  /// will not have all of them pulled in a single media-open; the next
+  /// open resumes from the persisted cursor. Combined with the
+  /// [_kCooldown], this prevents `pullRecordingsForTarget` from
+  /// hammering the server on every media open.
+  static const _kMaxPagesPerCall = 5;
+
+  /// Minimum interval between pulls for the same (targetType, targetId)
+  /// pair. Subsequent calls inside the cooldown window short-circuit to
+  /// an empty success.
+  static const _kCooldown = Duration(minutes: 5);
 
   Future<SyncResult> pullRecordingsForTarget({
     required String targetType,
     required String targetId,
+    DateTime? now,
   }) async {
     final errors = <String>[];
     var synced = 0;
     var failed = 0;
-    final key = SettingsKeys.syncCursorRecordingTarget(targetType, targetId);
-    var cursor = await _db.settingsDao.getValue(key);
+    final cursorKey =
+        SettingsKeys.syncCursorRecordingTarget(targetType, targetId);
+    final cooldownKey =
+        SettingsKeys.syncLastPullAtRecordingTarget(targetType, targetId);
+
+    // Cooldown: short-circuit when we just pulled for this target.
+    final clock = now ?? DateTime.now();
+    final lastPullRaw = await _db.settingsDao.getValue(cooldownKey);
+    final lastPull = lastPullRaw == null
+        ? null
+        : DateTime.tryParse(lastPullRaw)?.toUtc();
+    if (lastPull != null &&
+        clock.toUtc().difference(lastPull) < _kCooldown) {
+      _log.fine(
+        'pullRecordingsForTarget($targetType:$targetId): skipped, '
+        'cooldown active (last pull $lastPull, now $clock)',
+      );
+      return const SyncResult(success: true, synced: 0, failed: 0);
+    }
+
+    var cursor = await _db.settingsDao.getValue(cursorKey);
     if (cursor != null && cursor.isEmpty) cursor = null;
 
-    while (true) {
+    var pages = 0;
+    while (pages < _kMaxPagesPerCall) {
+      pages++;
       List<Map<String, dynamic>> batch;
       try {
         final raw = await _recordingApi.recordings(
@@ -64,11 +103,27 @@ class RecordingTargetSyncService {
       final maxIso = _maxUpdatedAtIso(batch);
       if (maxIso != null) {
         cursor = maxIso;
-        await _db.settingsDao.setValue(key, maxIso);
+        await _db.settingsDao.setValue(cursorKey, maxIso);
       }
 
       if (batch.length < _pageSize) break;
     }
+
+    if (pages >= _kMaxPagesPerCall) {
+      _log.info(
+        'pullRecordingsForTarget($targetType:$targetId): hit page cap '
+        '($_kMaxPagesPerCall × $_pageSize), will resume from cursor on '
+        'next call',
+      );
+    }
+
+    // Persist the cooldown timestamp even on partial success so a
+    // future open inside the cooldown window does not re-enter the
+    // pagination loop.
+    await _db.settingsDao.setValue(
+      cooldownKey,
+      clock.toUtc().toIso8601String(),
+    );
 
     return SyncResult(
       success: failed == 0,

--- a/lib/features/sync/data/sync_queue_repository.dart
+++ b/lib/features/sync/data/sync_queue_repository.dart
@@ -32,6 +32,13 @@ class SyncQueueRepository {
 
   /// Adds or refreshes a queue row for `(entityType, entityId, action)` —
   /// mirrors web [addSyncQueueItem].
+  ///
+  /// On an existing row, only [payloadJson] is overwritten. The
+  /// `retryCount`, `lastAttempt`, and `error` columns are **preserved**
+  /// so a permanently failed row stays failed even if the entity is
+  /// edited locally — editing the entity should not silently re-arm
+  /// a row that was rejected by the server. To re-arm failed rows
+  /// use [resetFailed].
   Future<int> addOrUpsert({
     required String entityType,
     required String entityId,
@@ -53,9 +60,6 @@ class SyncQueueRepository {
       )..where((t) => t.id.equals(existing.id))).write(
         SyncQueueCompanion(
           payloadJson: Value(payloadJson),
-          retryCount: const Value(0),
-          error: const Value(null),
-          lastAttempt: const Value(null),
         ),
       );
       return existing.id;

--- a/test/features/sync/recording_target_sync_service_test.dart
+++ b/test/features/sync/recording_target_sync_service_test.dart
@@ -1,0 +1,188 @@
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/services/recording_api.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/settings_keys.dart';
+import 'package:enjoy_player/features/sync/data/recording_target_sync_service.dart';
+import 'package:enjoy_player/features/sync/domain/sync_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+class _FakeRecordingApi extends RecordingApi {
+  _FakeRecordingApi(this.responses, super._);
+
+  final List<List<Map<String, dynamic>>> responses;
+  int callCount = 0;
+  String? lastUpdatedAfter;
+
+  @override
+  Future<List<Map<String, dynamic>>> recordings({
+    String? targetId,
+    String? targetType,
+    String? language,
+    int? limit,
+    String? updatedAfter,
+  }) async {
+    callCount += 1;
+    lastUpdatedAfter = updatedAfter;
+    if (responses.isEmpty) return const <Map<String, dynamic>>[];
+    return responses.removeAt(0);
+  }
+}
+
+/// Pass-through ApiClient that the [RecordingApi] super-constructor
+/// will accept; the fake subclass overrides every method that the
+/// service under test actually calls.
+class _NullApiClient extends ApiClient {
+  _NullApiClient() : super(
+    httpClient: _NullHttpClient(),
+    getBaseUrl: () async => 'https://test.invalid',
+    getAccessToken: () async => null,
+  );
+}
+
+class _NullHttpClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    throw UnsupportedError('RecordingTargetSyncService tests must override '
+        'every method they exercise; the base class should never be called.');
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('RecordingTargetSyncService.pullRecordingsForTarget', () {
+    late AppDatabase db;
+    late _FakeRecordingApi api;
+    late RecordingTargetSyncService service;
+
+    setUp(() {
+      db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+    });
+
+    Map<String, dynamic> recording(int i, {String? updatedAt}) => {
+          'id': 'r$i',
+          'targetId': 't1',
+          'targetType': 'audio',
+          'durationSeconds': i,
+          'updatedAt': updatedAt ?? DateTime.utc(2024, 1, 1, 0, i).toIso8601String(),
+        };
+
+    test('respects the page cap and persists the cooldown timestamp', () async {
+      // Six full pages so the cap (5) is hit.
+      api = _FakeRecordingApi(
+        List.generate(
+          6,
+          (page) => List.generate(
+            50,
+            (i) => recording(page * 50 + i,
+                updatedAt: DateTime.utc(2024, 1, 1, 0, page * 50 + i)
+                    .toIso8601String()),
+          ),
+        ),
+        _NullApiClient(),
+      );
+      service = RecordingTargetSyncService(db: db, recordingApi: api);
+      final t0 = DateTime.utc(2024, 6, 1, 12);
+
+      final result = await service.pullRecordingsForTarget(
+        targetType: 'audio',
+        targetId: 't1',
+        now: t0,
+      );
+
+      // 5 pages * 50 = 250 rows synced, then the cap stops the loop.
+      expect(result.success, isTrue);
+      expect(result.synced, 250);
+      expect(api.callCount, 5);
+
+      final cooldown = await db.settingsDao
+          .getValue(SettingsKeys.syncLastPullAtRecordingTarget('audio', 't1'));
+      expect(cooldown, t0.toUtc().toIso8601String());
+    });
+
+    test('returns empty success when called inside the cooldown window',
+        () async {
+      api = _FakeRecordingApi([
+        List.generate(10, (i) => recording(i)),
+      ], _NullApiClient());
+      service = RecordingTargetSyncService(db: db, recordingApi: api);
+      final t0 = DateTime.utc(2024, 6, 1, 12);
+
+      // First call hits the API.
+      final r1 = await service.pullRecordingsForTarget(
+        targetType: 'audio',
+        targetId: 't1',
+        now: t0,
+      );
+      expect(r1.synced, 10);
+      expect(api.callCount, 1);
+
+      // Second call 1 minute later is short-circuited.
+      final r2 = await service.pullRecordingsForTarget(
+        targetType: 'audio',
+        targetId: 't1',
+        now: t0.add(const Duration(minutes: 1)),
+      );
+      expect(r2.synced, 0);
+      expect(r2.failed, 0);
+      expect(r2.success, isTrue);
+      expect(api.callCount, 1, reason: 'cooldown should prevent a second call');
+    });
+
+    test('hits the API again after the cooldown elapses', () async {
+      api = _FakeRecordingApi([
+        List.generate(10, (i) => recording(i)),
+        List.generate(5, (i) => recording(100 + i)),
+      ], _NullApiClient());
+      service = RecordingTargetSyncService(db: db, recordingApi: api);
+      final t0 = DateTime.utc(2024, 6, 1, 12);
+
+      final r1 = await service.pullRecordingsForTarget(
+        targetType: 'audio',
+        targetId: 't1',
+        now: t0,
+      );
+      expect(r1.synced, 10);
+
+      // 6 minutes later: cooldown is over, cursor persisted, the next
+      // call should resume from the cursor and pick up new rows.
+      final r2 = await service.pullRecordingsForTarget(
+        targetType: 'audio',
+        targetId: 't1',
+        now: t0.add(const Duration(minutes: 6)),
+      );
+      expect(r2.synced, 5);
+      expect(api.callCount, 2);
+      expect(api.lastUpdatedAfter, isNotNull);
+      expect(api.lastUpdatedAfter, isNot(isEmpty));
+    });
+
+    test('cooldowns are per-target and do not leak across pairs', () async {
+      api = _FakeRecordingApi([
+        List.generate(3, (i) => recording(i)),
+        List.generate(2, (i) => recording(100 + i)),
+      ], _NullApiClient());
+      service = RecordingTargetSyncService(db: db, recordingApi: api);
+      final t0 = DateTime.utc(2024, 6, 1, 12);
+
+      final r1 = await service.pullRecordingsForTarget(
+        targetType: 'audio',
+        targetId: 't1',
+        now: t0,
+      );
+      expect(r1.synced, 3);
+
+      // Different targetId — separate cooldown bucket.
+      final r2 = await service.pullRecordingsForTarget(
+        targetType: 'audio',
+        targetId: 't2',
+        now: t0.add(const Duration(seconds: 30)),
+      );
+      expect(r2.synced, 2);
+      expect(api.callCount, 2);
+    });
+  });
+}

--- a/test/features/sync/sync_queue_repository_test.dart
+++ b/test/features/sync/sync_queue_repository_test.dart
@@ -30,9 +30,78 @@ void main() {
       final row = await (db.select(
         db.syncQueue,
       )..where((t) => t.id.equals(id1))).getSingle();
+      // Payload is refreshed; the retry / error state is preserved so
+      // editing an entity does not silently re-arm a permanently
+      // failed row.
+      expect(row.payloadJson, '{"x":2}');
+      expect(row.retryCount, 1);
+      expect(row.error, 'fail');
+    },
+  );
+
+  test(
+    'SyncQueueRepository addOrUpsert preserves a permanently failed row',
+    () async {
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+      final repo = SyncQueueRepository(db);
+
+      final id = await repo.addOrUpsert(
+        entityType: 'audio',
+        entityId: 'a1',
+        action: 'create',
+        payloadJson: '{"x":1}',
+      );
+      // Drive the row to permanent failure (5 failed attempts).
+      for (var i = 0; i < 5; i++) {
+        await db.syncQueueDao.markAttempted(id, error: 'fail $i');
+      }
+
+      // Editing the entity updates the payload but does NOT reset the
+      // retry budget.
+      final id2 = await repo.addOrUpsert(
+        entityType: 'audio',
+        entityId: 'a1',
+        action: 'create',
+        payloadJson: '{"x":2}',
+      );
+      expect(id2, id);
+
+      final row = await (db.select(
+        db.syncQueue,
+      )..where((t) => t.id.equals(id))).getSingle();
+      expect(row.payloadJson, '{"x":2}');
+      expect(row.retryCount, 5);
+      expect(row.error, 'fail 4');
+    },
+  );
+
+  test(
+    'SyncQueueRepository.resetFailed re-arms permanently failed rows',
+    () async {
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+      final repo = SyncQueueRepository(db);
+
+      final id = await repo.addOrUpsert(
+        entityType: 'audio',
+        entityId: 'a1',
+        action: 'create',
+        payloadJson: '{"x":1}',
+      );
+      for (var i = 0; i < 5; i++) {
+        await db.syncQueueDao.markAttempted(id, error: 'fail');
+      }
+
+      final n = await repo.resetFailed();
+      expect(n, 1);
+
+      final row = await (db.select(
+        db.syncQueue,
+      )..where((t) => t.id.equals(id))).getSingle();
       expect(row.retryCount, 0);
       expect(row.error, isNull);
-      expect(row.payloadJson, '{"x":2}');
+      expect(row.lastAttempt, isNull);
     },
   );
 }


### PR DESCRIPTION
Closes #107.

## Sync queue semantics

### `addOrUpsert` no longer resets the retry budget

`SyncQueueRepository.addOrUpsert` previously wrote `retryCount: 0`, `error: null`, and `lastAttempt: null` on every existing row. The bug: if a row had been permanently failed (`retryCount >= 5`), the next `addOrUpsert` from any local edit silently re-armed it for retry. The new behavior only overwrites `payloadJson`; the retry / error / last-attempt state is preserved. To re-arm intentionally, callers use the existing `resetFailed()` (unchanged).

Test coverage:
- `test/features/sync/sync_queue_repository_test.dart` — existing test updated to the new contract; new test pinning "permanently-failed stays failed"; new test for `resetFailed()` re-arming after a user-triggered reset.

## Recording pull

### Per-call page cap

`pullRecordingsForTarget` previously ran `while (true)` paginating the upstream API. A user with thousands of recordings would pull all of them in a single media open. The new cap is **5 pages × 50 = 250 rows per call**. The cap is hit only when the upstream still has more rows after 5 pages; the persisted cursor means the next open (after the cooldown) resumes exactly where the previous one stopped.

### 5-minute per-target cooldown

The pull is triggered from `player_open_side_effects.pullRecordingsForTarget`, which fires on every media open. Without a cooldown, a user opening 10 media in 10 minutes hit the API 10 times. The new cooldown is persisted per `(targetType, targetId)` pair in `settingsKv` under `SettingsKeys.syncLastPullAtRecordingTarget(targetType, targetId)`. Calls inside the window short-circuit to an empty success.

A test-only `now` parameter is exposed so the cooldown can be exercised without sleeping.

Test coverage:
- `test/features/sync/recording_target_sync_service_test.dart` — 4 tests covering the page cap + cooldown-timestamp persistence, the cooldown short-circuit, the cooldown expiry (with cursor resume), and per-target isolation.

## Files

- `lib/features/sync/data/sync_queue_repository.dart` — `addOrUpsert` doc + behavior
- `lib/features/sync/data/recording_target_sync_service.dart` — page cap + cooldown
- `lib/data/db/settings_keys.dart` — new `syncLastPullAtRecordingTarget` key
- `test/features/sync/sync_queue_repository_test.dart` — updated + 2 new tests
- `test/features/sync/recording_target_sync_service_test.dart` — new file, 4 tests

## Verification

```
flutter analyze (lib/features/sync lib/data/db)         # 0 issues
flutter test test/features/sync                          # 20/20 pass
flutter test                                              # same 2 pre-existing failures as main
```
