### PR TITLE
perf(ai): token cache dedup + isolate WAV ffmpeg + couple AI URL to API URL (#105)

### DIFF
--- a/lib/data/api/api_client_provider.dart
+++ b/lib/data/api/api_client_provider.dart
@@ -60,11 +60,17 @@ class AiApiBaseUrl extends _$AiApiBaseUrl {
   @override
   Future<String> build() async {
     final db = ref.watch(guestAppDatabaseProvider);
+    // When no AI base URL is explicitly persisted, follow the main
+    // [ApiBaseUrl] (the worker lives on the same origin as the public
+    // API by default). This keeps the two settings coupled by default
+    // and avoids the "I changed the API URL but the AI still hits the
+    // old host" footgun called out in #83. An explicit override in
+    // settingsKv still wins.
     final raw = await db.settingsDao.getValue(SettingsKeys.apiAiBaseUrl);
-    return normalizeApiBaseUrl(
-      raw ?? kDefaultAiApiBaseUrl,
-      kDefaultAiApiBaseUrl,
-    );
+    if (raw == null) {
+      return ref.watch(apiBaseUrlProvider.future);
+    }
+    return normalizeApiBaseUrl(raw, await ref.read(apiBaseUrlProvider.future));
   }
 
   /// Persists and refreshes [aiApiClientProvider].
@@ -75,6 +81,14 @@ class AiApiBaseUrl extends _$AiApiBaseUrl {
         .settingsDao
         .setValue(SettingsKeys.apiAiBaseUrl, normalized);
     state = AsyncData(normalized);
+    ref.invalidate(aiApiClientProvider);
+  }
+
+  /// Clears the override and falls back to following [apiBaseUrlProvider].
+  Future<void> clearOverride() async {
+    final db = ref.read(guestAppDatabaseProvider);
+    await db.settingsDao.deleteValue(SettingsKeys.apiAiBaseUrl);
+    state = AsyncData(await ref.read(apiBaseUrlProvider.future));
     ref.invalidate(aiApiClientProvider);
   }
 }

--- a/lib/data/api/services/ai/azure_token_cache.dart
+++ b/lib/data/api/services/ai/azure_token_cache.dart
@@ -1,6 +1,8 @@
 /// Short-lived Azure Speech token cache (Enjoy worker `POST /azure/tokens`).
 library;
 
+import 'dart:async';
+
 import 'package:enjoy_player/data/api/services/ai/azure_token_api.dart';
 import 'package:meta/meta.dart';
 
@@ -25,6 +27,12 @@ final class AzureTokenCache {
   ({String token, String region})? _cached;
   DateTime? _fetchedAt;
 
+  /// In-flight fetch shared by concurrent callers. Without this, two
+  /// `getToken` calls that both miss the cache (e.g. on a cold start
+  /// or right after `clear()`) would each hit the worker, doubling
+  /// the call budget. The completer is cleared once the fetch settles.
+  Future<({String token, String region})>? _inFlight;
+
   /// [durationSeconds] is forwarded for worker-side cost estimation (assessment).
   Future<({String token, String region})> getToken({
     required int durationSeconds,
@@ -36,28 +44,44 @@ final class AzureTokenCache {
       return c;
     }
 
-    final json = _debugOverrideFetch != null
-        ? await _debugOverrideFetch()
-        : await _api!.generateToken(
-            usage: <String, dynamic>{
-              'purpose': 'assessment',
-              'assessment': <String, dynamic>{
-                'durationSeconds': durationSeconds,
-              },
-            },
-          );
-
-    final token = json['token'] as String?;
-    final region = json['region'] as String?;
-    if (token == null || token.isEmpty || region == null || region.isEmpty) {
-      throw StateError(
-        'Azure token response missing token/region: ${json.keys.join(", ")}',
-      );
+    final existing = _inFlight;
+    if (existing != null) {
+      return existing;
     }
 
-    _cached = (token: token, region: region);
-    _fetchedAt = now;
-    return _cached!;
+    Future<({String token, String region})> fetch() async {
+      final json = _debugOverrideFetch != null
+          ? await _debugOverrideFetch()
+          : await _api!.generateToken(
+              usage: <String, dynamic>{
+                'purpose': 'assessment',
+                'assessment': <String, dynamic>{
+                  'durationSeconds': durationSeconds,
+                },
+              },
+            );
+
+      final token = json['token'] as String?;
+      final region = json['region'] as String?;
+      if (token == null || token.isEmpty || region == null || region.isEmpty) {
+        throw StateError(
+          'Azure token response missing token/region: ${json.keys.join(", ")}',
+        );
+      }
+
+      final value = (token: token, region: region);
+      _cached = value;
+      _fetchedAt = DateTime.now();
+      return value;
+    }
+
+    final pending = fetch();
+    _inFlight = pending;
+    try {
+      return await pending;
+    } finally {
+      _inFlight = null;
+    }
   }
 
   void clear() {

--- a/lib/data/db/app_database.dart
+++ b/lib/data/db/app_database.dart
@@ -618,6 +618,10 @@ class SettingsDao extends DatabaseAccessor<AppDatabase>
     SettingRow(key: key, value: value),
     mode: InsertMode.insertOrReplace,
   );
+
+  /// Removes a key. No-op when the key is absent.
+  Future<void> deleteValue(String key) =>
+      (delete(settingsKv)..where((t) => t.key.equals(key))).go();
 }
 
 @DriftAccessor(tables: [YoutubeChannelSubscriptions])

--- a/lib/features/ai/data/azure_assessment_wav_normalizer.dart
+++ b/lib/features/ai/data/azure_assessment_wav_normalizer.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:enjoy_player/core/audio/wav_signal_peak.dart';
 import 'package:enjoy_player/core/logging/log.dart';
@@ -25,35 +26,29 @@ String _shellEscape(String path) {
   return path;
 }
 
-Future<bool> _runFfmpegWindows({
-  required String exe,
-  required String inputPath,
-  required String outputWavPath,
-  required String audioFilter,
-}) async {
-  final r = await Process.run(exe, [
+/// Top-level so the ffmpeg invocation can run inside a worker isolate
+/// (see [normalizeWavForAzureAssessment]). Returns the same
+/// `({int exitCode, String stderr})` shape we used to capture from
+/// `Process.run` so the caller can log the same way.
+Future<({int exitCode, String stderr})> _runFfmpegWindowsInIsolate(
+  _WindowsFfmpegArgs args,
+) async {
+  final r = await Process.run(args.exe, <String>[
     '-nostdin',
     '-hide_banner',
     '-loglevel',
     'error',
     '-y',
     '-i',
-    inputPath,
+    args.inputPath,
     '-vn',
     '-af',
-    audioFilter,
+    args.audioFilter,
     '-c:a',
     'pcm_s16le',
-    outputWavPath,
+    args.outputWavPath,
   ]);
-  if (r.exitCode != 0) {
-    _log.fine(
-      'normalizeWav: ffmpeg failed (exit ${r.exitCode}) filter="$audioFilter": '
-      '${r.stderr}',
-    );
-    return false;
-  }
-  return true;
+  return (exitCode: r.exitCode, stderr: r.stderr is String ? r.stderr as String : '');
 }
 
 Future<bool> _runFfmpegKit({
@@ -104,6 +99,9 @@ bool _looksSilent(WavPeakScan scan) {
 ///
 /// Returns `true` when [outputWavPath] exists, has at least 100 bytes, and
 /// passes a non-silent peak/RMS check (guards against empty FFmpeg decode).
+///
+/// On Windows the ffmpeg invocation runs in a worker isolate (via
+/// [Isolate.run]) so a long re-encode does not block the UI thread.
 Future<bool> normalizeWavForAzureAssessment({
   required String inputPath,
   required String outputWavPath,
@@ -134,12 +132,30 @@ Future<bool> normalizeWavForAzureAssessment({
       _log.fine('normalizeWav: no ffmpeg on Windows, skipping');
       return false;
     }
-    encoded = await _runFfmpegWindows(
-      exe: exe,
-      inputPath: inputPath,
-      outputWavPath: outputWavPath,
-      audioFilter: filter,
-    );
+    try {
+      final result = await Isolate.run(
+        () => _runFfmpegWindowsInIsolate(
+          _WindowsFfmpegArgs(
+            exe: exe,
+            inputPath: inputPath,
+            outputWavPath: outputWavPath,
+            audioFilter: filter,
+          ),
+        ),
+        debugName: 'azure-wav-ffmpeg',
+      );
+      if (result.exitCode != 0) {
+        _log.fine(
+          'normalizeWav: ffmpeg failed (exit ${result.exitCode}) '
+          'filter="$filter": ${result.stderr}',
+        );
+        return false;
+      }
+      encoded = true;
+    } catch (e, st) {
+      _log.fine('normalizeWav: isolate run failed', e, st);
+      return false;
+    }
   } else {
     encoded = await _runFfmpegKit(
       inputPath: inputPath,
@@ -200,4 +216,17 @@ Future<String?> tryCreateNormalizedAzureAssessmentWav(String inputPath) async {
     return null;
   }
   return File(out).absolute.path;
+}
+
+class _WindowsFfmpegArgs {
+  const _WindowsFfmpegArgs({
+    required this.exe,
+    required this.inputPath,
+    required this.outputWavPath,
+    required this.audioFilter,
+  });
+  final String exe;
+  final String inputPath;
+  final String outputWavPath;
+  final String audioFilter;
 }

--- a/lib/features/ai/presentation/ai_playground_azure_error.dart
+++ b/lib/features/ai/presentation/ai_playground_azure_error.dart
@@ -1,0 +1,25 @@
+/// Re-export the [AzureSpeechException] type and a formatter so the AI
+/// playground can handle the SDK's error type without importing the
+/// `azure_speech` package at the top of the playground widget file.
+///
+/// The playground is gated to debug builds via the router. Keeping the
+/// `azure_speech` import behind this small helper file is a (small)
+/// defense-in-depth measure: if a future refactor accidentally promotes
+/// the playground to a release build, the SDK is still linked in (the
+/// Azure plugin registers the platform implementation), but the import
+/// only shows up in this one place.
+library;
+
+import 'package:azure_speech/azure_speech.dart';
+
+/// True when [e] is an [AzureSpeechException]. Use in a generic catch
+/// block so callers do not need to import `azure_speech` themselves.
+bool isAzureSpeechException(Object e) => e is AzureSpeechException;
+
+/// Format the SDK's error code and message for a log line / UI label.
+/// Returns `null` when [e] is not an [AzureSpeechException] so the
+/// caller can fall back to a generic error formatter.
+String? formatAzureSpeechError(Object e) {
+  if (e is! AzureSpeechException) return null;
+  return 'AzureSpeech ${e.code}: ${e.message}';
+}

--- a/lib/features/ai/presentation/ai_playground_screen.dart
+++ b/lib/features/ai/presentation/ai_playground_screen.dart
@@ -8,13 +8,13 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:azure_speech/azure_speech.dart';
 import 'package:enjoy_player/core/errors/app_failure.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/ai/application/ai_services.dart';
 import 'package:enjoy_player/features/ai/domain/chat_message.dart';
 import 'package:enjoy_player/features/ai/domain/models/asr_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/assessment_request.dart';
+import 'package:enjoy_player/features/ai/presentation/ai_playground_azure_error.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 import 'package:logging/logging.dart';
 
@@ -230,12 +230,13 @@ class _AiPlaygroundScreenState extends ConsumerState<AiPlaygroundScreen> {
         }
       }
       _append(buf.toString());
-    } on AzureSpeechException catch (e, st) {
-      _log.warning('Assessment failed', e, st);
-      _append('Assessment ${e.code}: ${e.message}');
     } catch (e, st) {
       _log.warning('Assessment failed', e, st);
-      _append('Assessment ${_err(e)}');
+      if (isAzureSpeechException(e)) {
+        _append('Assessment ${formatAzureSpeechError(e)}');
+      } else {
+        _append('Assessment ${_err(e)}');
+      }
     }
   }
 

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -1417,29 +1417,67 @@ class _AiApiBaseUrlEditorState extends ConsumerState<_AiApiBaseUrlEditor> {
           autocorrect: false,
         ),
         SizedBox(height: t.space12),
-        FilledButton(
-          onPressed: (!_loaded || _saving)
-              ? null
-              : () async {
-                  setState(() => _saving = true);
-                  try {
-                    await ref
-                        .read(aiApiBaseUrlProvider.notifier)
-                        .setBaseUrl(_controller.text);
-                    if (context.mounted) {
-                      AppNotice.success(context, l10n.settingsAiApiBaseUrlSave);
-                    }
-                  } finally {
-                    if (mounted) setState(() => _saving = false);
-                  }
-                },
-          child: _saving
-              ? const SizedBox(
-                  height: 20,
-                  width: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : Text(l10n.settingsAiApiBaseUrlSave),
+        Row(
+          children: [
+            Expanded(
+              child: FilledButton(
+                onPressed: (!_loaded || _saving)
+                    ? null
+                    : () async {
+                        setState(() => _saving = true);
+                        try {
+                          await ref
+                              .read(aiApiBaseUrlProvider.notifier)
+                              .setBaseUrl(_controller.text);
+                          if (context.mounted) {
+                            AppNotice.success(
+                              context,
+                              l10n.settingsAiApiBaseUrlSave,
+                            );
+                          }
+                        } finally {
+                          if (mounted) setState(() => _saving = false);
+                        }
+                      },
+                child: _saving
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(l10n.settingsAiApiBaseUrlSave),
+              ),
+            ),
+            SizedBox(width: t.space8),
+            Expanded(
+              child: OutlinedButton(
+                onPressed: (!_loaded || _saving)
+                    ? null
+                    : () async {
+                        setState(() => _saving = true);
+                        try {
+                          await ref
+                              .read(aiApiBaseUrlProvider.notifier)
+                              .clearOverride();
+                          final url = await ref
+                              .read(aiApiBaseUrlProvider.future);
+                          if (mounted) {
+                            _controller.text = url;
+                          }
+                          if (context.mounted) {
+                            AppNotice.success(
+                              context,
+                              l10n.settingsAiApiBaseUrlCleared,
+                            );
+                          }
+                        } finally {
+                          if (mounted) setState(() => _saving = false);
+                        }
+                      },
+                child: Text(l10n.settingsAiApiBaseUrlUseDefault),
+              ),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -545,6 +545,8 @@
   "settingsAiApiBaseUrl": "AI API base URL",
   "settingsAiApiBaseUrlHint": "Example: https://worker.enjoy.bot",
   "settingsAiApiBaseUrlSave": "Save AI API URL",
+  "settingsAiApiBaseUrlUseDefault": "Use API URL",
+  "settingsAiApiBaseUrlCleared": "AI API now follows the main API URL.",
   "settingsAccountSignedOut": "Not signed in",
   "settingsAccountOpenProfile": "Open profile",
   "settingsAccountSignIn": "Sign in",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2505,6 +2505,18 @@ abstract class AppLocalizations {
   /// **'Save AI API URL'**
   String get settingsAiApiBaseUrlSave;
 
+  /// No description provided for @settingsAiApiBaseUrlUseDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'Use API URL'**
+  String get settingsAiApiBaseUrlUseDefault;
+
+  /// No description provided for @settingsAiApiBaseUrlCleared.
+  ///
+  /// In en, this message translates to:
+  /// **'AI API now follows the main API URL.'**
+  String get settingsAiApiBaseUrlCleared;
+
   /// No description provided for @settingsAccountSignedOut.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1305,6 +1305,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsAiApiBaseUrlSave => 'Save AI API URL';
 
   @override
+  String get settingsAiApiBaseUrlUseDefault => 'Use API URL';
+
+  @override
+  String get settingsAiApiBaseUrlCleared =>
+      'AI API now follows the main API URL.';
+
+  @override
   String get settingsAccountSignedOut => 'Not signed in';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1254,6 +1254,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsAiApiBaseUrlSave => '保存 AI API 地址';
 
   @override
+  String get settingsAiApiBaseUrlUseDefault => '使用主 API 地址';
+
+  @override
+  String get settingsAiApiBaseUrlCleared => 'AI API 现在跟随主 API 地址。';
+
+  @override
   String get settingsAccountSignedOut => '未登录';
 
   @override
@@ -3004,6 +3010,12 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get settingsAiApiBaseUrlSave => '保存 AI API 地址';
+
+  @override
+  String get settingsAiApiBaseUrlUseDefault => '使用主 API 地址';
+
+  @override
+  String get settingsAiApiBaseUrlCleared => 'AI API 现在跟随主 API 地址。';
 
   @override
   String get settingsAccountSignedOut => '未登录';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -531,6 +531,8 @@
   "settingsAiApiBaseUrl": "AI API 基础地址",
   "settingsAiApiBaseUrlHint": "示例：https://worker.enjoy.bot",
   "settingsAiApiBaseUrlSave": "保存 AI API 地址",
+  "settingsAiApiBaseUrlUseDefault": "使用主 API 地址",
+  "settingsAiApiBaseUrlCleared": "AI API 现在跟随主 API 地址。",
   "settingsAccountSignedOut": "未登录",
   "settingsAccountOpenProfile": "打开个人资料",
   "settingsAccountSignIn": "登录",

--- a/lib/l10n/app_zh_CN.arb
+++ b/lib/l10n/app_zh_CN.arb
@@ -531,6 +531,8 @@
   "settingsAiApiBaseUrl": "AI API 基础地址",
   "settingsAiApiBaseUrlHint": "示例：https://worker.enjoy.bot",
   "settingsAiApiBaseUrlSave": "保存 AI API 地址",
+  "settingsAiApiBaseUrlUseDefault": "使用主 API 地址",
+  "settingsAiApiBaseUrlCleared": "AI API 现在跟随主 API 地址。",
   "settingsAccountSignedOut": "未登录",
   "settingsAccountOpenProfile": "打开个人资料",
   "settingsAccountSignIn": "登录",

--- a/test/features/ai/azure_token_cache_dedup_test.dart
+++ b/test/features/ai/azure_token_cache_dedup_test.dart
@@ -1,0 +1,131 @@
+import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/services/ai/azure_token_api.dart';
+import 'package:enjoy_player/data/api/services/ai/azure_token_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+class _FakeAzureTokenApi extends AzureTokenApi {
+  _FakeAzureTokenApi(this.handler) : super(_NullApiClient());
+
+  final Future<Map<String, dynamic>> Function() handler;
+  int callCount = 0;
+
+  @override
+  Future<Map<String, dynamic>> generateToken({
+    Map<String, dynamic>? usage,
+  }) async {
+    callCount += 1;
+    return handler();
+  }
+}
+
+/// Pass-through ApiClient that the [AzureTokenApi] super-constructor
+/// will accept; the fake subclass overrides every method the cache
+/// actually calls.
+class _NullApiClient extends ApiClient {
+  _NullApiClient() : super(
+    httpClient: _NullHttpClient(),
+    getBaseUrl: () async => 'https://test.invalid',
+    getAccessToken: () async => null,
+  );
+}
+
+class _NullHttpClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    throw UnsupportedError('AzureTokenCache tests must override every method '
+        'they exercise; the base class should never be called.');
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AzureTokenCache', () {
+    test('returns the cached token on a hit', () async {
+      var n = 0;
+      final api = _FakeAzureTokenApi(() async {
+        n += 1;
+        return <String, dynamic>{'token': 'tok-1', 'region': 'westus'};
+      });
+      final cache = AzureTokenCache(api: api);
+
+      final a = await cache.getToken(durationSeconds: 30);
+      final b = await cache.getToken(durationSeconds: 30);
+
+      expect(a.token, 'tok-1');
+      expect(b.token, 'tok-1');
+      expect(n, 1, reason: 'second call must hit the cache');
+    });
+
+    test('concurrent calls share a single fetch', () async {
+      var inFlight = 0;
+      var maxInFlight = 0;
+      final api = _FakeAzureTokenApi(() async {
+        inFlight += 1;
+        if (inFlight > maxInFlight) maxInFlight = inFlight;
+        // Simulate the worker taking a moment to respond.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        inFlight -= 1;
+        return <String, dynamic>{'token': 'tok-1', 'region': 'westus'};
+      });
+      final cache = AzureTokenCache(api: api);
+
+      final results = await Future.wait([
+        cache.getToken(durationSeconds: 30),
+        cache.getToken(durationSeconds: 30),
+        cache.getToken(durationSeconds: 30),
+      ]);
+
+      expect(results.map((r) => r.token).toSet(), {'tok-1'});
+      expect(api.callCount, 1, reason: 'deduplication must collapse fetches');
+      expect(maxInFlight, 1, reason: 'only one fetch may be in flight');
+    });
+
+    test('subsequent call after expiry hits the API again', () async {
+      var n = 0;
+      final api = _FakeAzureTokenApi(() async {
+        n += 1;
+        return <String, dynamic>{
+          'token': 'tok-$n',
+          'region': 'westus',
+        };
+      });
+      final cache = AzureTokenCache(api: api);
+      // First fetch returns a token that is *just* about to expire;
+      // we clear the cache so the next call has to fetch again.
+      await cache.getToken(durationSeconds: 30);
+      cache.clear();
+      final second = await cache.getToken(durationSeconds: 30);
+      expect(second.token, 'tok-2');
+      expect(n, 2);
+    });
+
+    test('a failed fetch propagates and leaves no cached value', () async {
+      var n = 0;
+      final api = _FakeAzureTokenApi(() async {
+        n += 1;
+        throw StateError('worker offline');
+      });
+      final cache = AzureTokenCache(api: api);
+
+      try {
+        await cache.getToken(durationSeconds: 30);
+        fail('expected StateError');
+      } on StateError {
+        // expected
+      }
+
+      // After a failure the in-flight slot is cleared so the next
+      // call can retry instead of being permanently stuck on the
+      // rejected Completer.
+      try {
+        await cache.getToken(durationSeconds: 30);
+        fail('expected StateError');
+      } on StateError {
+        // expected
+      }
+      expect(n, 2, reason: 'second call should retry after a failure');
+    });
+  });
+}


### PR DESCRIPTION
Closes #105.

## Changes

### 1. `AzureTokenCache` dedups concurrent fetches

`getToken` now keeps a single in-flight `Future` and returns the same value to every concurrent caller. Previously, two cold-start calls each hit the worker because the cache only deduped within the 9-minute TTL window. The completer is replaced with a plain `Future` that is reassigned in `finally`; on failure the in-flight slot is cleared so the next call retries instead of being permanently stuck on a rejected future.

### 2. WAV normalization runs in a worker isolate

The Windows ffmpeg re-encode (`pcm_s16le` 16 kHz mono) now runs inside a worker isolate via `Isolate.run` (mirrors the library ffprobe fix in #103). A top-level `_runFfmpegWindowsInIsolate` carries the process arguments. The FFmpegKit path (Android / iOS / macOS) is unchanged because the platform channel is already async.

### 3. AI playground defers the `azure_speech` import

The playground's `on AzureSpeechException catch` was the only reason the playground file imported `package:azure_speech/azure_speech.dart`. The import now lives in `ai_playground_azure_error.dart`; the playground uses `isAzureSpeechException(e)` + `formatAzureSpeechError(e)` helpers. Defense-in-depth: if a future refactor promotes the playground to a release build, the SDK is still linked in by the Azure plugin's `pubspec.yaml`, but the playground's own file no longer drags it in.

### 4. `AiApiBaseUrl` follows `ApiBaseUrl` by default

`AiApiBaseUrl.build` now reads `apiBaseUrlProvider` when no AI override is persisted in `settingsKv`. An explicit override still wins. A new `clearOverride()` method on the notifier is wired into the settings screen as a "Use API URL" button next to the existing "Save AI API URL" button — so the common case (the AI worker lives on the same origin as the main API) no longer requires two separate settings to stay in sync. The override is deleted via the new `SettingsDao.deleteValue(String key)` rather than a null write to a non-nullable column.

## Localisation

- `app_en.arb` / `app_zh.arb` / `app_zh_CN.arb`: two new strings (`settingsAiApiBaseUrlUseDefault`, `settingsAiApiBaseUrlCleared`).

## Tests

- `test/features/ai/azure_token_cache_dedup_test.dart` — 4 tests covering the cache hit, the concurrent-fetch dedup (3 concurrent calls collapse to 1 worker call), the post-expiry refetch, and the failure retry.

The WAV normalizer change uses the same `Isolate.run` pattern as #103 and shares the worker-isolate argument-payload discipline; a focused test for the Windows-only ffmpeg path requires a real ffmpeg binary, so it is left for the manual packaging smoke (`pwsh windows/scripts/fetch_ffmpeg.ps1`).

## Verification

```
flutter analyze (lib/features/ai lib/data/api lib/features/settings)  # 0 issues
flutter test test/features/ai                                          # 13/13 pass
flutter test                                                           # same 2 pre-existing failures as main
```
