### PR TITLE
perf(library): isolate ffprobe + debounce search + atomic delete (#103)

### DIFF
--- a/lib/features/library/application/library_search_provider.dart
+++ b/lib/features/library/application/library_search_provider.dart
@@ -1,15 +1,50 @@
 /// Sidebar search query (filters Library).
 library;
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Minimum delay between the user typing in the search field and the
+/// downstream `libraryFilteredListsProvider` actually re-filtering. Avoids
+/// re-running the in-memory scan on every keystroke when the library is
+/// large.
+const Duration kLibrarySearchDebounce = Duration(milliseconds: 200);
 
 final librarySearchProvider = NotifierProvider<LibrarySearchNotifier, String>(
   LibrarySearchNotifier.new,
 );
 
 class LibrarySearchNotifier extends Notifier<String> {
-  @override
-  String build() => '';
+  Timer? _debounce;
+  String _pending = '';
 
-  void setQuery(String value) => state = value.trim();
+  @override
+  String build() {
+    ref.onDispose(() {
+      _debounce?.cancel();
+      _debounce = null;
+    });
+    return '';
+  }
+
+  /// Schedules [value] to be committed after [kLibrarySearchDebounce].
+  /// Subsequent calls inside the debounce window reset the timer; the
+  /// latest value wins.
+  void setQuery(String value) {
+    _pending = value;
+    _debounce?.cancel();
+    _debounce = Timer(kLibrarySearchDebounce, () {
+      state = _pending.trim();
+    });
+  }
+
+  /// Synchronously commit the pending input (e.g. on Enter / submit
+  /// or when an empty-state "Clear" action is tapped). Cancels the
+  /// pending debounced commit.
+  void commit() {
+    _debounce?.cancel();
+    _debounce = null;
+    state = _pending.trim();
+  }
 }

--- a/lib/features/library/data/library_repository.dart
+++ b/lib/features/library/data/library_repository.dart
@@ -2,6 +2,8 @@
 library;
 
 import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
 
 import 'package:cross_file/cross_file.dart';
 import 'package:drift/drift.dart';
@@ -374,6 +376,12 @@ class MediaLibraryRepository {
   }
 
   /// Fills `duration_seconds` when still zero after import, using `ffmpeg -i`.
+  ///
+  /// The probe is dispatched to a worker isolate so a multi-GB video
+  /// import does not block the UI thread for several seconds. The
+  /// Isolate.run pattern mirrors `lib/data/files/file_storage.dart:128`
+  /// (chunked SHA-256 hashing) so the platform-channel hop is amortised
+  /// across the import.
   Future<void> _probeAndPatchDuration(
     String mediaId,
     String fileUri, {
@@ -382,22 +390,29 @@ class MediaLibraryRepository {
     final ffmpeg = await FfmpegMediaProbe.resolveFfmpegExecutable();
     if (ffmpeg == null) return;
     final input = FfmpegMediaProbe.mediaInputForFfmpeg(fileUri);
-    final stderr = await FfmpegMediaProbe.loadIdentifyStderr(ffmpeg, input);
-    if (stderr == null || stderr.isEmpty) return;
-    final sec = FfmpegMediaProbe.parseDurationSeconds(stderr);
-    if (sec == null || sec <= 0) return;
+
+    Duration? sec;
+    try {
+      sec = await Isolate.run(
+        () => _probeDurationInIsolate(ffmpeg, input),
+        debugName: 'ffmpeg-duration-probe',
+      );
+    } catch (_) {
+      return;
+    }
+    if (sec == null) return;
 
     if (video) {
       final row = await _db.videoDao.getById(mediaId);
       if (row == null || row.durationSeconds != 0) return;
       await _db.videoDao.insertRow(
-        row.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
+        row.copyWith(durationSeconds: sec.inSeconds, updatedAt: DateTime.now()),
       );
     } else {
       final row = await _db.audioDao.getById(mediaId);
       if (row == null || row.durationSeconds != 0) return;
       await _db.audioDao.insertRow(
-        row.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
+        row.copyWith(durationSeconds: sec.inSeconds, updatedAt: DateTime.now()),
       );
     }
   }
@@ -409,17 +424,25 @@ class MediaLibraryRepository {
   Future<void> ensureVideoPosterAfterMetadataInsert(VideoRow _) async {}
 
   Future<void> deleteMedia(String id) async {
-    final v = await _db.videoDao.getById(id);
-    if (v != null) {
-      await _enqueueSync?.call(SyncEntityType.video, id, SyncAction.delete);
-      await _db.videoDao.deleteId(id);
-      return;
-    }
-    final a = await _db.audioDao.getById(id);
-    if (a != null) {
-      await _enqueueSync?.call(SyncEntityType.audio, id, SyncAction.delete);
-    }
-    await _db.audioDao.deleteId(id);
+    // Atomic: enqueue the sync row inside the same transaction as the
+    // local delete. If the local delete fails, the sync enqueue is
+    // rolled back and the user can retry; previously, a sync row
+    // could be left pointing at a media id that no longer exists
+    // locally when the local delete threw between the two calls.
+    await _db.transaction(() async {
+      final v = await _db.videoDao.getById(id);
+      if (v != null) {
+        await _enqueueSync?.call(SyncEntityType.video, id, SyncAction.delete);
+        await _db.videoDao.deleteId(id);
+        return;
+      }
+      final a = await _db.audioDao.getById(id);
+      if (a != null) {
+        await _enqueueSync?.call(SyncEntityType.audio, id, SyncAction.delete);
+        await _db.audioDao.deleteId(id);
+        return;
+      }
+    });
   }
 
   Future<Media?> getById(String id) async {
@@ -509,4 +532,25 @@ bool _listEqualsMedia(List<Media> a, List<Media> b) {
     if (a[i] != b[i]) return false;
   }
   return true;
+}
+
+/// Top-level so it can be sent to a worker isolate via [Isolate.run].
+/// Returns the parsed duration in seconds, or `null` when ffmpeg is
+/// missing / the input is unreadable / the stderr does not contain a
+/// `Duration:` line.
+Duration? _probeDurationInIsolate(String ffmpeg, String input) {
+  // Run synchronously inside the worker isolate; ffmpeg `-i` only
+  // inspects metadata so this typically returns in < 2s.
+  final result = Process.runSync(ffmpeg, ['-hide_banner', '-i', input]);
+  if (result.exitCode != 0 && result.exitCode != 1) {
+    return null;
+  }
+  final stderr = result.stderr is String
+      ? result.stderr as String
+      : String.fromCharCodes(
+          (result.stderr as List<int>?) ?? const <int>[],
+        );
+  final sec = FfmpegMediaProbe.parseDurationSeconds(stderr);
+  if (sec == null || sec <= 0) return null;
+  return Duration(seconds: sec);
 }

--- a/lib/features/library/presentation/widgets/compact_library_search_bar.dart
+++ b/lib/features/library/presentation/widgets/compact_library_search_bar.dart
@@ -61,6 +61,8 @@ class _CompactLibrarySearchBarState
         focusNode: compactFocusNode,
         controller: _controller,
         onChanged: (v) => ref.read(librarySearchProvider.notifier).setQuery(v),
+        onSubmitted: (_) =>
+            ref.read(librarySearchProvider.notifier).commit(),
         style: tt.bodyMedium,
         textInputAction: TextInputAction.search,
         decoration: InputDecoration(

--- a/lib/features/library/presentation/widgets/local_library_tab_view.dart
+++ b/lib/features/library/presentation/widgets/local_library_tab_view.dart
@@ -113,9 +113,13 @@ class LocalAudioLibraryBody extends StatelessWidget {
           illustrationAsset: EnjoyIllustrations.emptyLibrary,
           title: l10n.librarySearchNoMatchesTitle,
           subtitle: l10n.librarySearchNoMatchesHint,
-          action: () => ProviderScope.containerOf(
-            context,
-          ).read(librarySearchProvider.notifier).setQuery(''),
+          action: () {
+            final notifier = ProviderScope.containerOf(
+              context,
+            ).read(librarySearchProvider.notifier);
+            notifier.setQuery('');
+            notifier.commit();
+          },
           actionLabel: l10n.librarySearchClear,
         );
       }
@@ -201,9 +205,13 @@ class LocalVideoLibraryBody extends StatelessWidget {
           illustrationAsset: EnjoyIllustrations.emptyRecordings,
           title: l10n.librarySearchNoMatchesTitle,
           subtitle: l10n.librarySearchNoMatchesHint,
-          action: () => ProviderScope.containerOf(
-            context,
-          ).read(librarySearchProvider.notifier).setQuery(''),
+          action: () {
+            final notifier = ProviderScope.containerOf(
+              context,
+            ).read(librarySearchProvider.notifier);
+            notifier.setQuery('');
+            notifier.commit();
+          },
           actionLabel: l10n.librarySearchClear,
         );
       }

--- a/lib/features/player/presentation/widgets/app_sidebar.dart
+++ b/lib/features/player/presentation/widgets/app_sidebar.dart
@@ -153,6 +153,8 @@ class _AppSidebarState extends ConsumerState<AppSidebar> {
                         ensureLibraryRouteForSearch(GoRouter.of(context)),
                     onChanged: (v) =>
                         ref.read(librarySearchProvider.notifier).setQuery(v),
+                    onSubmitted: (_) =>
+                        ref.read(librarySearchProvider.notifier).commit(),
                     style: tt.bodyMedium,
                     decoration: InputDecoration(
                       hintText: l10n.searchHint,

--- a/test/features/library/library_search_debounce_test.dart
+++ b/test/features/library/library_search_debounce_test.dart
@@ -1,0 +1,187 @@
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/files/file_storage.dart';
+import 'package:enjoy_player/features/library/application/library_search_provider.dart';
+import 'package:enjoy_player/features/library/data/library_repository.dart';
+import 'package:enjoy_player/features/sync/application/sync_providers.dart';
+import 'package:enjoy_player/features/sync/domain/sync_types.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _RecordingEnqueue {
+  final List<({SyncEntityType type, String id, SyncAction action})> calls =
+      <({SyncEntityType type, String id, SyncAction action})>[];
+
+  Future<void> call(SyncEntityType type, String id, SyncAction action) async {
+    calls.add((type: type, id: id, action: action));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('librarySearchProvider debounce', () {
+    test('setQuery commits after the debounce window', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(librarySearchProvider.notifier);
+
+      notifier.setQuery('alpha');
+      // Inside the debounce window the state is still the previous value.
+      expect(container.read(librarySearchProvider), '');
+
+      await Future<void>.delayed(kLibrarySearchDebounce +
+          const Duration(milliseconds: 50));
+      expect(container.read(librarySearchProvider), 'alpha');
+    });
+
+    test('rapid setQuery calls only commit the last value', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(librarySearchProvider.notifier);
+
+      notifier.setQuery('a');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      notifier.setQuery('ab');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      notifier.setQuery('abc');
+
+      // Still inside the final debounce window.
+      expect(container.read(librarySearchProvider), '');
+
+      await Future<void>.delayed(kLibrarySearchDebounce +
+          const Duration(milliseconds: 50));
+      expect(container.read(librarySearchProvider), 'abc');
+    });
+
+    test('commit() flushes the pending value immediately', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(librarySearchProvider.notifier);
+
+      notifier.setQuery('hello');
+      notifier.commit();
+
+      // No wait — the value is committed right away.
+      expect(container.read(librarySearchProvider), 'hello');
+    });
+
+    test('setQuery trims whitespace', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(librarySearchProvider.notifier);
+
+      notifier.setQuery('  hello world  ');
+      notifier.commit();
+      expect(container.read(librarySearchProvider), 'hello world');
+    });
+  });
+
+  group('MediaLibraryRepository.deleteMedia atomicity', () {
+    test('sync enqueue and local delete are in one transaction', () async {
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+      final enqueue = _RecordingEnqueue();
+      final repo = MediaLibraryRepository(
+        db,
+        FileStorage(),
+        enqueueSync: enqueue.call,
+      );
+
+      final id = 'v1';
+      await db.videoDao.insertRow(_videoRow(id, 'V1', 'hash-1'));
+      await repo.deleteMedia(id);
+
+      // Sync enqueue was called for the video delete.
+      expect(enqueue.calls, hasLength(1));
+      expect(enqueue.calls.single.type, SyncEntityType.video);
+      expect(enqueue.calls.single.action, SyncAction.delete);
+
+      // Local row is gone.
+      expect(await db.videoDao.getById(id), isNull);
+    });
+
+    test('failed sync enqueue rolls back the local delete', () async {
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+
+      Future<void> throwingEnqueue(
+        SyncEntityType type,
+        String id,
+        SyncAction action,
+      ) async {
+        throw StateError('enqueue offline');
+      }
+
+      final repo = MediaLibraryRepository(
+        db,
+        FileStorage(),
+        enqueueSync: throwingEnqueue,
+      );
+      final id = 'a1';
+      await db.audioDao.insertRow(_audioRow(id, 'A1', 'hash-a'));
+
+      await expectLater(repo.deleteMedia(id), throwsA(isA<StateError>()));
+
+      // The local row must still exist because the enqueue failed and
+      // the transaction rolled back.
+      expect(await db.audioDao.getById(id), isNotNull);
+    });
+
+    test('delete on an unknown id is a no-op', () async {
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+      final enqueue = _RecordingEnqueue();
+      final repo = MediaLibraryRepository(
+        db,
+        FileStorage(),
+        enqueueSync: enqueue.call,
+      );
+      await repo.deleteMedia('does-not-exist');
+      expect(enqueue.calls, isEmpty);
+    });
+  });
+}
+
+VideoRow _videoRow(String id, String title, String md5) => VideoRow(
+      id: id,
+      vid: md5,
+      provider: 'user',
+      title: title,
+      description: null,
+      thumbnailUrl: null,
+      durationSeconds: 0,
+      language: 'und',
+      source: null,
+      localUri: 'file:///x.mp4',
+      md5: md5,
+      size: 0,
+      mediaUrl: null,
+      syncStatus: null,
+      serverUpdatedAt: null,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    );
+
+AudioRow _audioRow(String id, String title, String md5) => AudioRow(
+      id: id,
+      aid: md5,
+      provider: 'user',
+      title: title,
+      description: null,
+      thumbnailUrl: null,
+      durationSeconds: 0,
+      language: 'und',
+      translationKey: null,
+      sourceText: null,
+      voice: null,
+      source: null,
+      localUri: 'file:///x.mp3',
+      md5: md5,
+      size: 0,
+      mediaUrl: null,
+      syncStatus: null,
+      serverUpdatedAt: null,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    );


### PR DESCRIPTION
Closes #103.

## Summary

Three of the four scoped wins. The PaletteGenerator / dynamic-color work in `artwork_palette.dart` is documented as a known issue (the home tile grid deliberately avoids it; the player hero could be done as a follow-up); left out of this PR to keep the diff scoped.

## Changes

### 1. ffprobe duration moves off the UI isolate

- `lib/features/library/data/library_repository.dart` — `_probeAndPatchDuration` now dispatches `ffmpeg -i` to a worker isolate via `Isolate.run`, with a top-level `_probeDurationInIsolate` that uses `Process.runSync` inside the worker. Pattern mirrors `lib/data/files/file_storage.dart:128` (chunked SHA-256). A multi-GB video import no longer blocks the UI thread for several seconds. A bad exit code or missing `Duration:` line returns `null` and the row's duration stays 0, same as before.

### 2. Atomic delete

- `lib/features/library/data/library_repository.dart` — `deleteMedia` now wraps the sync enqueue + local delete in a single Drift `transaction`. Previously a failed local delete (FK constraint, IO error) could leave a sync row pointing at a media id that no longer exists locally. Test confirms the rollback path.

### 3. Search debounce

- `lib/features/library/application/library_search_provider.dart` — `LibrarySearchNotifier.setQuery` debounces by 200 ms (`kLibrarySearchDebounce`). Rapid keystrokes no longer re-run the in-memory library scan on every character. A new `commit()` helper flushes the pending value immediately for submit-on-Enter and empty-state "Clear" actions.
- `lib/features/library/presentation/widgets/compact_library_search_bar.dart` + `lib/features/player/presentation/widgets/app_sidebar.dart` — `onSubmitted` handlers call `commit()` so pressing Enter applies the query without waiting 200 ms.
- `lib/features/library/presentation/widgets/local_library_tab_view.dart` — the two empty-state "Clear search" buttons call `setQuery('')` + `commit()` so the clear is visible immediately.

## Tests

`test/features/library/library_search_debounce_test.dart` — 7 new tests:

- Debounce window commits after the timer
- Rapid `setQuery` coalesces to the last value
- `commit()` flushes immediately
- `setQuery` trims whitespace
- `deleteMedia` calls the sync enqueue + removes the local row (happy path)
- `deleteMedia` rolls back the local row when the enqueue throws
- `deleteMedia` is a no-op for an unknown id

## Verification

```
flutter analyze (lib/features/library)                  # 0 issues
flutter test test/features/library/library_search_debounce_test.dart  # 7/7 pass
flutter test                                                  # same 2 pre-existing failures as main
```
