### PR TITLE
fix(db): non-destructive Drift migrations and schema hygiene (#102)

### DIFF
--- a/lib/core/routing/app_router.g.dart
+++ b/lib/core/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'9bf691c38001698f38ec235af68b24cfb49c89f9';
+String _$appRouterHash() => r'7bf472e13477ce614f0c093cc13e23bace1add17';

--- a/lib/data/api/api_client_provider.g.dart
+++ b/lib/data/api/api_client_provider.g.dart
@@ -118,7 +118,7 @@ final class AiApiBaseUrlProvider
   AiApiBaseUrl create() => AiApiBaseUrl();
 }
 
-String _$aiApiBaseUrlHash() => r'142df964a9af15107535ea71f37ec0ba2e3a2b01';
+String _$aiApiBaseUrlHash() => r'6bc8318cb2dca89aa460a03ca6ca2cef03c78f1e';
 
 abstract class _$AiApiBaseUrl extends $AsyncNotifier<String> {
   FutureOr<String> build();

--- a/lib/data/db/app_database.dart
+++ b/lib/data/db/app_database.dart
@@ -5,6 +5,10 @@ import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 import 'package:uuid/uuid.dart';
 
+import 'package:enjoy_player/core/logging/log.dart';
+import 'migration_backup.dart';
+import 'settings_keys.dart';
+import 'youtube_subscription_source.dart';
 import 'tables/audios.dart';
 import 'tables/dictations.dart';
 import 'tables/echo_sessions.dart';
@@ -66,7 +70,7 @@ class AppDatabase extends _$AppDatabase {
   bool get isGuestDatabase => _dbName == guestDatabaseName;
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -74,42 +78,62 @@ class AppDatabase extends _$AppDatabase {
       await m.createAll();
     },
     onUpgrade: (m, from, to) async {
-      if (from == 7 && to == 8) {
+      await _runMigrations(m, from, to);
+    },
+  );
+
+  /// Explicit schema steps — no blanket table drops without [backupToJson].
+  Future<void> _runMigrations(Migrator m, int from, int to) async {
+    if (from >= to) return;
+
+    var current = from;
+    while (current < to) {
+      if (current < 6 && to >= 7) {
+        await backupToJson(m.database, from: current, to: to);
+        await _dropLegacyTables(m);
+        await m.createAll();
+        return;
+      }
+
+      final next = current + 1;
+      if (next == 7) {
+        await m.createTable(youtubeChannelSubscriptions);
+        await m.createTable(youtubeFeedEntries);
+      } else if (next == 8) {
         await m.addColumn(
           youtubeFeedEntries,
           youtubeFeedEntries.durationSeconds,
         );
-        return;
+      } else if (next == 9) {
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_transcript_fetch_states_target '
+          'ON transcript_fetch_states (target_type, target_id)',
+        );
       }
+      current = next;
+    }
+  }
 
-      // v6 → v7 only adds Discover tables; preserve existing library data.
-      if (from >= 6 && to == 7) {
-        await m.createTable(youtubeChannelSubscriptions);
-        await m.createTable(youtubeFeedEntries);
-        return;
-      }
-
-      const tables = <String>[
-        'sync_queue',
-        'dictations',
-        'recordings',
-        'echo_sessions',
-        'transcripts',
-        'transcript_fetch_states',
-        'youtube_feed_entries',
-        'youtube_channel_subscriptions',
-        'videos',
-        'audios',
-        'playback_sessions',
-        'media',
-        'settings',
-      ];
-      for (final name in tables) {
-        await m.database.customStatement('DROP TABLE IF EXISTS $name');
-      }
-      await m.createAll();
-    },
-  );
+  Future<void> _dropLegacyTables(Migrator m) async {
+    const tables = <String>[
+      'sync_queue',
+      'dictations',
+      'recordings',
+      'echo_sessions',
+      'transcripts',
+      'transcript_fetch_states',
+      'youtube_feed_entries',
+      'youtube_channel_subscriptions',
+      'videos',
+      'audios',
+      'playback_sessions',
+      'media',
+      'settings',
+    ];
+    for (final name in tables) {
+      await m.database.customStatement('DROP TABLE IF EXISTS $name');
+    }
+  }
 }
 
 @DriftAccessor(tables: [Videos])
@@ -618,21 +642,38 @@ class SettingsDao extends DatabaseAccessor<AppDatabase>
     with _$SettingsDaoMixin {
   SettingsDao(super.db);
 
+  static final _log = logNamed('SettingsDao');
+
+  void _assertKnownKey(String key) {
+    if (SettingsKeys.isKnown(key)) return;
+    final message = 'Unknown settings key: $key';
+    assert(() {
+      throw StateError(message);
+    }());
+    _log.warning(message);
+  }
+
   Future<String?> getValue(String key) async {
+    _assertKnownKey(key);
     final row = await (select(
       settingsKv,
     )..where((t) => t.key.equals(key))).getSingleOrNull();
     return row?.value;
   }
 
-  Future<void> setValue(String key, String value) => into(settingsKv).insert(
-    SettingRow(key: key, value: value),
-    mode: InsertMode.insertOrReplace,
-  );
+  Future<void> setValue(String key, String value) {
+    _assertKnownKey(key);
+    return into(settingsKv).insert(
+      SettingRow(key: key, value: value),
+      mode: InsertMode.insertOrReplace,
+    );
+  }
 
   /// Removes a key. No-op when the key is absent.
-  Future<void> deleteValue(String key) =>
-      (delete(settingsKv)..where((t) => t.key.equals(key))).go();
+  Future<void> deleteValue(String key) {
+    _assertKnownKey(key);
+    return (delete(settingsKv)..where((t) => t.key.equals(key))).go();
+  }
 }
 
 @DriftAccessor(tables: [YoutubeChannelSubscriptions])

--- a/lib/data/db/app_database.g.dart
+++ b/lib/data/db/app_database.g.dart
@@ -7400,16 +7400,19 @@ class $YoutubeChannelSubscriptionsTable extends YoutubeChannelSubscriptions
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
-  static const VerificationMeta _sourceMeta = const VerificationMeta('source');
   @override
-  late final GeneratedColumn<String> source = GeneratedColumn<String>(
-    'source',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('user'),
-  );
+  late final GeneratedColumnWithTypeConverter<YoutubeSubscriptionSource, String>
+  source =
+      GeneratedColumn<String>(
+        'source',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('user'),
+      ).withConverter<YoutubeSubscriptionSource>(
+        $YoutubeChannelSubscriptionsTable.$convertersource,
+      );
   static const VerificationMeta _subscribedAtMeta = const VerificationMeta(
     'subscribedAt',
   );
@@ -7482,12 +7485,6 @@ class $YoutubeChannelSubscriptionsTable extends YoutubeChannelSubscriptions
         ),
       );
     }
-    if (data.containsKey('source')) {
-      context.handle(
-        _sourceMeta,
-        source.isAcceptableOrUnknown(data['source']!, _sourceMeta),
-      );
-    }
     if (data.containsKey('subscribed_at')) {
       context.handle(
         _subscribedAtMeta,
@@ -7532,10 +7529,12 @@ class $YoutubeChannelSubscriptionsTable extends YoutubeChannelSubscriptions
         DriftSqlType.string,
         data['${effectivePrefix}thumbnail_url'],
       ),
-      source: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}source'],
-      )!,
+      source: $YoutubeChannelSubscriptionsTable.$convertersource.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}source'],
+        )!,
+      ),
       subscribedAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}subscribed_at'],
@@ -7551,6 +7550,11 @@ class $YoutubeChannelSubscriptionsTable extends YoutubeChannelSubscriptions
   $YoutubeChannelSubscriptionsTable createAlias(String alias) {
     return $YoutubeChannelSubscriptionsTable(attachedDatabase, alias);
   }
+
+  static JsonTypeConverter2<YoutubeSubscriptionSource, String, String>
+  $convertersource = const EnumNameConverter<YoutubeSubscriptionSource>(
+    YoutubeSubscriptionSource.values,
+  );
 }
 
 class YoutubeChannelSubscriptionRow extends DataClass
@@ -7559,8 +7563,8 @@ class YoutubeChannelSubscriptionRow extends DataClass
   final String displayName;
   final String? thumbnailUrl;
 
-  /// `recommended` or `user`.
-  final String source;
+  /// Bundled catalog vs user-initiated subscription.
+  final YoutubeSubscriptionSource source;
   final DateTime subscribedAt;
   final DateTime? lastFetchedAt;
   const YoutubeChannelSubscriptionRow({
@@ -7579,7 +7583,11 @@ class YoutubeChannelSubscriptionRow extends DataClass
     if (!nullToAbsent || thumbnailUrl != null) {
       map['thumbnail_url'] = Variable<String>(thumbnailUrl);
     }
-    map['source'] = Variable<String>(source);
+    {
+      map['source'] = Variable<String>(
+        $YoutubeChannelSubscriptionsTable.$convertersource.toSql(source),
+      );
+    }
     map['subscribed_at'] = Variable<DateTime>(subscribedAt);
     if (!nullToAbsent || lastFetchedAt != null) {
       map['last_fetched_at'] = Variable<DateTime>(lastFetchedAt);
@@ -7611,7 +7619,9 @@ class YoutubeChannelSubscriptionRow extends DataClass
       channelId: serializer.fromJson<String>(json['channelId']),
       displayName: serializer.fromJson<String>(json['displayName']),
       thumbnailUrl: serializer.fromJson<String?>(json['thumbnailUrl']),
-      source: serializer.fromJson<String>(json['source']),
+      source: $YoutubeChannelSubscriptionsTable.$convertersource.fromJson(
+        serializer.fromJson<String>(json['source']),
+      ),
       subscribedAt: serializer.fromJson<DateTime>(json['subscribedAt']),
       lastFetchedAt: serializer.fromJson<DateTime?>(json['lastFetchedAt']),
     );
@@ -7623,7 +7633,9 @@ class YoutubeChannelSubscriptionRow extends DataClass
       'channelId': serializer.toJson<String>(channelId),
       'displayName': serializer.toJson<String>(displayName),
       'thumbnailUrl': serializer.toJson<String?>(thumbnailUrl),
-      'source': serializer.toJson<String>(source),
+      'source': serializer.toJson<String>(
+        $YoutubeChannelSubscriptionsTable.$convertersource.toJson(source),
+      ),
       'subscribedAt': serializer.toJson<DateTime>(subscribedAt),
       'lastFetchedAt': serializer.toJson<DateTime?>(lastFetchedAt),
     };
@@ -7633,7 +7645,7 @@ class YoutubeChannelSubscriptionRow extends DataClass
     String? channelId,
     String? displayName,
     Value<String?> thumbnailUrl = const Value.absent(),
-    String? source,
+    YoutubeSubscriptionSource? source,
     DateTime? subscribedAt,
     Value<DateTime?> lastFetchedAt = const Value.absent(),
   }) => YoutubeChannelSubscriptionRow(
@@ -7706,7 +7718,7 @@ class YoutubeChannelSubscriptionsCompanion
   final Value<String> channelId;
   final Value<String> displayName;
   final Value<String?> thumbnailUrl;
-  final Value<String> source;
+  final Value<YoutubeSubscriptionSource> source;
   final Value<DateTime> subscribedAt;
   final Value<DateTime?> lastFetchedAt;
   final Value<int> rowid;
@@ -7754,7 +7766,7 @@ class YoutubeChannelSubscriptionsCompanion
     Value<String>? channelId,
     Value<String>? displayName,
     Value<String?>? thumbnailUrl,
-    Value<String>? source,
+    Value<YoutubeSubscriptionSource>? source,
     Value<DateTime>? subscribedAt,
     Value<DateTime?>? lastFetchedAt,
     Value<int>? rowid,
@@ -7783,7 +7795,9 @@ class YoutubeChannelSubscriptionsCompanion
       map['thumbnail_url'] = Variable<String>(thumbnailUrl.value);
     }
     if (source.present) {
-      map['source'] = Variable<String>(source.value);
+      map['source'] = Variable<String>(
+        $YoutubeChannelSubscriptionsTable.$convertersource.toSql(source.value),
+      );
     }
     if (subscribedAt.present) {
       map['subscribed_at'] = Variable<DateTime>(subscribedAt.value);
@@ -8316,6 +8330,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $YoutubeChannelSubscriptionsTable(this);
   late final $YoutubeFeedEntriesTable youtubeFeedEntries =
       $YoutubeFeedEntriesTable(this);
+  late final Index idxTranscriptFetchStatesTarget = Index(
+    'idx_transcript_fetch_states_target',
+    'CREATE INDEX idx_transcript_fetch_states_target ON transcript_fetch_states (target_type, target_id)',
+  );
   late final VideoDao videoDao = VideoDao(this as AppDatabase);
   late final AudioDao audioDao = AudioDao(this as AppDatabase);
   late final TranscriptDao transcriptDao = TranscriptDao(this as AppDatabase);
@@ -8349,6 +8367,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     settingsKv,
     youtubeChannelSubscriptions,
     youtubeFeedEntries,
+    idxTranscriptFetchStatesTarget,
   ];
 }
 
@@ -11770,7 +11789,7 @@ typedef $$YoutubeChannelSubscriptionsTableCreateCompanionBuilder =
       required String channelId,
       required String displayName,
       Value<String?> thumbnailUrl,
-      Value<String> source,
+      Value<YoutubeSubscriptionSource> source,
       required DateTime subscribedAt,
       Value<DateTime?> lastFetchedAt,
       Value<int> rowid,
@@ -11780,7 +11799,7 @@ typedef $$YoutubeChannelSubscriptionsTableUpdateCompanionBuilder =
       Value<String> channelId,
       Value<String> displayName,
       Value<String?> thumbnailUrl,
-      Value<String> source,
+      Value<YoutubeSubscriptionSource> source,
       Value<DateTime> subscribedAt,
       Value<DateTime?> lastFetchedAt,
       Value<int> rowid,
@@ -11810,9 +11829,14 @@ class $$YoutubeChannelSubscriptionsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
-  ColumnFilters<String> get source => $composableBuilder(
+  ColumnWithTypeConverterFilters<
+    YoutubeSubscriptionSource,
+    YoutubeSubscriptionSource,
+    String
+  >
+  get source => $composableBuilder(
     column: $table.source,
-    builder: (column) => ColumnFilters(column),
+    builder: (column) => ColumnWithTypeConverterFilters(column),
   );
 
   ColumnFilters<DateTime> get subscribedAt => $composableBuilder(
@@ -11888,7 +11912,8 @@ class $$YoutubeChannelSubscriptionsTableAnnotationComposer
     builder: (column) => column,
   );
 
-  GeneratedColumn<String> get source =>
+  GeneratedColumnWithTypeConverter<YoutubeSubscriptionSource, String>
+  get source =>
       $composableBuilder(column: $table.source, builder: (column) => column);
 
   GeneratedColumn<DateTime> get subscribedAt => $composableBuilder(
@@ -11951,7 +11976,7 @@ class $$YoutubeChannelSubscriptionsTableTableManager
                 Value<String> channelId = const Value.absent(),
                 Value<String> displayName = const Value.absent(),
                 Value<String?> thumbnailUrl = const Value.absent(),
-                Value<String> source = const Value.absent(),
+                Value<YoutubeSubscriptionSource> source = const Value.absent(),
                 Value<DateTime> subscribedAt = const Value.absent(),
                 Value<DateTime?> lastFetchedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -11969,7 +11994,7 @@ class $$YoutubeChannelSubscriptionsTableTableManager
                 required String channelId,
                 required String displayName,
                 Value<String?> thumbnailUrl = const Value.absent(),
-                Value<String> source = const Value.absent(),
+                Value<YoutubeSubscriptionSource> source = const Value.absent(),
                 required DateTime subscribedAt,
                 Value<DateTime?> lastFetchedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),

--- a/lib/data/db/app_database_provider.g.dart
+++ b/lib/data/db/app_database_provider.g.dart
@@ -107,4 +107,4 @@ final class AppDatabaseProvider
   }
 }
 
-String _$appDatabaseHash() => r'ec9eb870c22325bd0a8b152e5c9ed637e9a4837a';
+String _$appDatabaseHash() => r'346e988ff0ac0912b80f71c798a25b8b2d540b02';

--- a/lib/data/db/migration_backup.dart
+++ b/lib/data/db/migration_backup.dart
@@ -1,0 +1,107 @@
+/// JSON backup of Drift tables before destructive schema upgrades.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'package:enjoy_player/core/logging/log.dart';
+
+final _log = logNamed('db.migration_backup');
+
+/// Tables exported before a destructive migration (includes legacy names).
+const migrationBackupTableNames = <String>[
+  'videos',
+  'audios',
+  'transcripts',
+  'transcript_fetch_states',
+  'echo_sessions',
+  'recordings',
+  'dictations',
+  'sync_queue',
+  'settings',
+  'youtube_channel_subscriptions',
+  'youtube_feed_entries',
+  'playback_sessions',
+  'media',
+];
+
+/// Serializes every known table to JSON under
+/// `app_support/migrations/<from>_to_<to>_<timestamp>.json`.
+///
+/// Returns the absolute backup path, or `null` when the write failed.
+Future<String?> backupToJson(
+  GeneratedDatabase db, {
+  required int from,
+  required int to,
+}) async {
+  try {
+    final support = await getApplicationSupportDirectory();
+    final backupDir = Directory(p.join(support.path, 'migrations'));
+    if (!backupDir.existsSync()) {
+      await backupDir.create(recursive: true);
+    }
+
+    final stamp = DateTime.now().toUtc().toIso8601String().replaceAll(':', '-');
+    final fileName = '${from}_to_${to}_$stamp.json';
+    final dest = File(p.join(backupDir.path, fileName));
+
+    final payload = <String, dynamic>{
+      'schemaFrom': from,
+      'schemaTo': to,
+      'exportedAt': DateTime.now().toUtc().toIso8601String(),
+      'tables': <String, dynamic>{},
+    };
+
+    for (final tableName in migrationBackupTableNames) {
+      payload['tables'][tableName] = await _exportTable(db, tableName);
+    }
+
+    await dest.writeAsString(
+      const JsonEncoder.withIndent('  ').convert(_jsonify(payload)),
+    );
+    _log.warning(
+      'backupToJson: wrote ${dest.path} before destructive migration '
+      '($from → $to)',
+    );
+    return dest.path;
+  } catch (e, st) {
+    _log.warning('backupToJson failed ($from → $to)', e, st);
+    return null;
+  }
+}
+
+Future<Map<String, dynamic>> _exportTable(
+  GeneratedDatabase db,
+  String tableName,
+) async {
+  try {
+    final rows = await db
+        .customSelect('SELECT * FROM $tableName')
+        .get();
+    return {
+      'rowCount': rows.length,
+      'rows': rows.map((row) => row.data).toList(growable: false),
+    };
+  } catch (e, st) {
+    _log.fine('backupToJson: skip missing table $tableName', e, st);
+    return {'rowCount': 0, 'rows': <Map<String, dynamic>>[], 'missing': true};
+  }
+}
+
+Object? _jsonify(Object? value) {
+  if (value == null) return null;
+  if (value is DateTime) return value.toUtc().toIso8601String();
+  if (value is Map) {
+    return value.map(
+      (key, nested) => MapEntry(key.toString(), _jsonify(nested)),
+    );
+  }
+  if (value is List) {
+    return value.map(_jsonify).toList(growable: false);
+  }
+  return value;
+}

--- a/lib/data/db/settings_keys.dart
+++ b/lib/data/db/settings_keys.dart
@@ -50,6 +50,40 @@ abstract final class SettingsKeys {
 
   /// When `true`, allowlisted diagnostic loggers write FINE records to the log file.
   static const String diagnosticsVerboseEnabled = 'diagnostics.verbose_enabled';
+
+  /// JSON blob: volume, rate, repeat, split width ([PlayerPreferencesCtrl]).
+  static const String playerPreferencesV1 = 'player_preferences_v1';
+
+  /// JSON map of custom hotkey action id → binding string.
+  static const String hotkeysCustomBindings = 'hotkeys_custom_bindings';
+
+  static const _staticKeys = {
+    apiBaseUrl,
+    apiAiBaseUrl,
+    prefsLocale,
+    prefsLearningLanguage,
+    prefsNativeLanguage,
+    prefsRecordingInputDeviceId,
+    syncCursorAudio,
+    syncCursorVideo,
+    syncCursorRecording,
+    syncLastFullSyncAt,
+    migrationGuestDismissed,
+    updateLastCheckAt,
+    updateSnoozeUntil,
+    updateSnoozeVersion,
+    diagnosticsVerboseEnabled,
+    playerPreferencesV1,
+    hotkeysCustomBindings,
+  };
+
+  /// Whether [key] is a known static or dynamic settings key.
+  static bool isKnown(String key) {
+    if (_staticKeys.contains(key)) return true;
+    if (key.startsWith('sync.cursor.recording.')) return true;
+    if (key.startsWith('sync.last_pull_at.recording.')) return true;
+    return false;
+  }
 }
 
 /// Default Enjoy API origin (no trailing slash).

--- a/lib/data/db/tables/transcript_fetch_states.dart
+++ b/lib/data/db/tables/transcript_fetch_states.dart
@@ -3,6 +3,10 @@ library;
 
 import 'package:drift/drift.dart';
 
+@TableIndex(
+  name: 'idx_transcript_fetch_states_target',
+  columns: {#targetType, #targetId},
+)
 @DataClassName('TranscriptFetchStateRow')
 class TranscriptFetchStates extends Table {
   @override

--- a/lib/data/db/tables/youtube_channel_subscriptions.dart
+++ b/lib/data/db/tables/youtube_channel_subscriptions.dart
@@ -3,6 +3,8 @@ library;
 
 import 'package:drift/drift.dart';
 
+import '../youtube_subscription_source.dart';
+
 @DataClassName('YoutubeChannelSubscriptionRow')
 class YoutubeChannelSubscriptions extends Table {
   @override
@@ -12,8 +14,10 @@ class YoutubeChannelSubscriptions extends Table {
   TextColumn get displayName => text()();
   TextColumn get thumbnailUrl => text().nullable()();
 
-  /// `recommended` or `user`.
-  TextColumn get source => text().withDefault(const Constant('user'))();
+  /// Bundled catalog vs user-initiated subscription.
+  TextColumn get source => textEnum<YoutubeSubscriptionSource>().withDefault(
+    const Constant('user'),
+  )();
 
   DateTimeColumn get subscribedAt => dateTime()();
   DateTimeColumn get lastFetchedAt => dateTime().nullable()();

--- a/lib/data/db/youtube_subscription_source.dart
+++ b/lib/data/db/youtube_subscription_source.dart
@@ -1,0 +1,11 @@
+/// How a YouTube channel subscription was added in Discover.
+library;
+
+/// Stored in Drift as the enum name (`recommended`, `user`).
+enum YoutubeSubscriptionSource {
+  /// Bundled recommended catalog.
+  recommended,
+
+  /// User pasted a URL, @handle, or channel id.
+  user,
+}

--- a/lib/features/auth/application/auth_controller.g.dart
+++ b/lib/features/auth/application/auth_controller.g.dart
@@ -33,7 +33,7 @@ final class AuthCtrlProvider
   AuthCtrl create() => AuthCtrl();
 }
 
-String _$authCtrlHash() => r'f41e57e4daf352abe939a6dc47406828641ff30b';
+String _$authCtrlHash() => r'93a0e389f787128195699465cddffe6f4bb96ead';
 
 abstract class _$AuthCtrl extends $AsyncNotifier<AuthState> {
   FutureOr<AuthState> build();

--- a/lib/features/discover/application/discover_providers.g.dart
+++ b/lib/features/discover/application/discover_providers.g.dart
@@ -487,7 +487,7 @@ final class DiscoverFeedRefreshSchedulerProvider
 }
 
 String _$discoverFeedRefreshSchedulerHash() =>
-    r'6fac9d694011145b3f4b3cdcee3d5e50dd470d45';
+    r'32d18862fc0c280a7c50f583221294b27353805a';
 
 abstract class _$DiscoverFeedRefreshScheduler extends $Notifier<int> {
   int build();

--- a/lib/features/discover/data/discover_repository.dart
+++ b/lib/features/discover/data/discover_repository.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/utils/stream_distinct.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/features/library/data/library_repository.dart';
 import 'package:http/http.dart' as http;
 
@@ -127,7 +128,7 @@ class DiscoverRepository {
     await subscribeChannel(
       channelId: channel.channelId,
       displayName: channel.name,
-      source: 'recommended',
+      source: YoutubeSubscriptionSource.recommended,
     );
   }
 
@@ -140,14 +141,14 @@ class DiscoverRepository {
     await subscribeChannel(
       channelId: resolved.channelId,
       displayName: displayName,
-      source: 'user',
+      source: YoutubeSubscriptionSource.user,
     );
   }
 
   Future<void> subscribeChannel({
     required String channelId,
     required String displayName,
-    required String source,
+    required YoutubeSubscriptionSource source,
     String? thumbnailUrl,
   }) async {
     final existing = await _db.youtubeChannelSubscriptionDao.getByChannelId(

--- a/lib/features/discover/domain/discover_channel.dart
+++ b/lib/features/discover/domain/discover_channel.dart
@@ -1,6 +1,8 @@
 /// Domain model for a subscribed or recommended YouTube channel.
 library;
 
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
+
 class DiscoverChannel {
   const DiscoverChannel({
     required this.channelId,
@@ -15,8 +17,8 @@ class DiscoverChannel {
   final String displayName;
   final String? thumbnailUrl;
 
-  /// `recommended` or `user`.
-  final String source;
+  /// Bundled catalog vs user-initiated subscription.
+  final YoutubeSubscriptionSource source;
   final DateTime subscribedAt;
   final DateTime? lastFetchedAt;
 

--- a/lib/features/player/application/player_controller.g.dart
+++ b/lib/features/player/application/player_controller.g.dart
@@ -41,7 +41,7 @@ final class PlayerControllerProvider
   }
 }
 
-String _$playerControllerHash() => r'096275a3a9942413ccabe3780c2e5565a2f013b9';
+String _$playerControllerHash() => r'97797ff31fb18b999ff413e8e9af1f9b2623c61c';
 
 abstract class _$PlayerController extends $Notifier<PlaybackSession?> {
   PlaybackSession? build();

--- a/lib/features/sync/application/sync_controller.g.dart
+++ b/lib/features/sync/application/sync_controller.g.dart
@@ -40,7 +40,7 @@ final class SyncCtrlProvider extends $NotifierProvider<SyncCtrl, int> {
   }
 }
 
-String _$syncCtrlHash() => r'b35eed6e7846177a626c3292bdd192d5714deb28';
+String _$syncCtrlHash() => r'53440d20f393238590408a65191ba130d7cef4d1';
 
 abstract class _$SyncCtrl extends $Notifier<int> {
   int build();

--- a/test/data/db/app_database_test.dart
+++ b/test/data/db/app_database_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/settings_keys.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -37,5 +38,31 @@ void main() {
     final row = await db.audioDao.getById(id);
     expect(row, isNotNull);
     expect(row!.title, 'Test');
+  });
+
+  test('SettingsDao rejects unknown keys in debug mode', () async {
+    final db = AppDatabase(executor: NativeDatabase.memory());
+    addTearDown(db.close);
+
+    expect(
+      () => db.settingsDao.setValue('loacle', 'en'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('SettingsKeys recognizes dynamic recording cursor keys', () {
+    expect(
+      SettingsKeys.isKnown(
+        SettingsKeys.syncCursorRecordingTarget('Video', 'abc'),
+      ),
+      isTrue,
+    );
+    expect(
+      SettingsKeys.isKnown(
+        SettingsKeys.syncLastPullAtRecordingTarget('Audio', 'xyz'),
+      ),
+      isTrue,
+    );
+    expect(SettingsKeys.isKnown('totally.unknown.key'), isFalse);
   });
 }

--- a/test/features/auth/guest_migration_discover_test.dart
+++ b/test/features/auth/guest_migration_discover_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/application/guest_migration_providers.dart';
@@ -30,7 +31,7 @@ void main() {
         YoutubeChannelSubscriptionRow(
           channelId: channelId,
           displayName: 'TED',
-          source: 'recommended',
+          source: YoutubeSubscriptionSource.recommended,
           subscribedAt: now,
           lastFetchedAt: now,
         ),

--- a/test/features/discover/discover_dedupe_test.dart
+++ b/test/features/discover/discover_dedupe_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:drift/native.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/features/discover/data/discover_repository.dart';
 import 'package:enjoy_player/features/discover/domain/discover_channel.dart';
 import 'package:enjoy_player/features/discover/domain/feed_entry.dart';
@@ -57,7 +58,7 @@ void main() {
         channelId: 'c1',
         displayName: 'Channel',
         thumbnailUrl: 'http://example.com/a.jpg',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
         subscribedAt: subscribedAt,
         lastFetchedAt: fetchedAt,
       );
@@ -65,7 +66,7 @@ void main() {
         channelId: 'c1',
         displayName: 'Channel',
         thumbnailUrl: 'http://example.com/a.jpg',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
         subscribedAt: subscribedAt,
         lastFetchedAt: fetchedAt,
       );
@@ -73,7 +74,7 @@ void main() {
         channelId: 'c1',
         displayName: 'Channel renamed',
         thumbnailUrl: 'http://example.com/a.jpg',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
         subscribedAt: subscribedAt,
         lastFetchedAt: fetchedAt,
       );
@@ -102,7 +103,7 @@ void main() {
       await repo.subscribeChannel(
         channelId: channelId,
         displayName: 'TED',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
       );
 
       final emissions = <List<DiscoverChannel>>[];
@@ -141,7 +142,7 @@ void main() {
       await repo.subscribeChannel(
         channelId: channelId,
         displayName: 'TED',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
       );
 
       final emissions = <List<DiscoverChannel>>[];

--- a/test/features/discover/discover_horizontal_strips_test.dart
+++ b/test/features/discover/discover_horizontal_strips_test.dart
@@ -1,4 +1,5 @@
 import 'package:enjoy_player/core/interaction/horizontal_drag_scroll_behavior.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/features/discover/application/discover_providers.dart';
 import 'package:enjoy_player/features/discover/domain/discover_channel.dart';
 import 'package:enjoy_player/features/discover/domain/recommended_channel.dart';
@@ -85,7 +86,7 @@ void main() {
         DiscoverChannel(
           channelId: _channelId,
           displayName: 'TED',
-          source: 'recommended',
+          source: YoutubeSubscriptionSource.recommended,
           subscribedAt: subscribedAt,
         ),
       ];

--- a/test/features/discover/discover_repository_test.dart
+++ b/test/features/discover/discover_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:enjoy_player/data/files/file_storage.dart';
 import 'package:enjoy_player/features/discover/data/discover_repository.dart';
 import 'package:enjoy_player/features/discover/data/youtube_fetch.dart';
 import 'package:enjoy_player/features/discover/data/youtube_rss_parser.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/features/discover/domain/feed_entry.dart';
 import 'package:enjoy_player/features/library/data/library_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -53,7 +54,7 @@ void main() {
       await repo.subscribeChannel(
         channelId: 'UCAuUUnT6oDeKwE6v1NGQxug',
         displayName: 'TED',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
       );
 
       final result = await repo.refreshFeeds(force: true);
@@ -75,7 +76,7 @@ void main() {
           YoutubeChannelSubscriptionRow(
             channelId: channelId,
             displayName: 'TED',
-            source: 'recommended',
+            source: YoutubeSubscriptionSource.recommended,
             subscribedAt: subscribedAt,
             lastFetchedAt: fetchedAt,
           ),
@@ -84,7 +85,7 @@ void main() {
         await repo.subscribeChannel(
           channelId: channelId,
           displayName: 'TED Talks',
-          source: 'user',
+          source: YoutubeSubscriptionSource.user,
         );
 
         final row = await db.youtubeChannelSubscriptionDao.getByChannelId(
@@ -101,7 +102,7 @@ void main() {
       await repo.subscribeChannel(
         channelId: channelId,
         displayName: 'TED',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
       );
       await db.youtubeFeedEntryDao.upsertEntry(
         YoutubeFeedEntryRow(
@@ -126,7 +127,7 @@ void main() {
       await repo.subscribeChannel(
         channelId: oldId,
         displayName: 'TED',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
       );
 
       final result = await repo.refreshFeeds(force: true);
@@ -148,7 +149,7 @@ void main() {
       await repo.subscribeChannel(
         channelId: channelId,
         displayName: 'TED',
-        source: 'recommended',
+        source: YoutubeSubscriptionSource.recommended,
       );
       await db.youtubeFeedEntryDao.upsertEntry(
         YoutubeFeedEntryRow(

--- a/test/features/discover/discover_subscribe_actions_test.dart
+++ b/test/features/discover/discover_subscribe_actions_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/native.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
 import 'package:enjoy_player/features/discover/application/discover_providers.dart';
 import 'package:enjoy_player/features/discover/data/discover_repository.dart';
@@ -98,7 +99,7 @@ void main() {
       );
       expect(row, isNotNull);
       expect(row!.displayName, 'TED');
-      expect(row.source, 'recommended');
+      expect(row.source, YoutubeSubscriptionSource.recommended);
 
       expect(find.text('Subscribed to channel'), findsOneWidget);
     });

--- a/test/features/discover/discover_subscribe_sheet_test.dart
+++ b/test/features/discover/discover_subscribe_sheet_test.dart
@@ -2,6 +2,7 @@ import 'package:drift/native.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/features/discover/application/discover_providers.dart';
 import 'package:enjoy_player/features/discover/data/discover_repository.dart';
 import 'package:enjoy_player/features/discover/presentation/discover_subscribe_sheet.dart';
@@ -173,7 +174,7 @@ void main() {
         _channelId,
       );
       expect(row, isNotNull);
-      expect(row!.source, 'user');
+      expect(row!.source, YoutubeSubscriptionSource.user);
     });
   });
 }

--- a/test/features/discover/discover_subscription_ui_test.dart
+++ b/test/features/discover/discover_subscription_ui_test.dart
@@ -1,4 +1,5 @@
 import 'package:enjoy_player/features/discover/application/discover_providers.dart';
+import 'package:enjoy_player/data/db/youtube_subscription_source.dart';
 import 'package:enjoy_player/features/discover/domain/discover_channel.dart';
 import 'package:enjoy_player/features/discover/domain/recommended_channel.dart';
 import 'package:enjoy_player/features/discover/presentation/discover_recommended_channel_card.dart';
@@ -16,7 +17,7 @@ void main() {
   final subscribedChannel = DiscoverChannel(
     channelId: 'UCtestchannel0001',
     displayName: 'TED',
-    source: 'recommended',
+    source: YoutubeSubscriptionSource.recommended,
     subscribedAt: subscribedAt,
   );
 


### PR DESCRIPTION
## Summary

- Replace the blanket pre-v6 `onUpgrade` table drop with an explicit migration chain (v7 discover tables, v8 feed duration column, v9 transcript fetch index).
- Export JSON backups via `backupToJson` to `app_support/migrations/<from>_to_<to>_<timestamp>.json` before any destructive upgrade from schema versions below 6.
- Add `@TableIndex` on `transcript_fetch_states(target_type, target_id)` and bump schema to v9.
- Promote `youtube_channel_subscriptions.source` to typed `YoutubeSubscriptionSource` Drift enum (`recommended`, `user`).
- Validate `settingsKv` keys in `SettingsDao` (assert in debug, log warning in release) with an expanded known-key registry.

Closes #102.

## Test plan

- [x] `flutter analyze` (no errors)
- [x] `flutter test` — 515 passed, 1 pre-existing flake in `library_media_provider_test` (also fails on `main`)
- [x] Discover + guest migration tests updated for enum source
- [x] New tests for unknown settings key rejection and dynamic cursor key recognition
