### PR TITLE
fix(player): harden subsystem — resolves #101

### DIFF
--- a/lib/core/recovery/widget_error_surface.dart
+++ b/lib/core/recovery/widget_error_surface.dart
@@ -1,0 +1,125 @@
+/// Full-screen fallback when a widget throws during build (release builds).
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/recovery/recovery_actions.dart';
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
+import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+
+/// Shown via [ErrorWidget.builder] when the widget tree hits an uncaught error.
+class WidgetErrorSurface extends StatefulWidget {
+  const WidgetErrorSurface({required this.details, super.key});
+
+  final FlutterErrorDetails details;
+
+  @override
+  State<WidgetErrorSurface> createState() => _WidgetErrorSurfaceState();
+}
+
+class _WidgetErrorSurfaceState extends State<WidgetErrorSurface> {
+  bool _busy = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final t = EnjoyThemeTokens.of(context);
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final message = widget.details.exceptionAsString();
+
+    return Material(
+      color: cs.surface,
+      child: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 520),
+            child: SingleChildScrollView(
+              padding: EdgeInsets.all(t.space24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Icon(Icons.error_outline_rounded, size: 56, color: cs.error),
+                  SizedBox(height: t.space16),
+                  Text(
+                    l10n.widgetErrorTitle,
+                    textAlign: TextAlign.center,
+                    style: tt.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  SizedBox(height: t.space12),
+                  Text(
+                    l10n.widgetErrorSubtitle,
+                    textAlign: TextAlign.center,
+                    style: tt.bodyMedium?.copyWith(
+                      color: cs.onSurfaceVariant,
+                      height: 1.5,
+                    ),
+                  ),
+                  SizedBox(height: t.space24),
+                  EnjoyCard(
+                    padding: EdgeInsets.all(t.space20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          message,
+                          style: tt.bodySmall?.copyWith(
+                            fontFamily: 'monospace',
+                            color: cs.onSurfaceVariant,
+                          ),
+                          maxLines: 8,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        SizedBox(height: t.space16),
+                        SizedBox(
+                          width: double.infinity,
+                          child: EnjoyButton.secondary(
+                            icon: Icons.copy_rounded,
+                            onPressed: _busy ? null : _onCopy,
+                            child: Text(l10n.recoveryCopyError),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onCopy() async {
+    setState(() => _busy = true);
+    try {
+      final ok = await copyErrorToClipboard(
+        widget.details.exception,
+        widget.details.stack,
+      );
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context)!;
+      if (ok) {
+        AppNotice.success(context, l10n.recoveryCopiedToClipboard);
+      } else {
+        AppNotice.error(context, l10n.recoveryCopiedToClipboard);
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+}
+
+/// Installs [ErrorWidget.builder] for release/profile (debug keeps red screen).
+void installReleaseWidgetErrorBuilder() {
+  ErrorWidget.builder = (FlutterErrorDetails details) {
+    return WidgetErrorSurface(details: details);
+  };
+}

--- a/lib/core/routing/player_navigation.dart
+++ b/lib/core/routing/player_navigation.dart
@@ -4,6 +4,16 @@ library;
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
+/// Opens the expanded player for [mediaId].
+///
+/// When the user is already on `/player/:id`, [GoRouter.replace] swaps the
+/// route in place so only one player platform view exists (critical for
+/// Windows YouTube WebView — see ADR-0015 and [ExpandedPlayerScreen] page key).
+///
+/// From shell tabs (Discover, Library, …) we [GoRouter.push] so back returns
+/// to the originating screen. Bottom navigation uses [GoRouter.go] elsewhere,
+/// which resets the stack to a single shell route — that path never stacks
+/// player routes.
 void openPlayerRoute(BuildContext context, String mediaId) {
   final location = '/player/$mediaId';
   final currentPath = GoRouterState.of(context).uri.path;

--- a/lib/features/player/application/display_position_provider.g.dart
+++ b/lib/features/player/application/display_position_provider.g.dart
@@ -41,4 +41,4 @@ final class DisplayPositionProvider
   }
 }
 
-String _$displayPositionHash() => r'4042801a08804a3667421c494e7355aa6c5d2d17';
+String _$displayPositionHash() => r'a12e06a1446ebd2bec49ee195d5813702f4d5d8f';

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -3,7 +3,6 @@ library;
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -13,133 +12,45 @@ import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/youtube_video_poster.dart';
-import 'youtube_page_inject.dart';
-import 'youtube_playback_stall_watchdog.dart';
-import 'youtube_watch_navigation_policy.dart';
+import 'youtube_session.dart';
+import 'youtube_webview_controller.dart';
 import 'youtube_webview_host.dart';
-import 'youtube_state_poller.dart';
 import 'youtube_webview_bridge.dart';
 
 final _logYoutube = logNamed('YouTubePlayerEngine');
 
 /// See [YoutubeWebViewBridge.watchUri] — not iframe embed.
 class YoutubePlayerEngine implements PlayerEngine {
-  YoutubePlayerEngine();
+  YoutubePlayerEngine() : _session = YoutubeSession() {
+    _webView = YoutubeWebViewController(
+      session: _session,
+      onStallRecovery: () => _webView.recoverStalledPlayback(),
+      onLogInitPhase: (phase) =>
+          _session.logInitPhase(phase, _logYoutube.info),
+    );
+  }
 
-  InAppWebViewController? _webController;
+  final YoutubeSession _session;
+  late final YoutubeWebViewController _webView;
 
-  final StreamController<Duration> _positionCtrl =
-      StreamController<Duration>.broadcast();
-  final StreamController<Duration> _durationCtrl =
-      StreamController<Duration>.broadcast();
-  final StreamController<bool> _playingCtrl =
-      StreamController<bool>.broadcast();
-  final StreamController<bool> _bufferingCtrl =
-      StreamController<bool>.broadcast();
-
-  /// Preserves [InAppWebView] state when the host moves loading → video stage.
-  final GlobalKey webViewHostKey = GlobalKey();
-
-  /// Bumps when mount is requested so loading UI rebuilds.
-  final ValueNotifier<int> mountTick = ValueNotifier(0);
-
-  String _videoId = '';
-  String? _posterUrl;
-  bool _mountRequested = false;
-  bool _webViewMounted = false;
-  bool _loggedFirstPlaying = false;
-  bool _watchPageLoadStopReceived = false;
-  bool _awaitingColdInitialNavigation = false;
-  bool _nonWatchRecoveryScheduled = false;
-
-  Stopwatch? _initStopwatch;
-
-  /// After [onPageFinished], nudge `<video>.play()` before a full stall reload.
-  static const Duration _kPlaybackNudgeDelay = Duration(seconds: 6);
-
-  /// When [initialUrlRequest] already navigates, wait longer before verify reload.
-  static const Duration _kColdMountVerifyDelay = Duration(seconds: 10);
-
-  Timer? _playbackNudgeTimer;
-  int _verifyGeneration = 0;
-
-  /// Exposed for WebView initial URL (see [YoutubeWebViewHost]).
-  String get currentVideoId => _videoId;
-
-  String? get posterUrl => _posterUrl;
-
-  bool get webViewMounted => _webViewMounted;
-
-  bool get shouldMountWebView => _mountRequested && !_disposed;
-
-  bool _disposed = false;
-  bool _playbackCompleted = false;
-
-  /// True after the first buffering→false transition of the current [open].
-  /// [mountTick] is bumped only on that first transition so the host Stack
-  /// rebuilds once at the loading→playing boundary instead of every time
-  /// [YoutubePlayerEngine] emits buffering events (ad reload, post-ad resume,
-  /// etc.). Subsequent buffering cycles still update the stream but skip the
-  /// mountTick bump — the WebView host has a stable GlobalKey, so the rebuild
-  /// is just a Stack refresh, but on Windows it can flicker.
-  bool _firstBufferingOffReceived = false;
-
-  Timer? _pollTimer;
-  Timer? _pollKickTimer;
-  double? _pendingSeekSeconds;
-
-  /// Last volume applied via [setVolumeNormalized]; re-applied on main playback.
-  double _volumeNormalized = 1;
-
-  bool _rejectingNativeFullscreen = false;
-
-  /// Bumped on each explicit watch/idle navigation so stale async loads can bail.
-  int _navGeneration = 0;
-
-  /// Auto full-page reloads after stall (per video open).
-  int _stallRecoveryCount = 0;
-  static const int _kMaxStallRecoveries = 1;
-
-  late final YoutubePlaybackStallWatchdog _stallWatchdog =
-      YoutubePlaybackStallWatchdog(
-        timeout: const Duration(seconds: 12),
-        onStall: (videoId) {
-          if (_playing) return;
-          _logYoutube.warning(
-            'youtube playback stalled after load_stop vid=$videoId',
-          );
-          unawaited(_recoverStalledPlayback());
-        },
-      );
-
-  /// Poll interval is 250ms; 3 ticks ≈ 750ms of stable `paused` before we trust
-  /// the poller over transient DOM noise.
-  static const int _kPauseConfirmPollTicks = 3;
-
-  /// [YoutubeStatePoller] can see a transient `paused` sample during DOM
-  /// swaps (e.g. after OAuth). Require several ticks before treating it as
-  /// user-visible pause so we do not stop polling / flip transport early.
-  int _pausedPollStreak = 0;
-
-  bool _playing = false;
-  bool _buffering = true;
-
-  Duration _lastPosition = Duration.zero;
-  Duration _lastDuration = Duration.zero;
-
-  final Stream<double> _aspectStream = Stream<double>.value(16 / 9);
+  GlobalKey get webViewHostKey => _session.webViewHostKey;
+  ValueNotifier<int> get mountTick => _session.mountTick;
+  String get currentVideoId => _session.videoId;
+  String? get posterUrl => _session.posterUrl;
+  bool get webViewMounted => _session.webViewMounted;
+  bool get shouldMountWebView => _session.shouldMountWebView;
 
   @override
-  Stream<Duration> get position => _positionCtrl.stream;
+  Stream<Duration> get position => _session.position;
 
   @override
-  Stream<Duration> get duration => _durationCtrl.stream;
+  Stream<Duration> get duration => _session.duration;
 
   @override
-  Stream<bool> get playing => _playingCtrl.stream;
+  Stream<bool> get playing => _session.playingStream;
 
   @override
-  Stream<bool> get buffering => _bufferingCtrl.stream;
+  Stream<bool> get buffering => _session.bufferingStream;
 
   @override
   Stream<mk.Tracks>? get mkTracksStream => null;
@@ -152,39 +63,22 @@ class YoutubePlayerEngine implements PlayerEngine {
 
   @override
   ({bool playing, bool buffering}) get transportSnapshot =>
-      (playing: _playing, buffering: _buffering);
+      _session.transportSnapshot;
 
   @override
-  Stream<double> get videoAspectRatioStream => _aspectStream;
+  Stream<double> get videoAspectRatioStream => _session.aspectStream;
 
-  void setPosterUrl(String? url) {
-    _posterUrl = url;
-  }
+  void setPosterUrl(String? url) => _session.setPosterUrl(url);
 
-  void markOpenTimingStart() {
-    _stallWatchdog.cancel();
-    _cancelPlaybackNudge();
-    _bumpVerifyGeneration();
-    _initStopwatch = Stopwatch()..start();
-    _loggedFirstPlaying = false;
-    _watchPageLoadStopReceived = false;
-    _awaitingColdInitialNavigation = false;
-    _nonWatchRecoveryScheduled = false;
-    _stallRecoveryCount = 0;
-    _logInitPhase('open_start');
-  }
+  void markOpenTimingStart() => _webView.markOpenTimingStart();
 
-  /// Signals UI to mount the shared [YoutubeWebViewHost].
   void ensureWebViewAttached() {
-    if (_disposed) return;
-    _mountRequested = true;
-    mountTick.value++;
+    _session.requestMount();
     _logInitPhase('mount_requested');
   }
 
-  /// Single long-lived WebView widget (see [webViewHostKey]).
   Widget buildWebViewHost() {
-    return YoutubeWebViewHost(key: webViewHostKey, engine: this);
+    return YoutubeWebViewHost(key: _session.webViewHostKey, engine: this);
   }
 
   @override
@@ -194,24 +88,11 @@ class YoutubePlayerEngine implements PlayerEngine {
         'YoutubePlayerEngine requires YoutubePlayableSource',
       );
     }
-    _stallWatchdog.cancel();
-    _cancelPlaybackNudge();
-    _bumpVerifyGeneration();
-    _watchPageLoadStopReceived = false;
-    _awaitingColdInitialNavigation = false;
-    _loggedFirstPlaying = false;
-    _nonWatchRecoveryScheduled = false;
-    _stallRecoveryCount = 0;
-    _firstBufferingOffReceived = false;
-    _videoId = source.videoId;
-    _playbackCompleted = false;
-    _emitBuffering(true);
-    _emitPlaying(false);
-    _emitPosition(Duration.zero);
-    _emitDuration(Duration.zero);
-    ensureWebViewAttached();
-    if (!_awaitingColdInitialNavigation) {
-      await _loadCurrentVideoIfAttached();
+    _webView.prepareWatchReload(resetFirstPlaying: true);
+    _session.resetForOpen(source.videoId);
+    _session.requestMount();
+    if (!_session.awaitingColdInitialNavigation) {
+      await _webView.loadCurrentVideoIfAttached();
     }
   }
 
@@ -227,15 +108,15 @@ class YoutubePlayerEngine implements PlayerEngine {
 
     return StreamBuilder<bool>(
       stream: buffering,
-      initialData: _buffering,
+      initialData: _session.buffering,
       builder: (context, snapshot) {
-        final showPoster = snapshot.data ?? _buffering;
+        final showPoster = snapshot.data ?? _session.buffering;
         return Stack(
           fit: StackFit.expand,
           children: [
             const ColoredBox(color: Colors.black),
             if (shouldMountWebView) buildWebViewHost(),
-            YoutubeVideoPoster(primaryUrl: _posterUrl, visible: showPoster),
+            YoutubeVideoPoster(primaryUrl: _session.posterUrl, visible: showPoster),
           ],
         );
       },
@@ -247,24 +128,29 @@ class YoutubePlayerEngine implements PlayerEngine {
 
   @override
   Future<void> seek(Duration target) async {
-    final seconds = target.inMilliseconds / 1000.0;
-    await YoutubeWebViewBridge.seekToSeconds(_webController, seconds);
+    await YoutubeWebViewBridge.seekToSeconds(
+      _webView.webController,
+      target.inMilliseconds / 1000.0,
+    );
   }
 
   @override
   Future<void> setRate(double rate) async {
-    await YoutubeWebViewBridge.setPlaybackRate(_webController, rate);
+    await YoutubeWebViewBridge.setPlaybackRate(_webView.webController, rate);
   }
 
   @override
   Future<void> setVolumeNormalized(double volume) async {
-    _volumeNormalized = volume.clamp(0, 1);
-    await YoutubeWebViewBridge.setVolume(_webController, _volumeNormalized);
+    _session.volumeNormalized = volume.clamp(0, 1);
+    await YoutubeWebViewBridge.setVolume(
+      _webView.webController,
+      _session.volumeNormalized,
+    );
   }
 
   @override
   Future<void> playOrPause() async {
-    if (_playing) {
+    if (_session.playing) {
       await pause();
     } else {
       await play();
@@ -273,66 +159,38 @@ class YoutubePlayerEngine implements PlayerEngine {
 
   @override
   Future<void> play() async {
-    if (_playbackCompleted) {
-      _prepareWatchReload(resetFirstPlaying: true);
-      _emitBuffering(true);
-      _emitPlaying(false);
-      await _loadCurrentVideoIfAttached();
+    if (_session.playbackCompleted) {
+      _webView.prepareWatchReload(resetFirstPlaying: true);
+      _session.emitBuffering(true);
+      _session.emitPlaying(false);
+      await _webView.loadCurrentVideoIfAttached();
       return;
     }
-    await YoutubeWebViewBridge.play(_webController);
+    await YoutubeWebViewBridge.play(_webView.webController);
   }
 
   @override
   Future<void> pause() async {
-    await YoutubeWebViewBridge.pause(_webController);
+    await YoutubeWebViewBridge.pause(_webView.webController);
   }
 
   @override
   Future<void> stop() async {
-    await YoutubeWebViewBridge.stop(_webController);
-    _emitPlaying(false);
-    _emitBuffering(false);
-    _emitPosition(Duration.zero);
-    _playbackCompleted = false;
+    await YoutubeWebViewBridge.stop(_webView.webController);
+    _session.emitPlaying(false);
+    _session.emitBuffering(false);
+    _session.emitPosition(Duration.zero);
+    _session.playbackCompleted = false;
   }
 
-  /// Stops playback and navigates to `about:blank` while keeping the WebView warm.
-  Future<void> idleAfterClear() async {
-    _stallWatchdog.cancel();
-    _cancelPlaybackNudge();
-    _bumpVerifyGeneration();
-    _watchPageLoadStopReceived = false;
-    _awaitingColdInitialNavigation = false;
-    _nonWatchRecoveryScheduled = false;
-    _stopPolling();
-    _videoId = '';
-    _mountRequested = false;
-    _playbackCompleted = false;
-    _emitPlaying(false);
-    _emitBuffering(false);
-    _emitPosition(Duration.zero);
-    mountTick.value++;
-    final navGen = ++_navGeneration;
-    final controller = _webController;
-    if (controller == null) return;
-    await YoutubeWebViewBridge.loadIdlePage(controller);
-    // After loadIdlePage, if a new open raced in (navGeneration advanced OR
-    // _videoId is non-empty), reload the watch page for the new id.
-    if (_navGeneration != navGen &&
-        _videoId.isNotEmpty &&
-        identical(_webController, controller)) {
-      unawaited(_loadCurrentVideoIfAttached());
-    }
-  }
+  Future<void> idleAfterClear() => _webView.idleAfterClear();
 
   @override
   Future<Uint8List?> screenshot({String? format}) async => null;
 
-  /// Best-effort WebView bitmap for share poster while echo is active.
   Future<Uint8List?> captureWebViewScreenshot() async {
-    final controller = _webController;
-    if (controller == null || _disposed) return null;
+    final controller = _webView.webController;
+    if (controller == null || _session.disposed) return null;
     try {
       return await controller.takeScreenshot();
     } on Object catch (e, st) {
@@ -342,92 +200,16 @@ class YoutubePlayerEngine implements PlayerEngine {
   }
 
   @override
-  void warmVideoSurface() {
-    ensureWebViewAttached();
-    // [YoutubeWebViewHost] uses `about:blank` as [initialUrlRequest] while idle;
-    // an extra [loadIdlePage] here can finish after [open] and stop playback.
-  }
+  void warmVideoSurface() => ensureWebViewAttached();
 
   @override
   Future<void> dispose() async {
-    _disposed = true;
-    _stallWatchdog.cancel();
-    _cancelPlaybackNudge();
-    _bumpVerifyGeneration();
-    _mountRequested = false;
-    _pollKickTimer?.cancel();
-    _pollKickTimer = null;
-    _stopPolling();
-    mountTick.value++;
-    await _positionCtrl.close();
-    await _durationCtrl.close();
-    await _playingCtrl.close();
-    await _bufferingCtrl.close();
+    await _webView.dispose();
+    await _session.closeStreams();
   }
 
-  void _emitPosition(Duration d) {
-    if (_disposed || _positionCtrl.isClosed) return;
-    if (d == _lastPosition) return;
-    _lastPosition = d;
-    _positionCtrl.add(d);
-  }
-
-  void _emitDuration(Duration d) {
-    if (_disposed || _durationCtrl.isClosed) return;
-    if (d == _lastDuration) return;
-    _lastDuration = d;
-    _durationCtrl.add(d);
-  }
-
-  void _emitPlaying(bool v) {
-    if (_disposed || _playingCtrl.isClosed) return;
-    if (v == _playing) return;
-    _playing = v;
-    _playingCtrl.add(v);
-    if (v) {
-      // Cancel stall watchdog on every play transition (not only the first).
-      // Subsequent load_stop events (ad reload, SPA hops) must not re-trigger
-      // full-page reload loops once playback has started.
-      _stallWatchdog.onFirstPlaying();
-      if (!_loggedFirstPlaying) {
-        _loggedFirstPlaying = true;
-        _cancelPlaybackNudge();
-        _logInitPhase('first_playing');
-      }
-    }
-  }
-
-  void _emitBuffering(bool v) {
-    if (_disposed || _bufferingCtrl.isClosed) return;
-    if (v == _buffering) return;
-    _buffering = v;
-    _bufferingCtrl.add(v);
-    if (!v && !_firstBufferingOffReceived) {
-      _firstBufferingOffReceived = true;
-      mountTick.value++;
-    }
-  }
-
-  void _logInitPhase(String phase) {
-    final ms = _initStopwatch?.elapsedMilliseconds;
-    final message = 'youtube init $phase${ms != null ? ' +${ms}ms' : ''}';
-    if (phase == 'load_stop' || phase == 'first_playing') {
-      _logYoutube.info(message);
-    } else {
-      _logYoutube.fine(message);
-    }
-  }
-
-  /// Called when [shouldOverrideUrlLoading] cancels passive Google sign-in.
-  Future<void> onSignInNavigationBlocked(
-    InAppWebViewController controller,
-  ) async {
-    final vid = _videoId;
-    if (vid.isEmpty || _disposed) return;
-    _prepareWatchReload(resetFirstPlaying: false);
-    _logYoutube.info('youtube reload after blocked sign-in vid=$vid');
-    await YoutubeWebViewBridge.loadWatchPage(controller, vid);
-  }
+  Future<void> onSignInNavigationBlocked(InAppWebViewController controller) =>
+      _webView.onSignInNavigationBlocked(controller);
 
   void onWebResourceHttpError({
     required String? url,
@@ -445,359 +227,36 @@ class YoutubePlayerEngine implements PlayerEngine {
     _logYoutube.warning('youtube load error url=$url msg=$description');
   }
 
-  Future<void> _recoverStalledPlayback() async {
-    final controller = _webController;
-    final vid = _videoId;
-    if (controller == null || vid.isEmpty || _disposed) return;
-    if (_playing) {
-      _stallWatchdog.cancel();
-      return;
-    }
-    if (_stallRecoveryCount >= _kMaxStallRecoveries) {
-      _logYoutube.info(
-        'youtube stall recovery limit reached vid=$vid; nudging play',
-      );
-      unawaited(_nudgePlaybackStart(controller));
-      return;
-    }
-    _stallRecoveryCount++;
-    _stallWatchdog.cancel();
-    _logYoutube.info('youtube reload after stall vid=$vid');
-    _prepareWatchReload(resetFirstPlaying: false, resetStallRecovery: false);
-    _emitBuffering(true);
-    await YoutubeWebViewBridge.loadWatchPage(controller, vid);
-  }
-
-  /// iOS/macOS WKWebView process exit or Android renderer crash — reload.
-  Future<void> onWebViewProcessTerminated() async {
-    final controller = _webController;
-    final vid = _videoId;
-    if (controller == null || vid.isEmpty || _disposed) return;
-    _logYoutube.warning(
-      'youtube WebView process terminated; reloading vid=$vid',
-    );
-    _prepareWatchReload(resetFirstPlaying: true);
-    _emitBuffering(true);
-    _emitPlaying(false);
-    await YoutubeWebViewBridge.loadWatchPage(controller, vid);
-  }
+  Future<void> onWebViewProcessTerminated() =>
+      _webView.onWebViewProcessTerminated();
 
   void onWebViewCreated(
     InAppWebViewController controller, {
     bool initialWatchUrlRequested = false,
   }) {
-    _webController = controller;
-    _webViewMounted = true;
-    _logInitPhase('webview_created');
-
-    if (initialWatchUrlRequested && _videoId.isNotEmpty) {
-      _awaitingColdInitialNavigation = true;
-    }
-
-    controller.addJavaScriptHandler(
-      handlerName: 'onAdReload',
-      callback: (List<dynamic> args) {
-        if (args.isNotEmpty) {
-          _pendingSeekSeconds = (args[0] as num?)?.toDouble() ?? 0;
-        }
-        return null;
-      },
+    _webView.onWebViewCreated(
+      controller,
+      initialWatchUrlRequested: initialWatchUrlRequested,
     );
-
-    controller.addJavaScriptHandler(
-      handlerName: 'onVideoEvent',
-      callback: (List<dynamic> args) {
-        if (args.isEmpty) return null;
-        final event = args[0] as String;
-        switch (event) {
-          case 'play':
-          case 'playing':
-            _pausedPollStreak = 0;
-            _playbackCompleted = false;
-            _emitPlaying(true);
-            _emitBuffering(false);
-            _startPolling();
-            _applyPendingSeek();
-            unawaited(_reapplyVolume());
-            break;
-          case 'pause':
-            // Defer playing=false / stop polling until poller confirms pause.
-            _pausedPollStreak = 0;
-            break;
-          case 'ended':
-            _pausedPollStreak = 0;
-            _playbackCompleted = true;
-            _stopPolling();
-            _emitPlaying(false);
-            unawaited(YoutubeWebViewBridge.pauseVideoElement(_webController));
-            break;
-          case 'waiting':
-            _emitBuffering(true);
-            break;
-          case 'canplay':
-            if (_buffering) {
-              _emitBuffering(false);
-            }
-            break;
-          case 'loadedmetadata':
-            _startPolling();
-            if (args.length > 1) {
-              final dur = (args[1] as num).toDouble();
-              if (dur > 0 && dur.isFinite) {
-                _emitDuration(Duration(milliseconds: (dur * 1000).round()));
-                _applyPendingSeek();
-              }
-            }
-            break;
-          case 'error':
-            _logYoutube.warning('YouTube video element error');
-            _emitBuffering(false);
-            break;
-          default:
-            break;
-        }
-        return null;
-      },
-    );
-
-    if (_videoId.isNotEmpty && !initialWatchUrlRequested) {
-      unawaited(_loadCurrentVideoIfAttached());
-      unawaited(_ensureWatchPageLoadedAfterDelay(skipIfLoadStopReceived: true));
-    } else if (_videoId.isNotEmpty) {
-      // Cold mount: [initialUrlRequest] is already navigating — do not reload at 2s
-      // (causes "connection was stopped" and delays first frame until stall recovery).
-      unawaited(
-        _ensureWatchPageLoadedAfterDelay(
-          delay: _kColdMountVerifyDelay,
-          skipIfLoadStopReceived: true,
-        ),
-      );
-    }
-  }
-
-  void _bumpVerifyGeneration() {
-    _verifyGeneration++;
-  }
-
-  void _prepareWatchReload({
-    required bool resetFirstPlaying,
-    bool resetStallRecovery = true,
-  }) {
-    _stallWatchdog.cancel();
-    _cancelPlaybackNudge();
-    _bumpVerifyGeneration();
-    _watchPageLoadStopReceived = false;
-    _awaitingColdInitialNavigation = false;
-    _nonWatchRecoveryScheduled = false;
-    if (resetFirstPlaying) {
-      _loggedFirstPlaying = false;
-    }
-    if (resetStallRecovery) {
-      _stallRecoveryCount = 0;
-    }
-  }
-
-  Future<void> _ensureWatchPageLoadedAfterDelay({
-    Duration delay = const Duration(seconds: 2),
-    bool skipIfLoadStopReceived = false,
-  }) async {
-    final gen = _verifyGeneration;
-    await Future<void>.delayed(delay);
-    if (gen != _verifyGeneration) return;
-    if (_disposed || _videoId.isEmpty || _webController == null) return;
-    if (_loggedFirstPlaying) return;
-    if (skipIfLoadStopReceived && _watchPageLoadStopReceived) return;
-    _logYoutube.info('youtube verify watch load vid=$_videoId');
-    await _loadCurrentVideoIfAttached();
-  }
-
-  void _schedulePlaybackNudge() {
-    _playbackNudgeTimer?.cancel();
-    _playbackNudgeTimer = Timer(_kPlaybackNudgeDelay, () {
-      _playbackNudgeTimer = null;
-      if (_disposed || _loggedFirstPlaying || _webController == null) return;
-      _logYoutube.info('youtube nudge play vid=$_videoId');
-      final web = _webController;
-      unawaited(_nudgePlaybackStart(web));
-    });
-  }
-
-  Future<void> _nudgePlaybackStart(InAppWebViewController? web) async {
-    if (web == null || _disposed || _loggedFirstPlaying) return;
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      await YoutubeWebViewBridge.forceInlinePlayback(web);
-    }
-    await YoutubeWebViewBridge.play(web);
-  }
-
-  void _cancelPlaybackNudge() {
-    _playbackNudgeTimer?.cancel();
-    _playbackNudgeTimer = null;
   }
 
   void onWebViewDisposed(InAppWebViewController? controller) {
-    if (identical(_webController, controller)) {
-      _webController = null;
-      _webViewMounted = false;
-      _awaitingColdInitialNavigation = false;
-      _cancelPlaybackNudge();
-      _bumpVerifyGeneration();
-      _stopPolling();
-      mountTick.value++;
-    }
-  }
-
-  Future<void> _loadCurrentVideoIfAttached() async {
-    final controller = _webController;
-    if (controller == null || _videoId.isEmpty) return;
-    final videoId = _videoId;
-    final navGen = ++_navGeneration;
-    try {
-      await YoutubeWebViewBridge.loadWatchPage(controller, videoId);
-    } on MissingPluginException catch (e, st) {
-      // Windows can deallocate the native platform view during route
-      // replacement before Dart receives widget disposal. Treat that controller
-      // as stale; the next mounted WebView will load [_videoId] via initialUrl.
-      if (identical(_webController, controller)) {
-        _webController = null;
-        _webViewMounted = false;
-        _stopPolling();
-        mountTick.value++;
-      }
-      _logYoutube.fine('Ignoring loadUrl on stale YouTube WebView', e, st);
-      return;
-    }
-    if (_navGeneration != navGen || _videoId != videoId) return;
+    _webView.onWebViewDisposed(controller);
   }
 
   Future<void> onPageFinished(
     InAppWebViewController controller,
     String? url,
-  ) async {
-    if (!isYoutubeWatchPageLoadStopUrl(url)) {
-      if (url != null && !url.startsWith('about:')) {
-        _logYoutube.fine('youtube skip load_stop url=$url');
-      }
-      _scheduleNonWatchRecovery();
-      return;
-    }
-    _awaitingColdInitialNavigation = false;
-    _watchPageLoadStopReceived = true;
-    _nonWatchRecoveryScheduled = false;
-    _logInitPhase('load_stop');
-    if (!_loggedFirstPlaying) {
-      _stallWatchdog.onLoadStop(_videoId);
-      _schedulePlaybackNudge();
-    } else {
-      _stallWatchdog.cancel();
-      _cancelPlaybackNudge();
-    }
-    await injectYoutubeMobileWatchPage(controller);
-    _schedulePollKick();
-  }
+  ) =>
+      _webView.onPageFinished(controller, url);
 
-  void _scheduleNonWatchRecovery() {
-    if (_disposed || _videoId.isEmpty || _loggedFirstPlaying) return;
-    if (_nonWatchRecoveryScheduled) return;
-    _nonWatchRecoveryScheduled = true;
-    _logYoutube.info('youtube non-watch load_stop; verifying watch page');
-    unawaited(_ensureWatchPageLoadedAfterDelay(skipIfLoadStopReceived: true));
-  }
+  Future<void> exitNativeFullscreen(InAppWebViewController controller) =>
+      _webView.exitNativeFullscreen(controller);
 
-  void _schedulePollKick() {
-    _pollKickTimer?.cancel();
-    _pollKickTimer = Timer(const Duration(milliseconds: 500), () {
-      _pollKickTimer = null;
-      if (!_disposed) _startPolling();
-    });
-  }
+  Future<void> onNativeFullscreenExit(InAppWebViewController controller) =>
+      _webView.onNativeFullscreenExit(controller);
 
-  Future<void> _reapplyVolume() async {
-    await YoutubeWebViewBridge.setVolume(_webController, _volumeNormalized);
-  }
-
-  Future<void> exitNativeFullscreen(InAppWebViewController controller) async {
-    if (_rejectingNativeFullscreen) return;
-    _rejectingNativeFullscreen = true;
-    try {
-      // JS inline attrs only — closeAllMediaPresentations() stops playback.
-      await YoutubeWebViewBridge.forceInlinePlayback(controller);
-    } catch (e, st) {
-      _logYoutube.fine('Failed to force inline playback', e, st);
-    } finally {
-      _rejectingNativeFullscreen = false;
-    }
-  }
-
-  Future<void> onNativeFullscreenExit(InAppWebViewController controller) async {
-    await YoutubeWebViewBridge.forceInlinePlayback(controller);
-    if (_playing && !_playbackCompleted) {
-      await YoutubeWebViewBridge.play(controller);
-    }
-  }
-
-  void _applyPendingSeek() {
-    final secs = _pendingSeekSeconds;
-    if (secs == null || secs <= 0) return;
-    _pendingSeekSeconds = null;
-    unawaited(seek(Duration(milliseconds: (secs * 1000).round())));
-  }
-
-  void _startPolling() {
-    if (_pollTimer != null) return;
-    _pausedPollStreak = 0;
-    _pollTimer = Timer.periodic(
-      const Duration(milliseconds: 250),
-      (_) => _pollTick(),
-    );
-  }
-
-  void _stopPolling() {
-    _pollTimer?.cancel();
-    _pollTimer = null;
-  }
-
-  Future<void> _pollTick() async {
-    await YoutubeStatePoller.poll(
-      disposed: _disposed,
-      web: _webController,
-      onResult:
-          ({
-            required Duration position,
-            Duration? newDuration,
-            required bool jsPaused,
-            required bool jsEnded,
-          }) {
-            if (_disposed) return;
-            _emitPosition(position);
-            if (newDuration != null &&
-                newDuration > Duration.zero &&
-                newDuration != _lastDuration) {
-              _emitDuration(newDuration);
-            }
-            if (jsEnded && !_playbackCompleted) {
-              _pausedPollStreak = 0;
-              _playbackCompleted = true;
-              _stopPolling();
-              _emitPlaying(false);
-            } else if (jsPaused && _playing && !jsEnded) {
-              _pausedPollStreak++;
-              if (_pausedPollStreak >= _kPauseConfirmPollTicks) {
-                _pausedPollStreak = 0;
-                _emitPlaying(false);
-                _stopPolling();
-              }
-            } else {
-              _pausedPollStreak = 0;
-              if (!jsPaused && !jsEnded) {
-                _playbackCompleted = false;
-                _emitPlaying(true);
-                if (_buffering) {
-                  _emitBuffering(false);
-                }
-              }
-            }
-          },
-    );
+  void _logInitPhase(String phase) {
+    _session.logInitPhase(phase, (m) => _logYoutube.fine(m));
   }
 }

--- a/lib/features/player/application/engines/youtube/youtube_session.dart
+++ b/lib/features/player/application/engines/youtube/youtube_session.dart
@@ -1,0 +1,145 @@
+/// Playback state and broadcast streams for [YoutubePlayerEngine].
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Owns YouTube open state, transport snapshot, and engine event streams.
+class YoutubeSession {
+  YoutubeSession();
+
+  final StreamController<Duration> positionCtrl =
+      StreamController<Duration>.broadcast();
+  final StreamController<Duration> durationCtrl =
+      StreamController<Duration>.broadcast();
+  final StreamController<bool> playingCtrl =
+      StreamController<bool>.broadcast();
+  final StreamController<bool> bufferingCtrl =
+      StreamController<bool>.broadcast();
+
+  final GlobalKey webViewHostKey = GlobalKey();
+  final ValueNotifier<int> mountTick = ValueNotifier(0);
+  final Stream<double> aspectStream = Stream<double>.value(16 / 9);
+
+  String videoId = '';
+  String? posterUrl;
+  bool mountRequested = false;
+  bool webViewMounted = false;
+  bool loggedFirstPlaying = false;
+  bool watchPageLoadStopReceived = false;
+  bool awaitingColdInitialNavigation = false;
+  bool nonWatchRecoveryScheduled = false;
+  bool disposed = false;
+  bool playbackCompleted = false;
+  bool firstBufferingOffReceived = false;
+
+  bool playing = false;
+  bool buffering = true;
+
+  Duration lastPosition = Duration.zero;
+  Duration lastDuration = Duration.zero;
+
+  double volumeNormalized = 1;
+  double? pendingSeekSeconds;
+
+  int pausedPollStreak = 0;
+  static const int pauseConfirmPollTicks = 3;
+
+  Stopwatch? initStopwatch;
+
+  Stream<Duration> get position => positionCtrl.stream;
+  Stream<Duration> get duration => durationCtrl.stream;
+  Stream<bool> get playingStream => playingCtrl.stream;
+  Stream<bool> get bufferingStream => bufferingCtrl.stream;
+
+  bool get shouldMountWebView => mountRequested && !disposed;
+
+  ({bool playing, bool buffering}) get transportSnapshot =>
+      (playing: playing, buffering: buffering);
+
+  void setPosterUrl(String? url) => posterUrl = url;
+
+  void resetForOpen(String newVideoId) {
+    loggedFirstPlaying = false;
+    watchPageLoadStopReceived = false;
+    awaitingColdInitialNavigation = false;
+    nonWatchRecoveryScheduled = false;
+    firstBufferingOffReceived = false;
+    videoId = newVideoId;
+    playbackCompleted = false;
+    emitBuffering(true);
+    emitPlaying(false);
+    emitPosition(Duration.zero);
+    emitDuration(Duration.zero);
+  }
+
+  void resetForClear() {
+    videoId = '';
+    mountRequested = false;
+    playbackCompleted = false;
+    watchPageLoadStopReceived = false;
+    awaitingColdInitialNavigation = false;
+    nonWatchRecoveryScheduled = false;
+    emitPlaying(false);
+    emitBuffering(false);
+    emitPosition(Duration.zero);
+    mountTick.value++;
+  }
+
+  void requestMount() {
+    if (disposed) return;
+    mountRequested = true;
+    mountTick.value++;
+  }
+
+  void emitPosition(Duration d) {
+    if (disposed || positionCtrl.isClosed) return;
+    if (d == lastPosition) return;
+    lastPosition = d;
+    positionCtrl.add(d);
+  }
+
+  void emitDuration(Duration d) {
+    if (disposed || durationCtrl.isClosed) return;
+    if (d == lastDuration) return;
+    lastDuration = d;
+    durationCtrl.add(d);
+  }
+
+  void emitPlaying(bool v) {
+    if (disposed || playingCtrl.isClosed) return;
+    if (v == playing) return;
+    playing = v;
+    playingCtrl.add(v);
+  }
+
+  void emitBuffering(bool v) {
+    if (disposed || bufferingCtrl.isClosed) return;
+    if (v == buffering) return;
+    buffering = v;
+    bufferingCtrl.add(v);
+    if (!v && !firstBufferingOffReceived) {
+      firstBufferingOffReceived = true;
+      mountTick.value++;
+    }
+  }
+
+  void logInitPhase(String phase, void Function(String message) log) {
+    final ms = initStopwatch?.elapsedMilliseconds;
+    final message = 'youtube init $phase${ms != null ? ' +${ms}ms' : ''}';
+    if (phase == 'load_stop' || phase == 'first_playing') {
+      log(message);
+    }
+  }
+
+  Future<void> closeStreams() async {
+    disposed = true;
+    mountRequested = false;
+    mountTick.value++;
+    await positionCtrl.close();
+    await durationCtrl.close();
+    await playingCtrl.close();
+    await bufferingCtrl.close();
+  }
+}

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -1,0 +1,292 @@
+/// WebView lifecycle, navigation, and DOM polling for [YoutubePlayerEngine].
+library;
+
+import 'dart:async';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_page_inject.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_playback_stall_watchdog.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_watch_navigation_policy.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_events.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_navigation.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_poll_loop.dart';
+
+final _logWebView = logNamed('YoutubeWebViewController');
+
+/// Manages [InAppWebView] attach/load/poll for one [YoutubeSession].
+class YoutubeWebViewController {
+  YoutubeWebViewController({
+    required this.session,
+    required this.onStallRecovery,
+    required this.onLogInitPhase,
+  }) : _stallWatchdog = YoutubePlaybackStallWatchdog(
+          timeout: const Duration(seconds: 12),
+          onStall: (videoId) {
+            if (session.playing) return;
+            _logWebView.warning(
+              'youtube playback stalled after load_stop vid=$videoId',
+            );
+            onStallRecovery();
+          },
+        ) {
+    _events = YoutubeWebViewEvents(
+      session: session,
+      webController: () => _webController,
+      onFirstPlaying: onFirstPlayingFromSession,
+      startPolling: () => _pollLoop.start(),
+      stopPolling: () => _pollLoop.stop(),
+      reapplyVolume: reapplyVolume,
+      seekTo: (d) => YoutubeWebViewBridge.seekToSeconds(
+        _webController,
+        d.inMilliseconds / 1000.0,
+      ),
+    );
+    _pollLoop = YoutubeWebViewPollLoop(
+      session: session,
+      webController: () => _webController,
+      onFirstPlaying: onFirstPlayingFromSession,
+    );
+    _navigation = YoutubeWebViewNavigation(
+      session: session,
+      webController: () => _webController,
+      captureVerifyGeneration: () => _verifyGeneration,
+      isVerifyGenerationStale: (gen) => gen != _verifyGeneration,
+      bumpNavGeneration: () => ++_navGeneration,
+      currentNavGeneration: () => _navGeneration,
+      onStaleWebView: () {
+        _webController = null;
+        session.webViewMounted = false;
+        _pollLoop.stop();
+        session.mountTick.value++;
+      },
+    );
+  }
+
+  final YoutubeSession session;
+  final Future<void> Function() onStallRecovery;
+  final void Function(String phase) onLogInitPhase;
+
+  static const int maxStallRecoveries = 1;
+
+  final YoutubePlaybackStallWatchdog _stallWatchdog;
+  late final YoutubeWebViewEvents _events;
+  late final YoutubeWebViewPollLoop _pollLoop;
+  late final YoutubeWebViewNavigation _navigation;
+
+  InAppWebViewController? _webController;
+  int _verifyGeneration = 0;
+  int _navGeneration = 0;
+  int _stallRecoveryCount = 0;
+  bool _rejectingNativeFullscreen = false;
+
+  InAppWebViewController? get webController => _webController;
+
+  void markOpenTimingStart() {
+    _stallWatchdog.cancel();
+    _navigation.cancelNudge();
+    _bumpVerifyGeneration();
+    session.initStopwatch = Stopwatch()..start();
+    session.loggedFirstPlaying = false;
+    session.watchPageLoadStopReceived = false;
+    session.awaitingColdInitialNavigation = false;
+    session.nonWatchRecoveryScheduled = false;
+    _stallRecoveryCount = 0;
+    onLogInitPhase('open_start');
+  }
+
+  void prepareWatchReload({
+    required bool resetFirstPlaying,
+    bool resetStallRecovery = true,
+  }) {
+    _stallWatchdog.cancel();
+    _navigation.cancelNudge();
+    _bumpVerifyGeneration();
+    session.watchPageLoadStopReceived = false;
+    session.awaitingColdInitialNavigation = false;
+    session.nonWatchRecoveryScheduled = false;
+    if (resetFirstPlaying) {
+      session.loggedFirstPlaying = false;
+    }
+    if (resetStallRecovery) {
+      _stallRecoveryCount = 0;
+    }
+  }
+
+  void onFirstPlayingFromSession() {
+    _stallWatchdog.onFirstPlaying();
+    if (!session.loggedFirstPlaying) {
+      session.loggedFirstPlaying = true;
+      _navigation.cancelNudge();
+      onLogInitPhase('first_playing');
+    }
+  }
+
+  Future<void> idleAfterClear() async {
+    _stallWatchdog.cancel();
+    _navigation.cancelNudge();
+    _bumpVerifyGeneration();
+    session.resetForClear();
+    _pollLoop.stop();
+    final navGen = ++_navGeneration;
+    final controller = _webController;
+    if (controller == null) return;
+    await YoutubeWebViewBridge.loadIdlePage(controller);
+    if (_navGeneration != navGen &&
+        session.videoId.isNotEmpty &&
+        identical(_webController, controller)) {
+      unawaited(_navigation.loadCurrentVideoIfAttached());
+    }
+  }
+
+  Future<void> dispose() async {
+    _stallWatchdog.cancel();
+    _navigation.cancelNudge();
+    _bumpVerifyGeneration();
+    _pollLoop.stop();
+  }
+
+  Future<void> onSignInNavigationBlocked(
+    InAppWebViewController controller,
+  ) =>
+      _navigation.onSignInNavigationBlocked(
+        controller,
+        prepareWatchReload: () => prepareWatchReload(resetFirstPlaying: false),
+      );
+
+  Future<void> onWebViewProcessTerminated() =>
+      _navigation.onWebViewProcessTerminated(
+        prepareWatchReload: () => prepareWatchReload(resetFirstPlaying: true),
+      );
+
+  void onWebViewCreated(
+    InAppWebViewController controller, {
+    bool initialWatchUrlRequested = false,
+  }) {
+    _webController = controller;
+    session.webViewMounted = true;
+    onLogInitPhase('webview_created');
+
+    if (initialWatchUrlRequested && session.videoId.isNotEmpty) {
+      session.awaitingColdInitialNavigation = true;
+    }
+
+    controller.addJavaScriptHandler(
+      handlerName: 'onAdReload',
+      callback: (List<dynamic> args) {
+        if (args.isNotEmpty) {
+          session.pendingSeekSeconds = (args[0] as num?)?.toDouble() ?? 0;
+        }
+        return null;
+      },
+    );
+
+    controller.addJavaScriptHandler(
+      handlerName: 'onVideoEvent',
+      callback: _events.handle,
+    );
+
+    if (session.videoId.isNotEmpty && !initialWatchUrlRequested) {
+      unawaited(_navigation.loadCurrentVideoIfAttached());
+      unawaited(
+        _navigation.ensureWatchPageLoadedAfterDelay(
+          skipIfLoadStopReceived: true,
+        ),
+      );
+    } else if (session.videoId.isNotEmpty) {
+      unawaited(
+        _navigation.ensureWatchPageLoadedAfterDelay(
+          delay: YoutubeWebViewNavigation.coldMountVerifyDelay,
+          skipIfLoadStopReceived: true,
+        ),
+      );
+    }
+  }
+
+  void onWebViewDisposed(InAppWebViewController? controller) {
+    if (identical(_webController, controller)) {
+      _webController = null;
+      session.webViewMounted = false;
+      session.awaitingColdInitialNavigation = false;
+      _navigation.cancelNudge();
+      _bumpVerifyGeneration();
+      _pollLoop.stop();
+      session.mountTick.value++;
+    }
+  }
+
+  Future<void> onPageFinished(
+    InAppWebViewController controller,
+    String? url,
+  ) async {
+    if (!isYoutubeWatchPageLoadStopUrl(url)) {
+      if (url != null && !url.startsWith('about:')) {
+        _logWebView.fine('youtube skip load_stop url=$url');
+      }
+      _navigation.scheduleNonWatchRecovery();
+      return;
+    }
+    session.awaitingColdInitialNavigation = false;
+    session.watchPageLoadStopReceived = true;
+    session.nonWatchRecoveryScheduled = false;
+    onLogInitPhase('load_stop');
+    if (!session.loggedFirstPlaying) {
+      _stallWatchdog.onLoadStop(session.videoId);
+      _navigation.schedulePlaybackNudge();
+    } else {
+      _stallWatchdog.cancel();
+      _navigation.cancelNudge();
+    }
+    await injectYoutubeMobileWatchPage(controller);
+    _pollLoop.scheduleKick();
+  }
+
+  Future<void> recoverStalledPlayback() async {
+    await _navigation.recoverStalledPlayback(
+      maxStallRecoveries: maxStallRecoveries,
+      stallRecoveryCount: () => _stallRecoveryCount,
+      setStallRecoveryCount: (c) => _stallRecoveryCount = c,
+      prepareWatchReload: () => prepareWatchReload(
+        resetFirstPlaying: false,
+        resetStallRecovery: false,
+      ),
+      cancelStallWatchdog: _stallWatchdog.cancel,
+    );
+  }
+
+  Future<void> loadCurrentVideoIfAttached() =>
+      _navigation.loadCurrentVideoIfAttached();
+
+  Future<void> reapplyVolume() async {
+    await YoutubeWebViewBridge.setVolume(
+      _webController,
+      session.volumeNormalized,
+    );
+  }
+
+  Future<void> exitNativeFullscreen(InAppWebViewController controller) async {
+    if (_rejectingNativeFullscreen) return;
+    _rejectingNativeFullscreen = true;
+    try {
+      await YoutubeWebViewBridge.forceInlinePlayback(controller);
+    } catch (e, st) {
+      _logWebView.fine('Failed to force inline playback', e, st);
+    } finally {
+      _rejectingNativeFullscreen = false;
+    }
+  }
+
+  Future<void> onNativeFullscreenExit(InAppWebViewController controller) async {
+    await YoutubeWebViewBridge.forceInlinePlayback(controller);
+    if (session.playing && !session.playbackCompleted) {
+      await YoutubeWebViewBridge.play(controller);
+    }
+  }
+
+  void stopPolling() => _pollLoop.stop();
+
+  void _bumpVerifyGeneration() => _verifyGeneration++;
+}

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -1,0 +1,99 @@
+/// DOM `<video>` event dispatch for [YoutubeWebViewController].
+library;
+
+import 'dart:async';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
+
+final _logEvents = logNamed('YoutubeWebViewEvents');
+
+typedef YoutubeSeekFn = Future<void> Function(Duration target);
+typedef YoutubePollStartFn = void Function();
+typedef YoutubePollStopFn = void Function();
+typedef YoutubeFirstPlayingFn = void Function();
+typedef YoutubeReapplyVolumeFn = Future<void> Function();
+
+/// Handles `onVideoEvent` JavaScript callbacks from the watch page.
+class YoutubeWebViewEvents {
+  YoutubeWebViewEvents({
+    required this.session,
+    required this.webController,
+    required this.onFirstPlaying,
+    required this.startPolling,
+    required this.stopPolling,
+    required this.reapplyVolume,
+    required this.seekTo,
+  });
+
+  final YoutubeSession session;
+  final InAppWebViewController? Function() webController;
+  final YoutubeFirstPlayingFn onFirstPlaying;
+  final YoutubePollStartFn startPolling;
+  final YoutubePollStopFn stopPolling;
+  final YoutubeReapplyVolumeFn reapplyVolume;
+  final YoutubeSeekFn seekTo;
+
+  dynamic handle(List<dynamic> args) {
+    if (args.isEmpty) return null;
+    final event = args[0] as String;
+    switch (event) {
+      case 'play':
+      case 'playing':
+        session.pausedPollStreak = 0;
+        session.playbackCompleted = false;
+        session.emitPlaying(true);
+        onFirstPlaying();
+        session.emitBuffering(false);
+        startPolling();
+        applyPendingSeek();
+        unawaited(reapplyVolume());
+        break;
+      case 'pause':
+        session.pausedPollStreak = 0;
+        break;
+      case 'ended':
+        session.pausedPollStreak = 0;
+        session.playbackCompleted = true;
+        stopPolling();
+        session.emitPlaying(false);
+        unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));
+        break;
+      case 'waiting':
+        session.emitBuffering(true);
+        break;
+      case 'canplay':
+        if (session.buffering) {
+          session.emitBuffering(false);
+        }
+        break;
+      case 'loadedmetadata':
+        startPolling();
+        if (args.length > 1) {
+          final dur = (args[1] as num).toDouble();
+          if (dur > 0 && dur.isFinite) {
+            session.emitDuration(Duration(milliseconds: (dur * 1000).round()));
+            applyPendingSeek();
+          }
+        }
+        break;
+      case 'error':
+        _logEvents.warning('YouTube video element error');
+        session.emitBuffering(false);
+        break;
+      default:
+        break;
+    }
+    return null;
+  }
+
+  void applyPendingSeek() {
+    final secs = session.pendingSeekSeconds;
+    if (secs == null || secs <= 0) return;
+    session.pendingSeekSeconds = null;
+    unawaited(seekTo(Duration(milliseconds: (secs * 1000).round())));
+  }
+}

--- a/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
@@ -1,0 +1,169 @@
+/// Watch-page load, verify, and stall-recovery navigation for YouTube WebView.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
+
+final _logNav = logNamed('YoutubeWebViewNavigation');
+
+/// Load/verify/nudge helpers shared by [YoutubeWebViewController].
+class YoutubeWebViewNavigation {
+  YoutubeWebViewNavigation({
+    required this.session,
+    required this.webController,
+    required this.captureVerifyGeneration,
+    required this.isVerifyGenerationStale,
+    required this.bumpNavGeneration,
+    required this.currentNavGeneration,
+    required this.onStaleWebView,
+  });
+
+  final YoutubeSession session;
+  final InAppWebViewController? Function() webController;
+  final int Function() captureVerifyGeneration;
+  final bool Function(int gen) isVerifyGenerationStale;
+  final int Function() bumpNavGeneration;
+  final int Function() currentNavGeneration;
+  final void Function() onStaleWebView;
+
+  static const Duration playbackNudgeDelay = Duration(seconds: 6);
+  static const Duration coldMountVerifyDelay = Duration(seconds: 10);
+
+  Timer? _playbackNudgeTimer;
+
+  void cancelNudge() {
+    _playbackNudgeTimer?.cancel();
+    _playbackNudgeTimer = null;
+  }
+
+  Future<void> loadCurrentVideoIfAttached() async {
+    final controller = webController();
+    if (controller == null || session.videoId.isEmpty) return;
+    final videoId = session.videoId;
+    final navGen = bumpNavGeneration();
+    try {
+      await YoutubeWebViewBridge.loadWatchPage(controller, videoId);
+    } on MissingPluginException catch (e, st) {
+      if (identical(webController(), controller)) {
+        onStaleWebView();
+      }
+      _logNav.fine('Ignoring loadUrl on stale YouTube WebView', e, st);
+      return;
+    }
+    if (currentNavGeneration() != navGen || session.videoId != videoId) return;
+  }
+
+  Future<void> ensureWatchPageLoadedAfterDelay({
+    Duration delay = const Duration(seconds: 2),
+    bool skipIfLoadStopReceived = false,
+  }) async {
+    final gen = captureVerifyGeneration();
+    await Future<void>.delayed(delay);
+    if (isVerifyGenerationStale(gen)) return;
+    if (session.disposed || session.videoId.isEmpty || webController() == null) {
+      return;
+    }
+    if (session.loggedFirstPlaying) return;
+    if (skipIfLoadStopReceived && session.watchPageLoadStopReceived) return;
+    _logNav.info('youtube verify watch load vid=${session.videoId}');
+    await loadCurrentVideoIfAttached();
+  }
+
+  void scheduleNonWatchRecovery() {
+    if (session.disposed ||
+        session.videoId.isEmpty ||
+        session.loggedFirstPlaying) {
+      return;
+    }
+    if (session.nonWatchRecoveryScheduled) return;
+    session.nonWatchRecoveryScheduled = true;
+    _logNav.info('youtube non-watch load_stop; verifying watch page');
+    unawaited(
+      ensureWatchPageLoadedAfterDelay(skipIfLoadStopReceived: true),
+    );
+  }
+
+  void schedulePlaybackNudge() {
+    _playbackNudgeTimer?.cancel();
+    _playbackNudgeTimer = Timer(playbackNudgeDelay, () {
+      _playbackNudgeTimer = null;
+      if (session.disposed ||
+          session.loggedFirstPlaying ||
+          webController() == null) {
+        return;
+      }
+      _logNav.info('youtube nudge play vid=${session.videoId}');
+      unawaited(nudgePlaybackStart(webController()));
+    });
+  }
+
+  Future<void> onWebViewProcessTerminated({
+    required void Function() prepareWatchReload,
+  }) async {
+    final controller = webController();
+    final vid = session.videoId;
+    if (controller == null || vid.isEmpty || session.disposed) return;
+    _logNav.warning(
+      'youtube WebView process terminated; reloading vid=$vid',
+    );
+    prepareWatchReload();
+    session.emitBuffering(true);
+    session.emitPlaying(false);
+    await YoutubeWebViewBridge.loadWatchPage(controller, vid);
+  }
+
+  Future<void> onSignInNavigationBlocked(
+    InAppWebViewController controller, {
+    required void Function() prepareWatchReload,
+  }) async {
+    final vid = session.videoId;
+    if (vid.isEmpty || session.disposed) return;
+    prepareWatchReload();
+    _logNav.info('youtube reload after blocked sign-in vid=$vid');
+    await YoutubeWebViewBridge.loadWatchPage(controller, vid);
+  }
+
+  Future<void> nudgePlaybackStart(InAppWebViewController? web) async {
+    if (web == null || session.disposed || session.loggedFirstPlaying) return;
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await YoutubeWebViewBridge.forceInlinePlayback(web);
+    }
+    await YoutubeWebViewBridge.play(web);
+  }
+
+  Future<void> recoverStalledPlayback({
+    required int maxStallRecoveries,
+    required int Function() stallRecoveryCount,
+    required void Function(int count) setStallRecoveryCount,
+    required void Function() prepareWatchReload,
+    required void Function() cancelStallWatchdog,
+  }) async {
+    final controller = webController();
+    final vid = session.videoId;
+    if (controller == null || vid.isEmpty || session.disposed) return;
+    if (session.playing) {
+      cancelStallWatchdog();
+      return;
+    }
+    if (stallRecoveryCount() >= maxStallRecoveries) {
+      _logNav.info(
+        'youtube stall recovery limit reached vid=$vid; nudging play',
+      );
+      unawaited(nudgePlaybackStart(controller));
+      return;
+    }
+    setStallRecoveryCount(stallRecoveryCount() + 1);
+    cancelStallWatchdog();
+    _logNav.info('youtube reload after stall vid=$vid');
+    prepareWatchReload();
+    session.emitBuffering(true);
+    await YoutubeWebViewBridge.loadWatchPage(controller, vid);
+  }
+}

--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -1,0 +1,96 @@
+/// Position/duration polling loop for the YouTube watch WebView.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_state_poller.dart';
+
+typedef YoutubeFirstPlayingFn = void Function();
+
+/// Periodic DOM poll for `<video>` play state (see [YoutubeStatePoller]).
+class YoutubeWebViewPollLoop {
+  YoutubeWebViewPollLoop({
+    required this.session,
+    required this.webController,
+    required this.onFirstPlaying,
+  });
+
+  final YoutubeSession session;
+  final InAppWebViewController? Function() webController;
+  final YoutubeFirstPlayingFn onFirstPlaying;
+
+  Timer? _pollTimer;
+  Timer? _pollKickTimer;
+
+  void scheduleKick() {
+    _pollKickTimer?.cancel();
+    _pollKickTimer = Timer(const Duration(milliseconds: 500), () {
+      _pollKickTimer = null;
+      if (!session.disposed) start();
+    });
+  }
+
+  void start() {
+    if (_pollTimer != null) return;
+    session.pausedPollStreak = 0;
+    _pollTimer = Timer.periodic(
+      const Duration(milliseconds: 250),
+      (_) => _tick(),
+    );
+  }
+
+  void stop() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    _pollKickTimer?.cancel();
+    _pollKickTimer = null;
+  }
+
+  Future<void> _tick() async {
+    await YoutubeStatePoller.poll(
+      disposed: session.disposed,
+      web: webController(),
+      onResult:
+          ({
+            required Duration position,
+            Duration? newDuration,
+            required bool jsPaused,
+            required bool jsEnded,
+          }) {
+            if (session.disposed) return;
+            session.emitPosition(position);
+            if (newDuration != null &&
+                newDuration > Duration.zero &&
+                newDuration != session.lastDuration) {
+              session.emitDuration(newDuration);
+            }
+            if (jsEnded && !session.playbackCompleted) {
+              session.pausedPollStreak = 0;
+              session.playbackCompleted = true;
+              stop();
+              session.emitPlaying(false);
+            } else if (jsPaused && session.playing && !jsEnded) {
+              session.pausedPollStreak++;
+              if (session.pausedPollStreak >= YoutubeSession.pauseConfirmPollTicks) {
+                session.pausedPollStreak = 0;
+                session.emitPlaying(false);
+                stop();
+              }
+            } else {
+              session.pausedPollStreak = 0;
+              if (!jsPaused && !jsEnded) {
+                session.playbackCompleted = false;
+                session.emitPlaying(true);
+                onFirstPlaying();
+                if (session.buffering) {
+                  session.emitBuffering(false);
+                }
+              }
+            }
+          },
+    );
+  }
+}

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -2,66 +2,80 @@
 library;
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:cross_file/cross_file.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'package:enjoy_player/core/logging/log.dart';
-import 'package:enjoy_player/core/utils/remote_thumbnail_url.dart';
-import 'package:enjoy_player/data/db/app_database.dart';
-import 'package:enjoy_player/data/db/app_database_provider.dart';
 import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
-import 'package:enjoy_player/features/library/domain/media.dart';
-import 'package:enjoy_player/features/player/domain/echo_window.dart';
-import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
-import 'package:enjoy_player/features/player/application/playback_open_resolver.dart';
-import 'package:enjoy_player/features/player/application/player_engine_binding.dart';
 import 'package:enjoy_player/features/player/application/player_engine_rev.dart';
-import 'package:enjoy_player/features/player/application/player_open_side_effects.dart';
-import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
-import 'package:enjoy_player/features/player/application/position_buckets.dart';
-import 'package:enjoy_player/features/player/application/video_poster_capture_service.dart';
-import 'package:enjoy_player/features/player/domain/playable_source.dart';
+import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
+import 'package:enjoy_player/features/player/application/player_open_coordinator.dart';
+import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
+import 'package:enjoy_player/features/player/domain/echo_window.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'open_media_provider.dart';
 import 'playback_session_persister.dart';
-import 'player_engine_test_double_provider.dart';
 
 part 'player_controller.g.dart';
 
-final _openMediaLog = logNamed('PlayerController.openMedia');
-
 @Riverpod(keepAlive: true)
-class PlayerController extends _$PlayerController {
+class PlayerController extends _$PlayerController implements PlayerOpenHost {
   /// Real engine (null until first open, or [PlayerEngine] tests override).
   PlayerEngine? _ownedEngine;
 
-  /// Active playback backend: test double, or lazily created [MediaKitPlayerEngine] / [YoutubePlayerEngine].
-  PlayerEngine get _activeEngine {
-    final testDouble = ref.read(playerEngineTestDoubleProvider);
-    if (testDouble != null) return testDouble;
-    _ownedEngine ??= MediaKitPlayerEngine();
-    return _ownedEngine!;
-  }
-
-  StreamSubscription<Duration>? _positionSub;
-  StreamSubscription<Duration>? _durationSub;
-
-  /// Last emitted UI bucket for raw [engine.position] ticks (see [_subscribeStreams]).
-  int? _lastPositionEmitBucket;
-
-  /// Last bucket used for echo clamping (see [_subscribeStreams]).
-  int? _lastEchoApplyBucket;
+  late final PlayerPositionTracker _positionTracker = PlayerPositionTracker(
+    ref: ref,
+    getEngine: () => activeEngine,
+    getSession: () => state,
+    setSession: (next) => state = next,
+    currentOpenGeneration: () => _openGeneration,
+  );
 
   /// Incremented on each [openMedia] call; stale async work bails out.
   int _openGeneration = 0;
 
+  @override
   int get openGeneration => _openGeneration;
 
-  PlayerEngine get engine => _activeEngine;
+  @override
+  bool isOpenStale(int gen) => gen != _openGeneration;
+
+  @override
+  PlayerEngine? get ownedEngine => _ownedEngine;
+
+  @override
+  set ownedEngine(PlayerEngine? engine) => _ownedEngine = engine;
+
+  @override
+  PlaybackSession? get session => state;
+
+  @override
+  set session(PlaybackSession? next) => state = next;
+
+  @override
+  PlayerPositionTracker get positionTracker => _positionTracker;
+
+  @override
+  PlayerEngine get activeEngine {
+    final testDouble = ref.read(playerEngineTestDoubleProvider);
+    if (testDouble != null) return testDouble;
+    _ensureDefaultMediaKitEngine();
+    return _ownedEngine!;
+  }
+
+  /// Allocates [MediaKitPlayerEngine] once when local/URL playback needs it.
+  /// Kept out of [build] so YouTube-only opens and headless tests avoid
+  /// [MediaKit.ensureInitialized] until a non-YouTube engine is required.
+  void _ensureDefaultMediaKitEngine() {
+    if (_ownedEngine != null) return;
+    if (ref.read(playerEngineTestDoubleProvider) != null) return;
+    _ownedEngine = MediaKitPlayerEngine();
+  }
+
+  PlayerEngine get engine => activeEngine;
 
   @override
   PlaybackSession? build() {
@@ -69,12 +83,10 @@ class PlayerController extends _$PlayerController {
 
     ref.onDispose(() async {
       persister.cancel();
-      await _positionSub?.cancel();
-      await _durationSub?.cancel();
-      _positionSub = null;
-      _durationSub = null;
+      await _positionTracker.cancel();
       await _ownedEngine?.dispose();
     });
+
     return null;
   }
 
@@ -87,291 +99,24 @@ class PlayerController extends _$PlayerController {
   }
 
   Future<void> openMedia(String mediaId) async {
-    // Re-entering `/player/:id` while this media is already active — skip reload.
     if (state?.mediaId == mediaId) return;
 
     final gen = ++_openGeneration;
 
-    try {
-      final db = ref.read(appDatabaseProvider);
-      final resolved = await resolvePlaybackOpen(db, mediaId);
-      if (resolved == null) return;
-      if (gen != _openGeneration) return;
-
-      final video = resolved.video;
-      final audio = resolved.audio;
-      final kind = resolved.kind;
-      final dexie = resolved.dexieTargetType;
-      final title = resolved.title;
-      final playable = resolved.playable;
-
-      schedulePlayerOpenSideEffects(
-        ref,
-        openGeneration: gen,
-        isStale: () => _openGeneration != gen,
-        mediaId: mediaId,
-        dexieTargetType: dexie,
-      );
-
-      await ensureEngineForPlayableSource(
-        ref,
-        playable: playable,
-        getOwnedEngine: () => _ownedEngine,
-        setOwnedEngine: (e) => _ownedEngine = e,
-      );
-      if (gen != _openGeneration) return;
-
-      final engine = _activeEngine;
-
-      final thumb = resolved.thumbnailUrl;
-      final language = resolved.language;
-      final durationSec = resolved.durationSeconds;
-
-      if (playable is YoutubePlayableSource && engine is YoutubePlayerEngine) {
-        engine.markOpenTimingStart();
-        engine.setPosterUrl(
-          _youtubePosterUrl(
-            thumbnailPath: thumb,
-            videoId: playable.videoId,
-            mediaUrl: video?.mediaUrl,
-          ),
-        );
-        engine.ensureWebViewAttached();
-      }
-
-      // Bind video output before first decode on Windows/macOS (see media_kit_video notes).
-      // Audio-only paths skip this so unit tests and headless runs avoid native libmpv.
-      if (kind == MediaKind.video &&
-          engine is MediaKitPlayerEngine &&
-          (Platform.isWindows || Platform.isMacOS)) {
-        engine.warmVideoSurface();
-      }
-
-      await _positionSub?.cancel();
-      await _durationSub?.cancel();
-      _positionSub = null;
-      _durationSub = null;
-
-      await engine.open(playable);
-      if (gen != _openGeneration) return;
-
-      if (engine.supportsSubtitleDisabling) {
-        await engine.disableRenderedSubtitles();
-        if (gen != _openGeneration) return;
-      }
-
-      await ref
-          .read(playerPreferencesCtrlProvider.notifier)
-          .applyCurrentToEngine();
-      if (gen != _openGeneration) return;
-
-      final persisted = await db.echoSessionDao.getLatestForTarget(
-        dexie,
-        mediaId,
-      );
-      if (gen != _openGeneration) return;
-
-      final posMs = persisted?.currentTimeMs ?? 0;
-      if (posMs > 0) {
-        await engine.seek(Duration(milliseconds: posMs));
-      }
-      if (gen != _openGeneration) return;
-
-      if (persisted != null && persisted.echoActive) {
-        ref
-            .read(echoModeProvider.notifier)
-            .restoreFromSession(
-              startLine: persisted.echoStartLine,
-              endLine: persisted.echoEndLine,
-              echoStartMs: persisted.echoStartMs ?? 0,
-              echoEndMs: persisted.echoEndMs ?? 0,
-            );
-      } else {
-        ref.read(echoModeProvider.notifier).deactivate();
-      }
-      if (gen != _openGeneration) return;
-
-      final now = DateTime.now();
-      state = PlaybackSession(
-        mediaId: mediaId,
-        dexieTargetType: dexie,
-        mediaType: kind.storageValue,
-        mediaTitle: title,
-        thumbnailUrl: thumb,
-        durationSeconds: durationSec > 0
-            ? durationSec.toDouble()
-            : posMs / 1000.0,
-        currentTimeSeconds: posMs / 1000.0,
-        currentSegmentIndex: persisted?.currentSegmentIndex ?? -1,
-        language: language,
-        startedAt: now,
-        lastActiveAt: now,
-      );
-
-      if (gen != _openGeneration) return;
-      _subscribeStreams(
-        mediaId: mediaId,
-        dexieTargetType: dexie,
-        kind: kind,
-        video: video,
-        audio: audio,
-        gen: gen,
-      );
-
-      if (playable is YoutubePlayableSource) {
-        scheduleYoutubeMetadataRefresh(
-          ref,
-          mediaId: mediaId,
-          openGeneration: gen,
-        );
-      }
-
-      if (kind == MediaKind.video &&
-          video != null &&
-          engine.supportsVideoPosterCapture) {
-        ref
-            .read(videoPosterCaptureServiceProvider)
-            .scheduleCapture(
-              mediaId: mediaId,
-              video: video,
-              restoredPositionMs: posMs,
-              gen: gen,
-              currentOpenGeneration: () => _openGeneration,
-              currentSessionMediaId: () => state?.mediaId,
-              sessionDurationSeconds: () => state?.durationSeconds,
-              activeEngine: engine,
-              onSessionThumbnail: (path) {
-                state = state?.copyWith(thumbnailUrl: path);
-              },
-            );
-      }
-    } on Object catch (e, st) {
-      if (gen == _openGeneration) {
-        state = null;
-      }
-      _openMediaLog.severe('openMedia failed for $mediaId', e, st);
-      rethrow;
-    }
-  }
-
-  void _subscribeStreams({
-    required String mediaId,
-    required String dexieTargetType,
-    required MediaKind kind,
-    required VideoRow? video,
-    required AudioRow? audio,
-    required int gen,
-  }) {
-    _lastPositionEmitBucket = null;
-    _lastEchoApplyBucket = null;
-    // Raw mpv position can arrive very often (notably streaming). Updating
-    // [PlaybackSession] on every tick rebuilds all [playerControllerProvider]
-    // listeners and can overwhelm the Windows semantics bridge — same motivation
-    // as [displayPositionProvider]'s quantization.
-    const positionBucketMs = kPositionBucketEchoApplyMs;
-    _positionSub = _activeEngine.position.listen(
-      (pos) {
-        if (gen != _openGeneration) return;
-        final seconds = pos.inMilliseconds / 1000.0;
-
-        final bucket = pos.inMilliseconds ~/ positionBucketMs;
-        final prevSec = state?.currentTimeSeconds;
-        final likelySeek = prevSec != null && (seconds - prevSec).abs() > 0.35;
-        if (likelySeek || bucket != _lastEchoApplyBucket) {
-          _lastEchoApplyBucket = bucket;
-          unawaited(_applyEcho(seconds));
+    await runPlayerOpenGuarded(
+      this,
+      ref,
+      mediaId,
+      onFailureResetSession: () {
+        if (gen == _openGeneration) {
+          state = null;
         }
-
-        if (!likelySeek && bucket == _lastPositionEmitBucket) {
-          return;
-        }
-        _lastPositionEmitBucket = bucket;
-
-        state = state?.copyWith(
-          currentTimeSeconds: seconds,
-          lastActiveAt: DateTime.now(),
-        );
-        final s = state;
-        if (s != null) {
-          ref
-              .read(playbackSessionPersisterProvider)
-              .schedule(
-                mediaId: mediaId,
-                dexieTargetType: dexieTargetType,
-                session: s,
-              );
-        }
-      },
-      onError: (Object e, StackTrace st) {
-        _openMediaLog.warning('engine position stream errored', e, st);
       },
     );
-
-    _durationSub = _activeEngine.duration.listen(
-      (d) async {
-        if (gen != _openGeneration) return;
-        if (d <= Duration.zero) return;
-        final newSec = d.inMilliseconds / 1000.0;
-        final prevSec = state?.durationSeconds;
-        if (prevSec != null && (newSec - prevSec).abs() < 0.001) {
-          return;
-        }
-        final sec = d.inMilliseconds ~/ 1000;
-        state = state?.copyWith(durationSeconds: newSec);
-        final db = ref.read(appDatabaseProvider);
-        if (kind == MediaKind.video &&
-            video != null &&
-            video.durationSeconds == 0) {
-          await db.videoDao.insertRow(
-            video.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
-          );
-        } else if (kind == MediaKind.audio &&
-            audio != null &&
-            audio.durationSeconds == 0) {
-          await db.audioDao.insertRow(
-            audio.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
-          );
-        }
-      },
-      onError: (Object e, StackTrace st) {
-        _openMediaLog.warning('engine duration stream errored', e, st);
-      },
-    );
-  }
-
-  Future<void> _applyEcho(double positionSeconds) async {
-    final echo = ref.read(echoModeProvider);
-    if (!echo.active) return;
-    final dur = state?.durationSeconds;
-    final window = normalizeEchoWindow((
-      active: true,
-      startTimeSeconds: echo.startTimeSeconds,
-      endTimeSeconds: echo.endTimeSeconds,
-      durationSeconds: dur != null && dur > 0 ? dur : null,
-    ));
-    if (window == null) return;
-    final decision = decideEchoPlaybackTime(positionSeconds, window);
-    switch (decision) {
-      case EchoOk():
-        return;
-      case EchoClamp(:final timeSeconds):
-        await _activeEngine.seek(
-          Duration(milliseconds: (timeSeconds * 1000).round()),
-        );
-      case EchoPauseAndRewind(:final timeSeconds):
-        await _activeEngine.pause();
-        await _activeEngine.seek(
-          Duration(milliseconds: (timeSeconds * 1000).round()),
-        );
-    }
   }
 
   Future<void> seekTo(
     Duration target, {
-
-    /// When set while echo is active, used for seek clamping instead of reading
-    /// [echoModeProvider] (avoids clamping to the previous segment on the same
-    /// stack as [EchoMode.activate]).
     ({double start, double end})? echoWindowForSeekClamp,
   }) async {
     final echo = ref.read(echoModeProvider);
@@ -390,7 +135,7 @@ class PlayerController extends _$PlayerController {
         seconds = clampSeekTimeToEchoWindow(seconds, window);
       }
     }
-    await _activeEngine.seek(Duration(milliseconds: (seconds * 1000).round()));
+    await activeEngine.seek(Duration(milliseconds: (seconds * 1000).round()));
   }
 
   Future<void> seekToSeconds(
@@ -404,23 +149,16 @@ class PlayerController extends _$PlayerController {
   }
 
   Future<void> togglePlay() async {
-    await _activeEngine.playOrPause();
+    await activeEngine.playOrPause();
   }
 
   Future<void> play() async {
-    await _activeEngine.play();
+    await activeEngine.play();
   }
 
   Future<void> clear() async {
-    final positionSub = _positionSub;
-    final durationSub = _durationSub;
-    _positionSub = null;
-    _durationSub = null;
-    _lastPositionEmitBucket = null;
-    _lastEchoApplyBucket = null;
+    await _positionTracker.cancel();
 
-    // Capture the current session + ids before [state = null] so the persister
-    // can flush the last 450 ms of position updates to Drift.
     final current = state;
     final persister = ref.read(playbackSessionPersisterProvider);
     if (current != null) {
@@ -433,23 +171,16 @@ class PlayerController extends _$PlayerController {
       persister.cancel();
     }
 
-    // Drop in-flight [openMedia] work so a dismissed YouTube open cannot
-    // resurrect session state or swap engines after the user opens local media.
     _openGeneration++;
 
-    final engine = _activeEngine;
+    final engine = activeEngine;
     final ownedEngine = _ownedEngine;
     final isYoutubeEngine =
         ref.read(playerEngineTestDoubleProvider) == null &&
         ownedEngine is YoutubePlayerEngine;
 
-    // Remove session synchronously so [Dismissible] transport unmounts before
-    // async engine teardown (swipe-to-dismiss during load/buffer).
     ref.read(echoModeProvider.notifier).deactivate();
     state = null;
-
-    await positionSub?.cancel();
-    await durationSub?.cancel();
 
     if (isYoutubeEngine) {
       await ownedEngine.idleAfterClear();
@@ -458,7 +189,6 @@ class PlayerController extends _$PlayerController {
     }
   }
 
-  /// Pre-spawns the YouTube WebView process before navigating to the player.
   void warmYoutubeSurface() {
     if (ref.read(playerEngineTestDoubleProvider) != null) return;
     final owned = _ownedEngine;
@@ -474,34 +204,13 @@ class PlayerController extends _$PlayerController {
     _ownedEngine!.warmVideoSurface();
   }
 
-  String? _youtubePosterUrl({
-    required String? thumbnailPath,
-    required String videoId,
-    required String? mediaUrl,
-  }) {
-    return remoteThumbnailForCard(
-      thumbnailPath,
-      youtubeVideoId: videoId,
-      mediaUrl: mediaUrl,
-    );
-  }
-
-  /// Cancels an in-flight [openMedia] before [PlaybackSession] is published.
   void abandonPendingOpen() {
     _openGeneration++;
   }
 
-  void patchSessionMetadataIfCurrent({
-    required String mediaId,
-    required int openGeneration,
-    required String title,
-    String? thumbnailUrl,
-  }) {
-    if (_openGeneration != openGeneration) return;
-    if (state?.mediaId != mediaId) return;
-    state = state?.copyWith(
-      mediaTitle: title,
-      thumbnailUrl: thumbnailUrl ?? state?.thumbnailUrl,
-    );
+  /// Called by [PlayerMetadataNotifier] after lazy title/thumbnail refresh.
+  void applySessionPatch(PlaybackSession patched) {
+    if (state?.mediaId != patched.mediaId) return;
+    state = patched;
   }
 }

--- a/lib/features/player/application/player_controller.g.dart
+++ b/lib/features/player/application/player_controller.g.dart
@@ -41,7 +41,7 @@ final class PlayerControllerProvider
   }
 }
 
-String _$playerControllerHash() => r'4aa9a6a24bd4d74d1b88701fa6c5ac46f3d05e1a';
+String _$playerControllerHash() => r'096275a3a9942413ccabe3780c2e5565a2f013b9';
 
 abstract class _$PlayerController extends $Notifier<PlaybackSession?> {
   PlaybackSession? build();

--- a/lib/features/player/application/player_engine_binding.dart
+++ b/lib/features/player/application/player_engine_binding.dart
@@ -11,26 +11,40 @@ import 'package:enjoy_player/features/player/application/player_engine_test_doub
 
 /// Ensures [_ownedEngine] matches [playable] (YouTube vs MediaKit), bumping
 /// [playerEngineRevProvider] when the implementation changes.
+///
+/// [openGeneration] must match [currentOpenGeneration] before and after each
+/// async step so concurrent [openMedia] calls cannot dispose another call's
+/// engine mid-flight.
 Future<void> ensureEngineForPlayableSource(
   Ref ref, {
   required PlayableSource playable,
+  required int openGeneration,
+  required int Function() currentOpenGeneration,
   required PlayerEngine? Function() getOwnedEngine,
   required void Function(PlayerEngine? next) setOwnedEngine,
 }) async {
   if (ref.read(playerEngineTestDoubleProvider) != null) return;
+  if (currentOpenGeneration() != openGeneration) return;
+
   final wantYt = playable is YoutubePlayableSource;
   final owned = getOwnedEngine();
   final haveYt = owned is YoutubePlayerEngine;
+
   if (wantYt && !haveYt) {
+    if (currentOpenGeneration() != openGeneration) return;
     if (owned != null) {
       await owned.dispose();
+      if (currentOpenGeneration() != openGeneration) return;
     }
     setOwnedEngine(YoutubePlayerEngine());
     ref.read(playerEngineRevProvider.notifier).bump();
     return;
   }
+
   if (!wantYt && haveYt) {
+    if (currentOpenGeneration() != openGeneration) return;
     await owned.dispose();
+    if (currentOpenGeneration() != openGeneration) return;
     setOwnedEngine(MediaKitPlayerEngine());
     ref.read(playerEngineRevProvider.notifier).bump();
   }

--- a/lib/features/player/application/player_metadata_notifier.dart
+++ b/lib/features/player/application/player_metadata_notifier.dart
@@ -1,0 +1,33 @@
+/// Patches in-flight [PlaybackSession] title/thumbnail after lazy metadata fetch.
+library;
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:enjoy_player/features/player/application/player_controller.dart';
+
+part 'player_metadata_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class PlayerMetadataNotifier extends _$PlayerMetadataNotifier {
+  @override
+  void build() {}
+
+  /// Updates session chrome when [openGeneration] and [mediaId] still match.
+  void patchIfCurrent({
+    required String mediaId,
+    required int openGeneration,
+    required String title,
+    String? thumbnailUrl,
+  }) {
+    final controller = ref.read(playerControllerProvider.notifier);
+    if (controller.openGeneration != openGeneration) return;
+    final session = ref.read(playerControllerProvider);
+    if (session?.mediaId != mediaId) return;
+    controller.applySessionPatch(
+      session!.copyWith(
+        mediaTitle: title,
+        thumbnailUrl: thumbnailUrl ?? session.thumbnailUrl,
+      ),
+    );
+  }
+}

--- a/lib/features/player/application/player_metadata_notifier.g.dart
+++ b/lib/features/player/application/player_metadata_notifier.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'player_metadata_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(PlayerMetadataNotifier)
+final playerMetadataProvider = PlayerMetadataNotifierProvider._();
+
+final class PlayerMetadataNotifierProvider
+    extends $NotifierProvider<PlayerMetadataNotifier, void> {
+  PlayerMetadataNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'playerMetadataProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$playerMetadataNotifierHash();
+
+  @$internal
+  @override
+  PlayerMetadataNotifier create() => PlayerMetadataNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$playerMetadataNotifierHash() =>
+    r'a803fb6b0d3daf39469ec97860ec838e5dee1e8a';
+
+abstract class _$PlayerMetadataNotifier extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/player/application/player_open_coordinator.dart
+++ b/lib/features/player/application/player_open_coordinator.dart
@@ -1,0 +1,198 @@
+/// Orchestrates [PlayerController.openMedia] resolve → engine → session publish.
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/core/utils/remote_thumbnail_url.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/library/domain/media.dart';
+import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
+import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/playback_open_resolver.dart';
+import 'package:enjoy_player/features/player/application/player_engine_binding.dart';
+import 'package:enjoy_player/features/player/application/player_open_side_effects.dart';
+import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
+import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
+import 'package:enjoy_player/features/player/application/video_poster_capture_service.dart';
+import 'package:enjoy_player/features/player/domain/playable_source.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+
+final _openLog = logNamed('PlayerOpenCoordinator');
+
+/// Host surface [runPlayerOpen] needs from [PlayerController].
+abstract interface class PlayerOpenHost {
+  int get openGeneration;
+  bool isOpenStale(int gen);
+  PlayerEngine get activeEngine;
+  PlayerEngine? get ownedEngine;
+  set ownedEngine(PlayerEngine? engine);
+  PlaybackSession? get session;
+  set session(PlaybackSession? next);
+  PlayerPositionTracker get positionTracker;
+}
+
+Future<void> runPlayerOpen(PlayerOpenHost host, Ref ref, String mediaId) async {
+  final gen = host.openGeneration;
+
+  final db = ref.read(appDatabaseProvider);
+  final resolved = await resolvePlaybackOpen(db, mediaId);
+  if (resolved == null) return;
+  if (host.isOpenStale(gen)) return;
+
+  final video = resolved.video;
+  final audio = resolved.audio;
+  final kind = resolved.kind;
+  final dexie = resolved.dexieTargetType;
+  final title = resolved.title;
+  final playable = resolved.playable;
+
+  schedulePlayerOpenSideEffects(
+    ref,
+    openGeneration: gen,
+    isStale: () => host.isOpenStale(gen),
+    mediaId: mediaId,
+    dexieTargetType: dexie,
+  );
+
+  await ensureEngineForPlayableSource(
+    ref,
+    playable: playable,
+    openGeneration: gen,
+    currentOpenGeneration: () => host.openGeneration,
+    getOwnedEngine: () => host.ownedEngine,
+    setOwnedEngine: (e) => host.ownedEngine = e,
+  );
+  if (host.isOpenStale(gen)) return;
+
+  final engine = host.activeEngine;
+
+  final thumb = resolved.thumbnailUrl;
+  final language = resolved.language;
+  final durationSec = resolved.durationSeconds;
+
+  if (playable is YoutubePlayableSource && engine is YoutubePlayerEngine) {
+    engine.markOpenTimingStart();
+    engine.setPosterUrl(
+      remoteThumbnailForCard(
+        thumb,
+        youtubeVideoId: playable.videoId,
+        mediaUrl: video?.mediaUrl,
+      ),
+    );
+    engine.ensureWebViewAttached();
+  }
+
+  if (kind == MediaKind.video &&
+      engine is MediaKitPlayerEngine &&
+      (Platform.isWindows || Platform.isMacOS)) {
+    engine.warmVideoSurface();
+  }
+
+  await host.positionTracker.cancel();
+
+  await engine.open(playable);
+  if (host.isOpenStale(gen)) return;
+
+  if (engine.supportsSubtitleDisabling) {
+    await engine.disableRenderedSubtitles();
+    if (host.isOpenStale(gen)) return;
+  }
+
+  await ref.read(playerPreferencesCtrlProvider.notifier).applyCurrentToEngine();
+  if (host.isOpenStale(gen)) return;
+
+  final persisted = await db.echoSessionDao.getLatestForTarget(dexie, mediaId);
+  if (host.isOpenStale(gen)) return;
+
+  final posMs = persisted?.currentTimeMs ?? 0;
+  if (posMs > 0) {
+    await engine.seek(Duration(milliseconds: posMs));
+  }
+  if (host.isOpenStale(gen)) return;
+
+  if (persisted != null && persisted.echoActive) {
+    ref.read(echoModeProvider.notifier).restoreFromSession(
+          startLine: persisted.echoStartLine,
+          endLine: persisted.echoEndLine,
+          echoStartMs: persisted.echoStartMs ?? 0,
+          echoEndMs: persisted.echoEndMs ?? 0,
+        );
+  } else {
+    ref.read(echoModeProvider.notifier).deactivate();
+  }
+  if (host.isOpenStale(gen)) return;
+
+  final now = DateTime.now();
+  // [PlaybackSession.startedAt] is the wall-clock time this playback stint
+  // began. It is set on every successful [openMedia] (including re-open after
+  // [PlayerController.clear]); it is not preserved across clear → re-open.
+  host.session = PlaybackSession(
+    mediaId: mediaId,
+    dexieTargetType: dexie,
+    mediaType: kind.storageValue,
+    mediaTitle: title,
+    thumbnailUrl: thumb,
+    durationSeconds: durationSec > 0 ? durationSec.toDouble() : posMs / 1000.0,
+    currentTimeSeconds: posMs / 1000.0,
+    currentSegmentIndex: persisted?.currentSegmentIndex ?? -1,
+    language: language,
+    startedAt: now,
+    lastActiveAt: now,
+  );
+
+  if (host.isOpenStale(gen)) return;
+  host.positionTracker.subscribe(
+    openGeneration: gen,
+    mediaId: mediaId,
+    dexieTargetType: dexie,
+    kind: kind,
+    video: video,
+    audio: audio,
+  );
+
+  if (playable is YoutubePlayableSource) {
+    scheduleYoutubeMetadataRefresh(
+      ref,
+      mediaId: mediaId,
+      openGeneration: gen,
+    );
+  }
+
+  if (kind == MediaKind.video &&
+      video != null &&
+      engine.supportsVideoPosterCapture) {
+    ref.read(videoPosterCaptureServiceProvider).scheduleCapture(
+          mediaId: mediaId,
+          video: video,
+          restoredPositionMs: posMs,
+          gen: gen,
+          currentOpenGeneration: () => host.openGeneration,
+          currentSessionMediaId: () => host.session?.mediaId,
+          sessionDurationSeconds: () => host.session?.durationSeconds,
+          activeEngine: engine,
+          onSessionThumbnail: (path) {
+            host.session = host.session?.copyWith(thumbnailUrl: path);
+          },
+        );
+  }
+}
+
+Future<void> runPlayerOpenGuarded(
+  PlayerOpenHost host,
+  Ref ref,
+  String mediaId, {
+  required void Function() onFailureResetSession,
+}) async {
+  try {
+    await runPlayerOpen(host, ref, mediaId);
+  } on Object catch (e, st) {
+    onFailureResetSession();
+    _openLog.severe('openMedia failed for $mediaId', e, st);
+    rethrow;
+  }
+}

--- a/lib/features/player/application/player_open_side_effects.dart
+++ b/lib/features/player/application/player_open_side_effects.dart
@@ -13,6 +13,7 @@ import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
 import 'package:enjoy_player/features/player/application/player_controller.dart';
+import 'package:enjoy_player/features/player/application/player_metadata_notifier.dart';
 import 'package:enjoy_player/features/sync/application/sync_providers.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_fetch_controller.dart';
 
@@ -128,12 +129,12 @@ Future<void> _runYoutubeMetadataRefresh(
       .refreshYoutubeMetadataIfNeeded(mediaId);
   if (patch == null) return;
 
-  controller.patchSessionMetadataIfCurrent(
-    mediaId: mediaId,
-    openGeneration: openGeneration,
-    title: patch.title,
-    thumbnailUrl: patch.thumbnailUrl,
-  );
+  ref.read(playerMetadataProvider.notifier).patchIfCurrent(
+        mediaId: mediaId,
+        openGeneration: openGeneration,
+        title: patch.title,
+        thumbnailUrl: patch.thumbnailUrl,
+      );
 }
 
 bool _youtubeMetadataNeedsRefresh(VideoRow row) {

--- a/lib/features/player/application/player_position_tracker.dart
+++ b/lib/features/player/application/player_position_tracker.dart
@@ -1,0 +1,164 @@
+/// Position/duration stream subscriptions, echo clamping, and session persistence.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/library/domain/media.dart';
+import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
+import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/position_buckets.dart';
+import 'package:enjoy_player/features/player/domain/echo_window.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'playback_session_persister.dart';
+
+final _positionLog = logNamed('PlayerPositionTracker');
+
+/// Manages engine position/duration listeners for one open generation.
+class PlayerPositionTracker {
+  PlayerPositionTracker({
+    required this.ref,
+    required this.getEngine,
+    required this.getSession,
+    required this.setSession,
+    required this.currentOpenGeneration,
+  });
+
+  final Ref ref;
+  final PlayerEngine Function() getEngine;
+  final PlaybackSession? Function() getSession;
+  final void Function(PlaybackSession? next) setSession;
+  final int Function() currentOpenGeneration;
+
+  int? _subscribedGeneration;
+
+  StreamSubscription<Duration>? _positionSub;
+  StreamSubscription<Duration>? _durationSub;
+  int? _lastPositionEmitBucket;
+  int? _lastEchoApplyBucket;
+
+  Future<void> cancel() async {
+    await _positionSub?.cancel();
+    await _durationSub?.cancel();
+    _positionSub = null;
+    _durationSub = null;
+    _lastPositionEmitBucket = null;
+    _lastEchoApplyBucket = null;
+  }
+
+  void subscribe({
+    required int openGeneration,
+    required String mediaId,
+    required String dexieTargetType,
+    required MediaKind kind,
+    required VideoRow? video,
+    required AudioRow? audio,
+  }) {
+    _subscribedGeneration = openGeneration;
+    _lastPositionEmitBucket = null;
+    _lastEchoApplyBucket = null;
+
+    const positionBucketMs = kPositionBucketEchoApplyMs;
+    _positionSub = getEngine().position.listen(
+      (pos) {
+        if (_subscribedGeneration != currentOpenGeneration()) return;
+        final seconds = pos.inMilliseconds / 1000.0;
+
+        final bucket = pos.inMilliseconds ~/ positionBucketMs;
+        final prevSec = getSession()?.currentTimeSeconds;
+        final likelySeek = prevSec != null && (seconds - prevSec).abs() > 0.35;
+        if (likelySeek || bucket != _lastEchoApplyBucket) {
+          _lastEchoApplyBucket = bucket;
+          unawaited(_applyEcho(seconds));
+        }
+
+        if (!likelySeek && bucket == _lastPositionEmitBucket) {
+          return;
+        }
+        _lastPositionEmitBucket = bucket;
+
+        setSession(
+          getSession()?.copyWith(
+            currentTimeSeconds: seconds,
+            lastActiveAt: DateTime.now(),
+          ),
+        );
+        final s = getSession();
+        if (s != null) {
+          ref
+              .read(playbackSessionPersisterProvider)
+              .schedule(
+                mediaId: mediaId,
+                dexieTargetType: dexieTargetType,
+                session: s,
+              );
+        }
+      },
+      onError: (Object e, StackTrace st) {
+        _positionLog.warning('engine position stream errored', e, st);
+      },
+    );
+
+    _durationSub = getEngine().duration.listen(
+      (d) async {
+        if (_subscribedGeneration != currentOpenGeneration()) return;
+        if (d <= Duration.zero) return;
+        final newSec = d.inMilliseconds / 1000.0;
+        final prevSec = getSession()?.durationSeconds;
+        if (prevSec != null && (newSec - prevSec).abs() < 0.001) {
+          return;
+        }
+        final sec = d.inMilliseconds ~/ 1000;
+        setSession(getSession()?.copyWith(durationSeconds: newSec));
+        final db = ref.read(appDatabaseProvider);
+        if (kind == MediaKind.video &&
+            video != null &&
+            video.durationSeconds == 0) {
+          await db.videoDao.insertRow(
+            video.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
+          );
+        } else if (kind == MediaKind.audio &&
+            audio != null &&
+            audio.durationSeconds == 0) {
+          await db.audioDao.insertRow(
+            audio.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
+          );
+        }
+      },
+      onError: (Object e, StackTrace st) {
+        _positionLog.warning('engine duration stream errored', e, st);
+      },
+    );
+  }
+
+  Future<void> _applyEcho(double positionSeconds) async {
+    final echo = ref.read(echoModeProvider);
+    if (!echo.active) return;
+    final dur = getSession()?.durationSeconds;
+    final window = normalizeEchoWindow((
+      active: true,
+      startTimeSeconds: echo.startTimeSeconds,
+      endTimeSeconds: echo.endTimeSeconds,
+      durationSeconds: dur != null && dur > 0 ? dur : null,
+    ));
+    if (window == null) return;
+    final decision = decideEchoPlaybackTime(positionSeconds, window);
+    switch (decision) {
+      case EchoOk():
+        return;
+      case EchoClamp(:final timeSeconds):
+        await getEngine().seek(
+          Duration(milliseconds: (timeSeconds * 1000).round()),
+        );
+      case EchoPauseAndRewind(:final timeSeconds):
+        await getEngine().pause();
+        await getEngine().seek(
+          Duration(milliseconds: (timeSeconds * 1000).round()),
+        );
+    }
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -781,5 +781,7 @@
   "recoveryResetLibraryConfirmAction": "Reset everything",
   "recoveryResetLibraryBackupError": "Backup failed — the local database was not wiped. The error has been logged.",
   "recoveryResetLibrarySuccess": "Local library reset. Enjoy Player will restart shortly.",
-  "recoveryResetLibraryError": "Could not reset the local library."
+  "recoveryResetLibraryError": "Could not reset the local library.",
+  "widgetErrorTitle": "Something went wrong",
+  "widgetErrorSubtitle": "This screen hit an unexpected error. You can copy the details below and try navigating elsewhere."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3566,6 +3566,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not reset the local library.'**
   String get recoveryResetLibraryError;
+
+  /// No description provided for @widgetErrorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong'**
+  String get widgetErrorTitle;
+
+  /// No description provided for @widgetErrorSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'This screen hit an unexpected error. You can copy the details below and try navigating elsewhere.'**
+  String get widgetErrorSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1900,4 +1900,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get recoveryResetLibraryError => 'Could not reset the local library.';
+
+  @override
+  String get widgetErrorTitle => 'Something went wrong';
+
+  @override
+  String get widgetErrorSubtitle =>
+      'This screen hit an unexpected error. You can copy the details below and try navigating elsewhere.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1815,6 +1815,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get recoveryResetLibraryError => '无法重置本地资料库。';
+
+  @override
+  String get widgetErrorTitle => '出了点问题';
+
+  @override
+  String get widgetErrorSubtitle => '此界面遇到意外错误。你可以复制下面的详情，然后尝试前往其他页面。';
 }
 
 /// The translations for Chinese, as used in China (`zh_CN`).
@@ -3628,4 +3634,10 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get recoveryResetLibraryError => '无法重置本地资料库。';
+
+  @override
+  String get widgetErrorTitle => '出了点问题';
+
+  @override
+  String get widgetErrorSubtitle => '此界面遇到意外错误。你可以复制下面的详情，然后尝试前往其他页面。';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -767,5 +767,7 @@
   "recoveryResetLibraryConfirmAction": "全部清除",
   "recoveryResetLibraryBackupError": "备份失败,本地数据库未被清除。错误已记录。",
   "recoveryResetLibrarySuccess": "本地资料库已重置,Enjoy Player 即将重启。",
-  "recoveryResetLibraryError": "无法重置本地资料库。"
+  "recoveryResetLibraryError": "无法重置本地资料库。",
+  "widgetErrorTitle": "出了点问题",
+  "widgetErrorSubtitle": "此界面遇到意外错误。你可以复制下面的详情，然后尝试前往其他页面。"
 }

--- a/lib/l10n/app_zh_CN.arb
+++ b/lib/l10n/app_zh_CN.arb
@@ -767,5 +767,7 @@
   "recoveryResetLibraryConfirmAction": "全部清除",
   "recoveryResetLibraryBackupError": "备份失败,本地数据库未被清除。错误已记录。",
   "recoveryResetLibrarySuccess": "本地资料库已重置,Enjoy Player 即将重启。",
-  "recoveryResetLibraryError": "无法重置本地资料库。"
+  "recoveryResetLibraryError": "无法重置本地资料库。",
+  "widgetErrorTitle": "出了点问题",
+  "widgetErrorSubtitle": "此界面遇到意外错误。你可以复制下面的详情，然后尝试前往其他页面。"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:media_kit/media_kit.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'app.dart';
+import 'core/recovery/widget_error_surface.dart';
 import 'core/logging/diagnostic_log_config.dart';
 import 'core/logging/diagnostic_session_header.dart';
 import 'core/logging/log.dart';
@@ -25,6 +26,9 @@ final Logger _bootstrapLog = logNamed('bootstrap');
 
 Future<void> _bootstrap() async {
   WidgetsFlutterBinding.ensureInitialized();
+  if (!kDebugMode) {
+    installReleaseWidgetErrorBuilder();
+  }
   // Two AppDatabase instances are expected: the device-global `guest` DB
   // (settings such as API base URL) and the per-user signed-in DB. They use
   // separate files and separate isolate executors, so Drift's runtime check


### PR DESCRIPTION
## Summary

- **Generation-guard** \nsureEngineForPlayableSource\ so concurrent \openMedia\ calls cannot dispose another call's engine mid-flight
- **Split \PlayerController\** into focused modules: \player_open_coordinator.dart\, \player_position_tracker.dart\, and slim session facade (~180 lines)
- **Split \YoutubePlayerEngine\** into \YoutubeSession\, \YoutubeWebViewController\, events/poll/navigation helpers (engine ~216 lines)
- **Move metadata patching** to \PlayerMetadataNotifier\ (\playerMetadataProvider\) instead of a public controller mutation
- **Release \ErrorWidget.builder\** via \WidgetErrorSurface\ with copy-to-clipboard (debug keeps default red screen)
- Document \PlaybackSession.startedAt\ semantics and \openPlayerRoute\ replace vs push policy

Closes #101

## Test plan

- [x] \lutter analyze\ clean on changed player/recovery paths
- [x] \lutter test test/features/player/\ — all 77 player tests pass
- [ ] Manual: open local media → YouTube → local again rapidly; confirm no engine crash
- [ ] Manual: trigger a widget build error in release/profile; confirm friendly error surface with copy button
- [ ] Manual: YouTube metadata refresh updates transport title without stale-open bleed