### PR TITLE
[perf-improver] perf(transcript): dedupe identical transcript_lines_provider emissions and drop listForTarget scan

### DIFF
--- a/lib/data/subtitle/transcript_line.dart
+++ b/lib/data/subtitle/transcript_line.dart
@@ -19,6 +19,18 @@ class TranscriptLine {
 
   double get endSeconds => (startMs + durationMs) / 1000.0;
 
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TranscriptLine &&
+        other.text == text &&
+        other.startMs == startMs &&
+        other.durationMs == durationMs;
+  }
+
+  @override
+  int get hashCode => Object.hash(text, startMs, durationMs);
+
   Map<String, dynamic> toJson() => {
     'text': text,
     'start': startMs,

--- a/lib/features/transcript/application/transcript_lines_provider.dart
+++ b/lib/features/transcript/application/transcript_lines_provider.dart
@@ -4,6 +4,7 @@ library;
 import 'package:async/async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/utils/stream_distinct.dart';
 import '../../../data/db/app_database.dart';
 import '../../../data/db/app_database_provider.dart';
 import '../../../data/db/media_target_resolver.dart';
@@ -11,18 +12,19 @@ import '../../../data/subtitle/transcript_line.dart';
 import '../data/transcript_repository.dart';
 import 'transcript_repository_provider.dart';
 
-List<TranscriptLine> _linesForActiveId(
-  TranscriptRepository repo,
-  List<TranscriptRow> transcriptRows,
-  String? activeId,
+/// Compares two transcript-line lists element-wise. Used to absorb identical
+/// re-emissions before they reach Riverpod listeners — see
+/// [transcriptLinesForMediaProvider].
+bool _listEqualsTranscriptLine(
+  List<TranscriptLine> previous,
+  List<TranscriptLine> current,
 ) {
-  if (activeId == null) return <TranscriptLine>[];
-  for (final r in transcriptRows) {
-    if (r.id == activeId) {
-      return repo.linesForRow(r);
-    }
+  if (identical(previous, current)) return true;
+  if (previous.length != current.length) return false;
+  for (var i = 0; i < previous.length; i++) {
+    if (previous[i] != current[i]) return false;
   }
-  return <TranscriptLine>[];
+  return true;
 }
 
 Future<List<TranscriptLine>> _computeLines(
@@ -33,9 +35,14 @@ Future<List<TranscriptLine>> _computeLines(
   required bool primary,
 }) async {
   final echo = await db.echoSessionDao.getLatestForTarget(tt, mediaId);
-  final rows = await db.transcriptDao.listForTarget(tt, mediaId);
   final id = primary ? echo?.transcriptId : echo?.secondaryTranscriptId;
-  return _linesForActiveId(repo, rows, id);
+  if (id == null) return <TranscriptLine>[];
+  // Fetch only the active row, not the entire transcript list. Avoids
+  // reading every transcript's timeline_json blob on every Drift tick —
+  // a frequent no-op tick when an in-active transcript row changes or
+  // when echo session aggregates (recordingsCount, lastActiveAt, …) bump.
+  final row = await db.transcriptDao.getById(id);
+  return row == null ? <TranscriptLine>[] : repo.linesForRow(row);
 }
 
 Stream<List<TranscriptLine>> _linesForMedia(
@@ -63,7 +70,7 @@ Stream<List<TranscriptLine>> _linesForMedia(
             .asyncMap(
               (_) => _computeLines(db, repo, tt, mediaId, primary: primary),
             ),
-      ]);
+      ]).distinctBy(_listEqualsTranscriptLine);
     });
   });
 }

--- a/test/features/transcript/transcript_lines_provider_dedupe_test.dart
+++ b/test/features/transcript/transcript_lines_provider_dedupe_test.dart
@@ -1,0 +1,320 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/subtitle/transcript_line.dart';
+import 'package:enjoy_player/features/transcript/application/transcript_lines_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _mediaId = 'media-dedupe';
+const _activeTranscriptId = 'tr-active';
+const _inactiveTranscriptId = 'tr-inactive';
+
+String _timeline(List<TranscriptLine> lines) =>
+    jsonEncode(lines.map((e) => e.toJson()).toList());
+
+List<TranscriptLine> _activeLines() => const [
+  TranscriptLine(text: 'hello', startMs: 0, durationMs: 500),
+  TranscriptLine(text: 'world', startMs: 500, durationMs: 500),
+];
+
+EchoSessionRow _echoSession({
+  required String transcriptId,
+  int recordingsCount = 0,
+  DateTime? lastActiveAt,
+}) {
+  final now = DateTime.utc(2026, 6, 28);
+  return EchoSessionRow(
+    id: 'echo-1',
+    targetType: 'Audio',
+    targetId: _mediaId,
+    language: 'und',
+    currentTimeMs: 0,
+    playbackRate: 1,
+    volume: 1,
+    echoStartMs: null,
+    echoEndMs: null,
+    transcriptId: transcriptId,
+    secondaryTranscriptId: null,
+    recordingsCount: recordingsCount,
+    recordingsDurationMs: 0,
+    lastRecordingAt: null,
+    currentSegmentIndex: -1,
+    echoActive: false,
+    echoStartLine: -1,
+    echoEndLine: -1,
+    startedAt: now,
+    lastActiveAt: lastActiveAt ?? now,
+    completedAt: null,
+    syncStatus: null,
+    serverUpdatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+TranscriptRow _transcript({
+  required String id,
+  required List<TranscriptLine> lines,
+  DateTime? updatedAt,
+}) {
+  final now = updatedAt ?? DateTime.utc(2026, 6, 28);
+  return TranscriptRow(
+    id: id,
+    targetType: 'Audio',
+    targetId: _mediaId,
+    language: 'en',
+    source: 'user',
+    timelineJson: _timeline(lines),
+    referenceId: null,
+    label: id,
+    trackIndex: null,
+    syncStatus: null,
+    serverUpdatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+AudioRow _audio() {
+  final now = DateTime.utc(2026, 6, 28);
+  return AudioRow(
+    id: _mediaId,
+    aid: 'f',
+    provider: 'user',
+    title: 't',
+    description: null,
+    thumbnailUrl: null,
+    durationSeconds: 0,
+    language: 'und',
+    translationKey: null,
+    sourceText: null,
+    voice: null,
+    source: null,
+    localUri: 'file:///a.mp3',
+    md5: null,
+    size: 1,
+    mediaUrl: null,
+    syncStatus: null,
+    serverUpdatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TranscriptLine value equality', () {
+    test('two lines with identical fields are ==', () {
+      const a = TranscriptLine(text: 'hi', startMs: 0, durationMs: 100);
+      const b = TranscriptLine(text: 'hi', startMs: 0, durationMs: 100);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('changing any field breaks ==', () {
+      const base = TranscriptLine(text: 'hi', startMs: 0, durationMs: 100);
+      const txt = TranscriptLine(text: 'bye', startMs: 0, durationMs: 100);
+      const start = TranscriptLine(text: 'hi', startMs: 1, durationMs: 100);
+      const dur = TranscriptLine(text: 'hi', startMs: 0, durationMs: 101);
+      expect(base, isNot(equals(txt)));
+      expect(base, isNot(equals(start)));
+      expect(base, isNot(equals(dur)));
+    });
+  });
+
+  group('transcriptLinesForMediaProvider dedupe', () {
+    late AppDatabase db;
+    late ProviderContainer container;
+    late ProviderSubscription<AsyncValue<List<TranscriptLine>>> sub;
+    final emissions = <List<TranscriptLine>>[];
+
+    Future<void> setupContainer() async {
+      container = ProviderContainer(
+        overrides: [appDatabaseProvider.overrideWithValue(db)],
+      );
+      addTearDown(container.dispose);
+
+      emissions.clear();
+      sub = container.listen(transcriptLinesForMediaProvider(_mediaId), (
+        _,
+        next,
+      ) {
+        if (next.hasValue) emissions.add(next.requireValue);
+      }, fireImmediately: true);
+      addTearDown(sub.close);
+
+      // Wait for the initial (post-setup) emission to land.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      // Drain the seeded-state emissions so the post-seed count is 0.
+      final initial = emissions.length;
+      emissions.clear();
+      // Sanity: at least one emission must have happened before draining.
+      expect(initial, greaterThanOrEqualTo(1));
+    }
+
+    setUp(() async {
+      db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+      await db.audioDao.insertRow(_audio());
+      await db.transcriptDao.upsert(
+        _transcript(id: _activeTranscriptId, lines: _activeLines()),
+      );
+      await db.transcriptDao.upsert(
+        _transcript(
+          id: _inactiveTranscriptId,
+          lines: const [
+            TranscriptLine(text: 'unused', startMs: 0, durationMs: 1),
+          ],
+        ),
+      );
+      await db.echoSessionDao.upsert(
+        _echoSession(transcriptId: _activeTranscriptId),
+      );
+    });
+
+    test(
+      'skips identical emissions when echo session bumps only counts',
+      () async {
+        await setupContainer();
+        // Bump recordingsCount — Drift re-emits the echo session row.
+        await (db.update(
+          db.echoSessions,
+        )..where((s) => s.id.equals('echo-1'))).write(
+          EchoSessionsCompanion(
+            recordingsCount: const Value(7),
+            updatedAt: Value(DateTime.utc(2026, 6, 28, 12)),
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          emissions,
+          isEmpty,
+          reason:
+              'Echo session count bump is a no-op for lines. '
+              'Got $emissions',
+        );
+      },
+    );
+
+    test(
+      'skips identical emissions when in-active transcript row changes',
+      () async {
+        await setupContainer();
+        // Touch the in-active transcript's updatedAt — Drift re-emits the
+        // watchAllForTarget stream.
+        await (db.update(
+          db.transcripts,
+        )..where((t) => t.id.equals(_inactiveTranscriptId))).write(
+          TranscriptsCompanion(updatedAt: Value(DateTime.utc(2026, 6, 28, 13))),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          emissions,
+          isEmpty,
+          reason:
+              'In-active transcript row change is a no-op for the active '
+              'lines. Got $emissions',
+        );
+      },
+    );
+
+    test('re-emits when the active transcript row is replaced', () async {
+      await setupContainer();
+      // Replace the active transcript's timeline — real change.
+      await db.transcriptDao.upsert(
+        _transcript(
+          id: _activeTranscriptId,
+          lines: const [
+            TranscriptLine(text: 'goodbye', startMs: 0, durationMs: 500),
+          ],
+          updatedAt: DateTime.utc(2026, 6, 28, 14),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(emissions, isNotEmpty);
+      expect(emissions.last.single.text, 'goodbye');
+    });
+
+    test(
+      're-emits when the active transcript id changes via echo session',
+      () async {
+        await setupContainer();
+        // Reassign the echo session to point at the in-active transcript id.
+        await (db.update(
+          db.echoSessions,
+        )..where((s) => s.id.equals('echo-1'))).write(
+          EchoSessionsCompanion(
+            transcriptId: const Value(_inactiveTranscriptId),
+            updatedAt: Value(DateTime.utc(2026, 6, 28, 15)),
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(emissions, isNotEmpty);
+        expect(emissions.last.single.text, 'unused');
+      },
+    );
+  });
+
+  group('_computeLines uses getById (not listForTarget)', () {
+    // Pins the contract: _computeLines must look up the active row by id,
+    // not scan the full list and pick the first row by ordering. We seed
+    // the in-active transcript with a timestamp LATER than the active
+    // one — a listForTarget-with-wrong-pick would surface 'unused'
+    // instead of the active lines.
+    test('lines come from getById(activeId), not listForTarget()', () async {
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+      await db.audioDao.insertRow(_audio());
+      await db.transcriptDao.upsert(
+        _transcript(id: _activeTranscriptId, lines: _activeLines()),
+      );
+      // Insert the in-active row AFTER the active one — if _computeLines
+      // scanned with listForTarget and ordered by source/language/createdAt
+      // (createdAt ascending puts the in-active row first), picking the
+      // first row instead of the active one would surface 'unused'.
+      await db.transcriptDao.upsert(
+        _transcript(
+          id: _inactiveTranscriptId,
+          lines: const [
+            TranscriptLine(text: 'unused', startMs: 0, durationMs: 1),
+          ],
+          updatedAt: DateTime.utc(2026, 6, 28, 11),
+        ),
+      );
+      await db.echoSessionDao.upsert(
+        _echoSession(transcriptId: _activeTranscriptId),
+      );
+
+      final c = ProviderContainer(
+        overrides: [appDatabaseProvider.overrideWithValue(db)],
+      );
+      addTearDown(c.dispose);
+
+      final emissions = <List<TranscriptLine>>[];
+      final sub = c.listen(transcriptLinesForMediaProvider(_mediaId), (
+        _,
+        next,
+      ) {
+        if (next.hasValue) emissions.add(next.requireValue);
+      }, fireImmediately: true);
+      addTearDown(sub.close);
+
+      // Wait for at least one emission to land.
+      final deadline = DateTime.now().add(const Duration(seconds: 2));
+      while (emissions.isEmpty && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      expect(
+        emissions,
+        isNotEmpty,
+        reason: 'Provider should emit at least once within 2s',
+      );
+      expect(emissions.last.map((l) => l.text).toList(), ['hello', 'world']);
+    });
+  });
+}


### PR DESCRIPTION
closes #131 

…istForTarget scan

The transcript lines provider hot path previously did a full transcriptDao.listForTarget(tt, mediaId) scan on every Drift tick, reading every transcript's timeline_json blob even when only an in-active row or an echo session aggregate (recordingsCount, lastActiveAt, ...) had changed. Then the merged stream emitted a new List<TranscriptLine> container each tick, forcing every downstream widget (transcript_panel, transcript_scrollable_list, transcript_line_recording_counts_provider,
transcript_playback_highlight_provider) to re-evaluate.

Two changes:

1. _computeLines now fetches only the active row by id (transcriptDao.getById(activeId)) instead of listForTarget. The active transcript's id is the only thing that matters for the derived lines; reading every transcript's timeline_json blob on every Drift tick was wasted I/O on the hot path.

2. The merged watch stream now ends in Stream.distinctBy(_listEqualsTranscriptLine) — same extension used by #37, #65, the recordings PR. Adds ==/hashCode to TranscriptLine so element-wise comparison works without touching the cache or re-decoding JSON.

Tests:
- New test/features/transcript/transcript_lines_provider_dedupe_test.dart with 7 cases: TranscriptLine ==/hashCode, provider skips echo session count bumps, provider skips in-active transcript row changes, provider re-emits on real active-row changes, provider re-emits when echo session's active transcript id changes, and a pinned contract test that getById (not listForTarget) drives the line resolution.
- flutter test test/features/transcript/ → 62/62 pass.
- Full flutter test → 522 pass / 1 pre-existing failure on library_media_provider_test.dart unchanged from main.

## Summary

<!-- One paragraph: what does this PR change and why? Reference the issue(s) it closes. -->

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / chore (no user-visible change)
- [ ] Documentation / ADR

## Platform tested

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux

## Checklist

- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes for affected areas
- [ ] No new `print()` calls (use `logNamed` from `lib/core/logging/log.dart`)
- [ ] No new `kIsWeb` branches (AGENTS.md hard rule)
- [ ] No new SQL outside Drift DAOs (AGENTS.md hard rule)
- [ ] No new `Player()` instances outside `PlayerController` (AGENTS.md hard rule)
- [ ] If behavior changed: `docs/features/<feature>.md` updated
- [ ] If architectural: new ADR in `docs/decisions/`
- [ ] New public API symbols have doc comments (if applicable)

## Test plan

<!-- How was this verified? List specific scenarios, commands, and platforms. -->

- [ ] ...
- [ ] ...

## Out of scope / follow-up

<!-- Anything intentionally deferred; link to follow-up issues. -->

- ...

## Human / owner follow-up

<!-- Any actions that require the repo owner (credential rotation, third-party sign-off,
     schema decisions). Do NOT silently perform these — flag them here. -->

- None / ...
