### PR TITLE
Add coverage CI gate and expand test coverage (fixes #109)

### DIFF
--- a/.github/scripts/check_coverage_gate.sh
+++ b/.github/scripts/check_coverage_gate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Fail when line coverage in coverage/lcov.info drops below MIN_COVERAGE (percent).
+set -euo pipefail
+
+LCOV="${1:-coverage/lcov.info}"
+MIN_COVERAGE="${MIN_COVERAGE:-32}"
+
+if [[ ! -f "$LCOV" ]]; then
+  echo "Coverage gate: missing $LCOV (run flutter test --coverage first)" >&2
+  exit 1
+fi
+
+read -r LF LH <<<"$(awk '
+  /^LF:/ { lf += substr($0, 4) + 0 }
+  /^LH:/ { lh += substr($0, 4) + 0 }
+  END { printf "%d %d", lf, lh }
+' "$LCOV")"
+
+if [[ "$LF" -eq 0 ]]; then
+  echo "Coverage gate: no line records in $LCOV" >&2
+  exit 1
+fi
+
+pct="$(awk -v lh="$LH" -v lf="$LF" 'BEGIN { printf "%.2f", 100 * lh / lf }')"
+echo "Coverage gate: ${LH}/${LF} lines (${pct}%) — minimum ${MIN_COVERAGE}%"
+
+awk -v pct="$pct" -v min="$MIN_COVERAGE" 'BEGIN { exit (pct + 0 >= min + 0) ? 0 : 1 }' || {
+  echo "Coverage gate FAILED: ${pct}% is below ${MIN_COVERAGE}%" >&2
+  exit 1
+}
+
+echo "Coverage gate passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,17 @@ jobs:
       - name: Flutter analyze
         run: flutter analyze
 
-      - name: Flutter test (app)
-        run: flutter test
+      - name: Flutter test (app, with coverage)
+        run: flutter test --coverage
+
+      - name: Coverage gate (line baseline)
+        run: bash .github/scripts/check_coverage_gate.sh coverage/lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/lcov.info
+          fail_ci_if_error: false
 
       - name: Flutter test (path packages)
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 32%
+        threshold: 0%
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "**/*.g.dart"
+  - "**/*.freezed.dart"
+  - "lib/l10n/**"
+  - "packages/**"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,8 +4,17 @@
 
 ```bash
 flutter test
+flutter test --coverage
 flutter analyze
 ```
+
+After generating coverage, enforce the CI baseline locally:
+
+```bash
+bash .github/scripts/check_coverage_gate.sh coverage/lcov.info
+```
+
+CI uploads `coverage/lcov.info` to [Codecov](https://codecov.io) and fails when line coverage drops below the recorded baseline (see `MIN_COVERAGE` in `.github/scripts/check_coverage_gate.sh`, currently **32%**).
 
 ## Layout
 
@@ -18,6 +27,10 @@ flutter analyze
 | Transcript lines provider | `test/features/transcript/transcript_lines_provider_test.dart` |
 | File import (streaming hash) | `test/data/files/file_storage_test.dart` |
 | Subtitle parsers | `test/data/subtitle/subtitle_parser_test.dart` |
+| Sync queue + retry backoff | `test/features/sync/sync_queue_repository_test.dart`, `test/features/sync/sync_engine_test.dart` |
+| Azure WAV normalization | `test/features/ai/azure_assessment_wav_normalizer_test.dart` |
+| Echo PCM extraction guards | `test/features/shadow_reading/echo_segment_pcm_extractor_test.dart` |
+| App smoke (EnjoyApp) | `test/widget_test.dart` |
 | Drift smoke | `test/data/db/app_database_test.dart` |
 
 ## Pre-release (platform compile)

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -23,7 +23,11 @@ import 'package:enjoy_player/features/update/presentation/update_prompt_host.dar
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 class EnjoyApp extends ConsumerStatefulWidget {
-  const EnjoyApp({super.key});
+  const EnjoyApp({super.key, @visibleForTesting this.themeBuilder});
+
+  /// When set (widget tests only), skips [buildAppTheme] / Google Fonts fetches.
+  @visibleForTesting
+  final ThemeData Function()? themeBuilder;
 
   @override
   ConsumerState<EnjoyApp> createState() => _EnjoyAppState();
@@ -117,7 +121,7 @@ class _EnjoyAppState extends ConsumerState<EnjoyApp> {
 
     final router = ref.watch(appRouterProvider);
     final prefsAsync = ref.watch(appPreferencesCtrlProvider);
-    final theme = buildAppTheme();
+    final theme = widget.themeBuilder?.call() ?? buildAppTheme();
 
     final live = prefsAsync.valueOrNull;
     final effective = live ?? _lastResolvedPrefs;

--- a/test/data/subtitle/subtitle_parser_test.dart
+++ b/test/data/subtitle/subtitle_parser_test.dart
@@ -16,6 +16,42 @@ Hello world
       expect(lines.first.startMs, 1000);
       expect(lines.first.durationMs, 2500);
     });
+
+    test('skips zero-duration cues', () {
+      const srt = '''
+1
+00:00:00,000 --> 00:00:00,000
+Zero length
+
+2
+00:00:01,000 --> 00:00:02,000
+Valid
+
+''';
+      final lines = const SrtParser().parse(srt);
+      expect(lines, hasLength(1));
+      expect(lines.single.text, 'Valid');
+    });
+
+    test('ignores malformed timestamp lines', () {
+      const srt = '''
+1
+not-a-timestamp
+Still here
+
+2
+00:00:01,000 --> 00:00:02,000
+Valid
+
+''';
+      final lines = const SrtParser().parse(srt);
+      expect(lines, hasLength(1));
+      expect(lines.single.text, 'Valid');
+    });
+
+    test('returns empty list for garbage input', () {
+      expect(const SrtParser().parse('@@@\n###\n'), isEmpty);
+    });
   });
 
   group('VttParser', () {
@@ -33,11 +69,104 @@ Hello
       expect(lines.first.startMs, 1000);
       expect(lines.first.durationMs, 1000);
     });
+
+    test('parses cue identifier before the timestamp', () {
+      const vtt = '''
+WEBVTT
+
+intro
+00:00:01.000 --> 00:00:02.000
+Hello
+
+''';
+      final lines = const VttParser().parse(vtt);
+      expect(lines, hasLength(1));
+      expect(lines.single.text, 'Hello');
+    });
+
+    test('skips NOTE blocks', () {
+      const vtt = '''
+WEBVTT
+
+NOTE
+This is a comment
+ spanning lines
+
+00:00:01.000 --> 00:00:02.000
+After note
+
+''';
+      final lines = const VttParser().parse(vtt);
+      expect(lines, hasLength(1));
+      expect(lines.single.text, 'After note');
+    });
+
+    test('skips zero-duration cues', () {
+      const vtt = '''
+WEBVTT
+
+00:00:00.000 --> 00:00:00.000
+Zero
+
+00:00:01.000 --> 00:00:02.000
+Valid
+
+''';
+      final lines = const VttParser().parse(vtt);
+      expect(lines, hasLength(1));
+      expect(lines.single.text, 'Valid');
+    });
+
+    test('strips inline HTML-like tags', () {
+      const vtt = '''
+WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+<c.bold>Bold</c> plain
+
+''';
+      final lines = const VttParser().parse(vtt);
+      expect(lines.single.text, 'Bold plain');
+    });
+  });
+
+  group('SubtitleParserFacade', () {
+    test('routes by filename extension', () {
+      const facade = SubtitleParserFacade();
+      const srt = '''
+1
+00:00:01,000 --> 00:00:02,000
+From SRT
+
+''';
+      const vtt = '''
+WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+From VTT
+
+''';
+      expect(
+        facade.parseWithHint(srt, fileName: 'clip.srt').single.text,
+        'From SRT',
+      );
+      expect(
+        facade.parseWithHint(vtt, fileName: 'clip.vtt').single.text,
+        'From VTT',
+      );
+    });
   });
 
   test('BOM and CRLF in SRT', () {
     const srt = '\uFEFF1\r\n00:00:00,000 --> 00:00:01,000\r\nA\r\n\r\n';
     final lines = const SrtParser().parse(srt);
     expect(lines.single.text, 'A');
+  });
+
+  test('BOM in WebVTT', () {
+    const vtt =
+        '\uFEFFWEBVTT\r\n\r\n00:00:00.000 --> 00:00:01.000\r\nB\r\n\r\n';
+    final lines = const VttParser().parse(vtt);
+    expect(lines.single.text, 'B');
   });
 }

--- a/test/features/ai/azure_assessment_wav_normalizer_test.dart
+++ b/test/features/ai/azure_assessment_wav_normalizer_test.dart
@@ -1,0 +1,37 @@
+import 'package:enjoy_player/features/ai/data/azure_assessment_wav_normalizer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('normalizeWavForAzureAssessment', () {
+    test('returns false for empty input path', () async {
+      expect(
+        await normalizeWavForAzureAssessment(
+          inputPath: '   ',
+          outputWavPath: '/tmp/out.wav',
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when input file does not exist', () async {
+      expect(
+        await normalizeWavForAzureAssessment(
+          inputPath: '/nonexistent/azure_input.wav',
+          outputWavPath: '/tmp/azure_out.wav',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('tryCreateNormalizedAzureAssessmentWav', () {
+    test('returns null when normalization fails', () async {
+      final result = await tryCreateNormalizedAzureAssessmentWav(
+        '/nonexistent/recording.wav',
+      );
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/features/ai/azure_token_cache_dedup_test.dart
+++ b/test/features/ai/azure_token_cache_dedup_test.dart
@@ -127,5 +127,17 @@ void main() {
       }
       expect(n, 2, reason: 'second call should retry after a failure');
     });
+
+    test('throws when token or region is missing from the response', () async {
+      final api = _FakeAzureTokenApi(
+        () async => <String, dynamic>{'token': '', 'region': 'westus'},
+      );
+      final cache = AzureTokenCache(api: api);
+
+      expect(
+        () => cache.getToken(durationSeconds: 30),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 }

--- a/test/features/shadow_reading/echo_segment_pcm_extractor_test.dart
+++ b/test/features/shadow_reading/echo_segment_pcm_extractor_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:enjoy_player/features/shadow_reading/data/echo_segment_pcm_extractor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../../support/test_path_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late PathProviderPlatform originalPathProvider;
+  late Directory tempRoot;
+
+  setUp(() {
+    originalPathProvider = PathProviderPlatform.instance;
+    tempRoot = Directory.systemTemp.createTempSync('echo_pcm_test');
+    PathProviderPlatform.instance = TestPathProvider(tempRoot.path);
+  });
+
+  tearDown(() {
+    PathProviderPlatform.instance = originalPathProvider;
+    if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+  });
+
+  group('extractMonoFloat32Segment', () {
+    test('returns null for non-positive duration', () async {
+      expect(
+        await extractMonoFloat32Segment(
+          mediaFilePath: '/tmp/media.mp3',
+          startSec: 0,
+          durationSec: 0,
+        ),
+        isNull,
+      );
+      expect(
+        await extractMonoFloat32Segment(
+          mediaFilePath: '/tmp/media.mp3',
+          startSec: 1,
+          durationSec: -1,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for blank media path', () async {
+      expect(
+        await extractMonoFloat32Segment(
+          mediaFilePath: '  ',
+          startSec: 0,
+          durationSec: 1,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('extractEntireFileMonoF32', () {
+    test('returns null for blank media path', () async {
+      expect(await extractEntireFileMonoF32(''), isNull);
+      expect(await extractEntireFileMonoF32('   '), isNull);
+    });
+
+    test('returns null when media file is missing', () async {
+      expect(
+        await extractEntireFileMonoF32('/nonexistent/echo_recording.wav'),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/sync/sync_engine_test.dart
+++ b/test/features/sync/sync_engine_test.dart
@@ -1,0 +1,82 @@
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/features/sync/application/sync_engine.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+SyncQueueRow _row({
+  required int id,
+  int retryCount = 0,
+  DateTime? lastAttempt,
+}) {
+  return SyncQueueRow(
+    id: id,
+    entityType: 'audio',
+    entityId: 'a1',
+    action: 'create',
+    payloadJson: '{}',
+    createdAt: DateTime(2026, 1, 1),
+    retryCount: retryCount,
+    lastAttempt: lastAttempt,
+    error: null,
+  );
+}
+
+void main() {
+  group('shouldRetryQueueItem', () {
+    test('allows first attempt when lastAttempt is null', () {
+      expect(shouldRetryQueueItem(_row(id: 1)), isTrue);
+    });
+
+    test('blocks permanently failed rows (retryCount >= 5)', () {
+      expect(
+        shouldRetryQueueItem(_row(id: 1, retryCount: 5)),
+        isFalse,
+      );
+    });
+
+    test('applies exponential backoff from lastAttempt', () {
+      final now = DateTime.now();
+      // retryCount 1 → delay 2000 ms
+      expect(
+        shouldRetryQueueItem(
+          _row(id: 1, retryCount: 1, lastAttempt: now),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldRetryQueueItem(
+          _row(
+            id: 1,
+            retryCount: 1,
+            lastAttempt: now.subtract(const Duration(seconds: 3)),
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('backoff doubles with each retryCount', () {
+      final now = DateTime.now();
+      // retryCount 2 → delay 4000 ms
+      expect(
+        shouldRetryQueueItem(
+          _row(
+            id: 1,
+            retryCount: 2,
+            lastAttempt: now.subtract(const Duration(seconds: 3)),
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldRetryQueueItem(
+          _row(
+            id: 1,
+            retryCount: 2,
+            lastAttempt: now.subtract(const Duration(seconds: 5)),
+          ),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/sync/sync_queue_repository_test.dart
+++ b/test/features/sync/sync_queue_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show driftRuntimeOptions;
 import 'package:drift/native.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/features/sync/data/sync_queue_repository.dart';
@@ -52,13 +53,10 @@ void main() {
         action: 'create',
         payloadJson: '{"x":1}',
       );
-      // Drive the row to permanent failure (5 failed attempts).
       for (var i = 0; i < 5; i++) {
         await db.syncQueueDao.markAttempted(id, error: 'fail $i');
       }
 
-      // Editing the entity updates the payload but does NOT reset the
-      // retry budget.
       final id2 = await repo.addOrUpsert(
         entityType: 'audio',
         entityId: 'a1',
@@ -104,4 +102,113 @@ void main() {
       expect(row.lastAttempt, isNull);
     },
   );
+
+  test('addOrUpsert is idempotent for the same composite key', () async {
+    final db = AppDatabase(executor: NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = SyncQueueRepository(db);
+
+    final id1 = await repo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'a1',
+      action: 'create',
+      payloadJson: '{"v":1}',
+    );
+    final id2 = await repo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'a1',
+      action: 'create',
+      payloadJson: '{"v":1}',
+    );
+
+    expect(id2, id1);
+    final rows = await db.select(db.syncQueue).get();
+    expect(rows, hasLength(1));
+  });
+
+  test('different actions on the same entity stay separate rows', () async {
+    final db = AppDatabase(executor: NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = SyncQueueRepository(db);
+
+    final createId = await repo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'a1',
+      action: 'create',
+      payloadJson: '{"v":1}',
+    );
+    final deleteId = await repo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'a1',
+      action: 'delete',
+    );
+
+    expect(deleteId, isNot(createId));
+    final rows = await db.select(db.syncQueue).get();
+    expect(rows, hasLength(2));
+  });
+
+  test('per-user databases keep isolated sync queues', () async {
+    driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+    final guestDb = AppDatabase(executor: NativeDatabase.memory());
+    addTearDown(guestDb.close);
+    final userDb = AppDatabase(
+      executor: NativeDatabase.memory(),
+      name: 'enjoy_player_user-test',
+    );
+    addTearDown(userDb.close);
+
+    final guestRepo = SyncQueueRepository(guestDb);
+    final userRepo = SyncQueueRepository(userDb);
+
+    await guestRepo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'guest-only',
+      action: 'create',
+      payloadJson: '{}',
+    );
+    await userRepo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'user-only',
+      action: 'create',
+      payloadJson: '{}',
+    );
+
+    expect(await guestDb.select(guestDb.syncQueue).get(), hasLength(1));
+    expect(await userDb.select(userDb.syncQueue).get(), hasLength(1));
+    expect(guestDb.isGuestDatabase, isTrue);
+    expect(userDb.isGuestDatabase, isFalse);
+
+    final guestRow = await guestDb.select(guestDb.syncQueue).getSingle();
+    final userRow = await userDb.select(userDb.syncQueue).getSingle();
+    expect(guestRow.entityId, 'guest-only');
+    expect(userRow.entityId, 'user-only');
+  });
+
+  test('watchSnapshot counts retryable vs permanently failed rows', () async {
+    final db = AppDatabase(executor: NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = SyncQueueRepository(db);
+
+    final retryableId = await repo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'retry',
+      action: 'create',
+    );
+    final failedId = await repo.addOrUpsert(
+      entityType: 'audio',
+      entityId: 'failed',
+      action: 'create',
+    );
+    await db.syncQueueDao.markAttempted(retryableId, error: 'once');
+    for (var i = 0; i < 5; i++) {
+      await db.syncQueueDao.markAttempted(failedId, error: 'fail');
+    }
+
+    final snapshot = await repo.watchSnapshot().first;
+    expect(snapshot.retryablePending, 1);
+    expect(snapshot.permanentlyFailed, 1);
+    expect(snapshot.isFullyCaughtUp, isFalse);
+    expect(snapshot.detailRows, hasLength(2));
+  });
 }

--- a/test/support/test_path_provider.dart
+++ b/test/support/test_path_provider.dart
@@ -8,4 +8,7 @@ class TestPathProvider extends PathProviderPlatform {
 
   @override
   Future<String?> getApplicationDocumentsPath() async => documentsPath;
+
+  @override
+  Future<String?> getTemporaryPath() async => documentsPath;
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,7 +1,114 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:enjoy_player/app.dart';
+import 'package:enjoy_player/core/application/app_preferences_provider.dart';
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/auth/application/auth_controller.dart';
+import 'package:enjoy_player/features/auth/domain/auth_state.dart';
+import 'package:enjoy_player/features/discover/application/discover_providers.dart';
+import 'package:enjoy_player/features/discover/domain/discover_channel.dart';
+import 'package:enjoy_player/features/library/application/library_media_provider.dart';
+import 'package:enjoy_player/features/library/domain/media.dart';
+import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
+import 'package:enjoy_player/features/sync/application/sync_providers.dart';
+import 'package:enjoy_player/features/update/application/update_controller.dart';
+import 'package:enjoy_player/features/update/domain/update_types.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'support/fake_player_engine.dart';
+import 'support/test_path_provider.dart';
+
+ThemeData _testTheme() {
+  final scheme = ColorScheme.fromSeed(
+    seedColor: const Color(0xFF7B61FF),
+    brightness: Brightness.dark,
+  );
+  return ThemeData(
+    colorScheme: scheme,
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    extensions: [EnjoyThemeTokens.build(scheme)],
+  );
+}
+
+class _SignedOutAuthCtrl extends AuthCtrl {
+  @override
+  Future<AuthState> build() async => const AuthSignedOut();
+}
+
+class _StaticPrefsCtrl extends AppPreferencesCtrl {
+  @override
+  Future<AppPreferencesState> build() async => AppPreferencesState.initial;
+}
+
+class _NoopUpdateCtrl extends UpdateCtrl {
+  @override
+  UpdateCheckResult? build() => null;
+
+  @override
+  Future<void> bootstrap() async {}
+}
 
 void main() {
-  test('workspace loads test harness', () {
-    expect(2, 1 + 1);
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('EnjoyApp smoke test boots signed-out home shell', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    PackageInfo.setMockInitialValues(
+      appName: 'Enjoy Player',
+      packageName: 'com.enjoy.player.test',
+      version: '0.2.3',
+      buildNumber: '4',
+      buildSignature: 'test',
+    );
+
+    final root = Directory.systemTemp.createTempSync('enjoy_widget_smoke');
+    PathProviderPlatform.instance = TestPathProvider(root.path);
+
+    final db = AppDatabase(executor: NativeDatabase.memory());
+    final fakeEngine = FakePlayerEngine();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          guestAppDatabaseProvider.overrideWithValue(db),
+          appDatabaseProvider.overrideWithValue(db),
+          authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new),
+          appPreferencesCtrlProvider.overrideWith(_StaticPrefsCtrl.new),
+          updateCtrlProvider.overrideWith(_NoopUpdateCtrl.new),
+          playerEngineTestDoubleProvider.overrideWithValue(fakeEngine),
+          syncEnqueueProvider.overrideWithValue((_, _, _) async {}),
+          libraryHomeRecentsProvider.overrideWith(
+            (ref) => Stream<List<Media>>.value(const []),
+          ),
+          discoverSubscriptionsProvider.overrideWith(
+            (ref) => Stream<List<DiscoverChannel>>.value(const []),
+          ),
+        ],
+        child: EnjoyApp(themeBuilder: _testTheme),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byType(EnjoyApp), findsOneWidget);
+    expect(find.byType(MaterialApp), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await fakeEngine.dispose();
+    await db.close();
+    if (root.existsSync()) root.deleteSync(recursive: true);
   });
 }


### PR DESCRIPTION
## Summary

- Run `flutter test --coverage` in CI, upload `coverage/lcov.info` to Codecov, and enforce a **32%** line-coverage baseline via `.github/scripts/check_coverage_gate.sh`.
- Expand shallow test areas from #109: sync queue idempotency/per-user isolation + `shouldRetryQueueItem` backoff, Azure WAV + token cache + echo PCM guard paths, subtitle parser edge cases, and an `EnjoyApp` widget smoke test (mocked `PackageInfo`, fake `PlayerEngine`, test theme hook).
- Document the coverage workflow in `docs/testing.md`.

## Test plan

- [x] `flutter test test/features/sync/`
- [x] `flutter test test/features/ai/azure_assessment_wav_normalizer_test.dart test/features/ai/azure_token_cache_dedup_test.dart`
- [x] `flutter test test/features/shadow_reading/echo_segment_pcm_extractor_test.dart`
- [x] `flutter test test/data/subtitle/subtitle_parser_test.dart`
- [x] `flutter test test/widget_test.dart`
- [x] `flutter test --coverage` (local baseline ~**33.8%**, above 32% gate)
- [ ] Confirm Codecov upload on CI (requires repo `CODECOV_TOKEN` if private)

Fixes #109

Made with [Cursor](https://cursor.com)