### PR TITLE
chore(lint): expand analysis baseline and code-quality polish

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,3 +16,11 @@ linter:
     prefer_const_constructors: true
     prefer_const_literals_to_create_immutables: true
     use_build_context_synchronously: true
+    prefer_single_quotes: true
+    sort_constructors_first: true
+    require_trailing_commas: true
+    unawaited_futures: true
+    discarded_futures: true
+    cancel_subscriptions: true
+    close_sinks: true
+    depend_on_referenced_packages: true

--- a/docs/decisions/0030-flutter-lints-baseline-no-custom-lint.md
+++ b/docs/decisions/0030-flutter-lints-baseline-no-custom-lint.md
@@ -1,0 +1,46 @@
+# ADR-0030: Expanded flutter_lints baseline; defer custom_lint
+
+## Status
+
+Accepted — 2026-06-29.
+
+## Context
+
+Issue #110 grouped several low-risk code-quality items. The lint baseline in
+`analysis_options.yaml` was intentionally thin (four rules on top of
+`flutter_lints`). The tech stack doc also noted that `custom_lint` was not
+adopted because of analyzer-range friction with `drift_dev` and other
+codegen packages.
+
+`flutter_lints` 6.0.0 is available on pub.dev and matches the project's
+Dart ^3.12 / Flutter 3.x toolchain.
+
+## Decision
+
+1. **Expand `analysis_options.yaml`** with additional core lints:
+   `prefer_single_quotes`, `sort_constructors_first`, `require_trailing_commas`,
+   `unawaited_futures`, `discarded_futures`, `cancel_subscriptions`,
+   `close_sinks`, and `depend_on_referenced_packages`.
+
+2. **Keep `flutter_lints: ^6.0.0`** — the caret range resolves to the current
+   stable 6.x release.
+
+3. **Do not adopt `custom_lint` yet.** Codegen (`drift_dev`, `riverpod_generator`,
+   `json_serializable`) still pins a shared analyzer range; adding
+   `custom_lint` + plugin packages would increase version-resolution churn
+   without clear MVP benefit. Revisit when analyzer constraints align or
+   when a specific custom rule becomes blocking.
+
+4. **Remove legacy `@deprecated` color aliases** in `AppColors` once callers
+   migrate to the `*Dark` names (no remaining references at time of adoption).
+
+5. **Replace deprecated `RadioListTile` group API** with `RadioGroup` where
+   subtitle track pickers still used the old pattern.
+
+## Consequences
+
+- `dart fix --apply` and `dart format` may touch many files when new rules
+  land; run as part of the same PR.
+- Stronger async hygiene lints (`unawaited_futures`, `discarded_futures`) may
+  surface latent bugs — fix or explicitly `unawaited()` at call sites.
+- `custom_lint` remains a documented follow-up, not a silent omission.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -53,3 +53,4 @@ Trade-offs, follow-up work, risks.
 | [0027](0027-native-auth-v2.md) | Native auth v2 — Google, Apple, email OTP, PKCE fallback (supersedes 0016 WebView-primary) |
 | [0028](0028-agentic-engine-choice.md) | Agentic workflow engine choice — third-party Anthropic-compatible proxy (proposed) |
 | [0029](0029-supply-chain-risk.md) | Supply-chain risk for pre-release and local-path dependencies |
+| [0030](0030-flutter-lints-baseline-no-custom-lint.md) | Expanded flutter_lints baseline; defer custom_lint |

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -17,7 +17,7 @@
 | Markdown (AI explanations) | `flutter_markdown` | Contextual translation in transcript lookup sheet |
 | i18n | `flutter_localizations` + ARB | `lib/l10n/app_en.arb`, `app_zh.arb`, `app_zh_CN.arb`; default display locale `zh-CN` ([`kAppDefaultDisplayLocale`](../lib/core/application/app_language_catalog.dart)) |
 | Codegen | `build_runner`, `drift_dev`, `riverpod_generator` | Run after schema/provider edits |
-| Lint | `flutter_lints` | `analysis_options.yaml` (no `custom_lint`: incompatible analyzer range vs `drift_dev` / codegen) |
+| Lint | `flutter_lints` ^6.0.0 | Expanded baseline in `analysis_options.yaml` (quotes, trailing commas, async hygiene, package deps). `custom_lint` deferred — see [ADR-0030](decisions/0030-flutter-lints-baseline-no-custom-lint.md). |
 
 Deferred (ADR-0005): URL streaming UX polish. Library/recording **cloud sync** remains deferred; see [ADR-0006](decisions/0006-auth-and-profile-sync.md) for optional auth + profile scope.
 

--- a/lib/core/application/app_preferences_provider.dart
+++ b/lib/core/application/app_preferences_provider.dart
@@ -1,6 +1,8 @@
 /// App-wide locale and learner language prefs (Drift-backed).
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -133,7 +135,7 @@ class AppPreferencesCtrl extends _$AppPreferencesCtrl {
       if (sig == _lastAppliedProfileSignature) return;
       _lastAppliedProfileSignature = sig;
       // Defer so we don't mutate state mid-listener.
-      Future<void>.microtask(() => applyFromUserProfile(v.profile));
+      unawaited(Future<void>.microtask(() => applyFromUserProfile(v.profile)));
     }, fireImmediately: true);
 
     _prefsLog.info('prefs: build done in ${sw.elapsedMilliseconds}ms');

--- a/lib/core/interaction/haptics.dart
+++ b/lib/core/interaction/haptics.dart
@@ -1,6 +1,8 @@
 /// Centralized haptic feedback — respects reduced motion and platform capability.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
@@ -21,25 +23,25 @@ abstract final class Haptics {
   /// Light tap / selection (navigation, toggles, list rows).
   static void selection(BuildContext context) {
     if (!_hapticCapable() || _reducedMotion(context)) return;
-    HapticFeedback.selectionClick();
+    unawaited(HapticFeedback.selectionClick());
   }
 
   /// Stronger feedback (long-press menus, destructive confirm).
   static void impactMedium(BuildContext context) {
     if (!_hapticCapable() || _reducedMotion(context)) return;
-    HapticFeedback.mediumImpact();
+    unawaited(HapticFeedback.mediumImpact());
   }
 
   /// Success / completed action (paired with positive SnackBars).
   static void success(BuildContext context) {
     if (!_hapticCapable() || _reducedMotion(context)) return;
-    HapticFeedback.mediumImpact();
+    unawaited(HapticFeedback.mediumImpact());
   }
 
   /// Warning / error attention (paired with error SnackBars).
   static void warning(BuildContext context) {
     if (!_hapticCapable() || _reducedMotion(context)) return;
-    HapticFeedback.heavyImpact();
+    unawaited(HapticFeedback.heavyImpact());
   }
 
   /// Wraps a tap callback with [selection] haptic (for [IconButton], [InkWell], etc.).

--- a/lib/core/logging/setup_logging.dart
+++ b/lib/core/logging/setup_logging.dart
@@ -8,6 +8,7 @@
 /// All builds also persist redacted records to a rotating file when supported.
 library;
 
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
@@ -35,7 +36,7 @@ Future<void> setupAppLogging() async {
         record.stackTrace != null;
 
     if (DiagnosticLogConfig.shouldPersistRecord(record)) {
-      LogFileSink.instance?.writeRecord(record);
+      unawaited(LogFileSink.instance?.writeRecord(record));
     }
 
     if (mirrorToStdout) {

--- a/lib/core/recovery/recovery_actions.dart
+++ b/lib/core/recovery/recovery_actions.dart
@@ -105,7 +105,8 @@ Future<String?> backupLocalDatabaseFile() async {
     if (!dbDir.existsSync()) {
       return null;
     }
-    final stamp = DateTime.now().toUtc()
+    final stamp = DateTime.now()
+        .toUtc()
         .toIso8601String()
         .replaceAll(':', '-')
         .replaceAll('.', '-');
@@ -119,9 +120,7 @@ Future<String?> backupLocalDatabaseFile() async {
     if (!source.existsSync()) {
       return null;
     }
-    final dest = File(
-      p.join(backupDir.path, 'enjoy_player_$stamp.sqlite'),
-    );
+    final dest = File(p.join(backupDir.path, 'enjoy_player_$stamp.sqlite'));
     await source.copy(dest.path);
     _log.info('backupLocalDatabaseFile: wrote ${dest.path}');
     return dest.path;

--- a/lib/core/recovery/recovery_surface.dart
+++ b/lib/core/recovery/recovery_surface.dart
@@ -43,11 +43,7 @@ class _RecoverySurfaceState extends State<RecoverySurface> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Icon(
-                    Icons.warning_amber_rounded,
-                    size: 64,
-                    color: cs.error,
-                  ),
+                  Icon(Icons.warning_amber_rounded, size: 64, color: cs.error),
                   SizedBox(height: t.space16),
                   Text(
                     l10n.recoveryTitle,

--- a/lib/core/routing/player_navigation.dart
+++ b/lib/core/routing/player_navigation.dart
@@ -1,6 +1,8 @@
 /// Helpers for opening the expanded player without stacking player platform views.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
@@ -20,7 +22,7 @@ void openPlayerRoute(BuildContext context, String mediaId) {
   if (currentPath.startsWith('/player/')) {
     context.replace(location);
   } else {
-    context.push(location);
+    unawaited(context.push(location));
   }
 }
 

--- a/lib/core/theme/colors.dart
+++ b/lib/core/theme/colors.dart
@@ -29,35 +29,4 @@ abstract final class AppColors {
 
   // ── Seed for Material 3 ColorScheme.fromSeed ──────────────────────────
   static const seedBrand = brand;
-
-  // ── Legacy aliases kept for widgets that still reference them ─────────
-  /// @deprecated Use surfaceDark
-  static const surface = surfaceDark;
-
-  /// @deprecated Use surfaceContainerLowestDark
-  static const surfaceContainerLowest = surfaceContainerLowestDark;
-
-  /// @deprecated Use surfaceContainerLowDark
-  static const surfaceContainerLow = surfaceContainerLowDark;
-
-  /// @deprecated Use surfaceContainerDark
-  static const surfaceContainer = surfaceContainerDark;
-
-  /// @deprecated Use surfaceContainerHighDark
-  static const surfaceContainerHigh = surfaceContainerHighDark;
-
-  /// @deprecated Use surfaceContainerHighestDark
-  static const surfaceContainerHighest = surfaceContainerHighestDark;
-
-  /// @deprecated Use gradientStartDark
-  static const gradientStart = gradientStartDark;
-
-  /// @deprecated Use gradientEndDark
-  static const gradientEnd = gradientEndDark;
-
-  /// @deprecated Use seedBrand
-  static const seedAmber = seedBrand;
-
-  /// @deprecated Use seedBrand
-  static const seedViolet = seedBrand;
 }

--- a/lib/core/theme/enjoy_tokens.dart
+++ b/lib/core/theme/enjoy_tokens.dart
@@ -10,6 +10,59 @@ import 'colors.dart';
 /// Premium cinematic-editorial tokens; use [EnjoyThemeTokens.of] from widgets.
 @immutable
 class EnjoyThemeTokens extends ThemeExtension<EnjoyThemeTokens> {
+  /// Dark-only app tokens derived from the active [ColorScheme].
+  factory EnjoyThemeTokens.build(ColorScheme scheme) {
+    return EnjoyThemeTokens(
+      space4: 4,
+      space8: 8,
+      space12: 12,
+      space16: 16,
+      space20: 20,
+      space24: 24,
+      space32: 32,
+      space40: 40,
+      radiusSm: 8,
+      radiusMd: 12,
+      radiusLg: 16,
+      radiusXl: 20,
+      radiusFull: 999,
+      elevationNone: 0,
+      elevationCard: 1,
+      elevationSheet: 3,
+      elevationModal: 8,
+      elevationBar: 2,
+      elevationSurface: 1,
+      breakpointRail: 900,
+      breakpointTranscriptSideBySide: 720,
+      motionFast: const Duration(milliseconds: 180),
+      motionStandard: const Duration(milliseconds: 260),
+      motionEnter: const Duration(milliseconds: 240),
+      motionExit: const Duration(milliseconds: 160),
+      motionMedium: const Duration(milliseconds: 220),
+      echoActive: AppColors.echoActive,
+      ccBadge: scheme.primary,
+      transcriptLinePadding: const EdgeInsets.symmetric(
+        horizontal: 16,
+        vertical: 10,
+      ),
+      contentMaxWidth: 720,
+      miniBarBlurSigma: 20,
+      sidebarWidth: 248,
+      sidebarBrandHeight: 56,
+      transportHeight: 88,
+      heroTitleLetterSpacing: -1.2,
+      glassTint: scheme.surface.withValues(alpha: 0.55),
+      glassBorder: scheme.outlineVariant.withValues(alpha: 0.22),
+      gradientStart: AppColors.gradientStartDark,
+      gradientEnd: AppColors.gradientEndDark,
+      useGlassOnSidebar: false,
+      bottomNavHeight: 68,
+      desktopGutter: 24,
+      modalMaxWidth: 400,
+      modalMaxWidthLarge: 560,
+      focusRingWidth: 2,
+    );
+  }
   const EnjoyThemeTokens({
     required this.space4,
     required this.space8,
@@ -165,60 +218,6 @@ class EnjoyThemeTokens extends ThemeExtension<EnjoyThemeTokens> {
   static EnjoyThemeTokens of(BuildContext context) {
     return Theme.of(context).extension<EnjoyThemeTokens>() ??
         EnjoyThemeTokens.build(Theme.of(context).colorScheme);
-  }
-
-  /// Dark-only app tokens derived from the active [ColorScheme].
-  factory EnjoyThemeTokens.build(ColorScheme scheme) {
-    return EnjoyThemeTokens(
-      space4: 4,
-      space8: 8,
-      space12: 12,
-      space16: 16,
-      space20: 20,
-      space24: 24,
-      space32: 32,
-      space40: 40,
-      radiusSm: 8,
-      radiusMd: 12,
-      radiusLg: 16,
-      radiusXl: 20,
-      radiusFull: 999,
-      elevationNone: 0,
-      elevationCard: 1,
-      elevationSheet: 3,
-      elevationModal: 8,
-      elevationBar: 2,
-      elevationSurface: 1,
-      breakpointRail: 900,
-      breakpointTranscriptSideBySide: 720,
-      motionFast: const Duration(milliseconds: 180),
-      motionStandard: const Duration(milliseconds: 260),
-      motionEnter: const Duration(milliseconds: 240),
-      motionExit: const Duration(milliseconds: 160),
-      motionMedium: const Duration(milliseconds: 220),
-      echoActive: AppColors.echoActive,
-      ccBadge: scheme.primary,
-      transcriptLinePadding: const EdgeInsets.symmetric(
-        horizontal: 16,
-        vertical: 10,
-      ),
-      contentMaxWidth: 720,
-      miniBarBlurSigma: 20,
-      sidebarWidth: 248,
-      sidebarBrandHeight: 56,
-      transportHeight: 88,
-      heroTitleLetterSpacing: -1.2,
-      glassTint: scheme.surface.withValues(alpha: 0.55),
-      glassBorder: scheme.outlineVariant.withValues(alpha: 0.22),
-      gradientStart: AppColors.gradientStartDark,
-      gradientEnd: AppColors.gradientEndDark,
-      useGlassOnSidebar: false,
-      bottomNavHeight: 68,
-      desktopGutter: 24,
-      modalMaxWidth: 400,
-      modalMaxWidthLarge: 560,
-      focusRingWidth: 2,
-    );
   }
 
   // ── copyWith ───────────────────────────────────────────────────────────

--- a/lib/core/theme/widgets/media_card.dart
+++ b/lib/core/theme/widgets/media_card.dart
@@ -5,6 +5,7 @@
 ///   [MediaCard.row]  — horizontal row card for list views (audio).
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart'
@@ -41,7 +42,7 @@ void _showMobileDeleteMenu(
   final title = (label != null && label.isNotEmpty)
       ? label
       : ml.deleteButtonTooltip;
-  showEnjoySheet<void>(
+  unawaited(showEnjoySheet<void>(
     context: context,
     builder: (sheetContext) {
       final cs = Theme.of(sheetContext).colorScheme;
@@ -68,7 +69,7 @@ void _showMobileDeleteMenu(
         ),
       );
     },
-  );
+  ));
 }
 
 Widget _heroArtworkShell(String? mediaId, Widget child) {

--- a/lib/core/theme/widgets/skeleton.dart
+++ b/lib/core/theme/widgets/skeleton.dart
@@ -1,6 +1,8 @@
 /// Shimmer skeleton placeholders for loading UX (respects reduced motion).
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -67,7 +69,7 @@ class _SkeletonState extends State<Skeleton>
       if (!mounted) return;
       final reduce = MediaQuery.disableAnimationsOf(context);
       if (!reduce) {
-        _ctrl.repeat();
+        unawaited(_ctrl.repeat());
       }
     });
   }
@@ -79,7 +81,7 @@ class _SkeletonState extends State<Skeleton>
     if (reduce) {
       _ctrl.stop();
     } else if (!_ctrl.isAnimating) {
-      _ctrl.repeat();
+      unawaited(_ctrl.repeat());
     }
   }
 

--- a/lib/core/utils/stream_distinct.dart
+++ b/lib/core/utils/stream_distinct.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 extension StreamDistinctExt<T> on Stream<T> {
   Stream<T> distinctBy(bool Function(T previous, T current) equals) {
     late StreamController<T> controller;
+    // ignore: cancel_subscriptions — cancelled in [StreamController.onCancel].
     StreamSubscription<T>? upstream;
 
     controller = StreamController<T>(
@@ -32,7 +33,7 @@ extension StreamDistinctExt<T> on Stream<T> {
           },
           onError: controller.addError,
           onDone: () {
-            if (!controller.isClosed) controller.close();
+            if (!controller.isClosed) unawaited(controller.close());
           },
         );
       },

--- a/lib/core/window/window_fullscreen_provider.dart
+++ b/lib/core/window/window_fullscreen_provider.dart
@@ -1,6 +1,8 @@
 /// Riverpod notifier for OS window fullscreen state.
 library;
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -23,9 +25,9 @@ class WindowFullscreen extends _$WindowFullscreen with WindowListener {
     ref.onDispose(() => windowManager.removeListener(this));
 
     // Seed with current state (sync best-effort; provider starts false).
-    getWindowFullscreen().then((v) {
+    unawaited(getWindowFullscreen().then((v) {
       if (state != v) state = v;
-    });
+    }));
 
     return false;
   }

--- a/lib/data/api/recording_client_platform_stub.dart
+++ b/lib/data/api/recording_client_platform_stub.dart
@@ -6,7 +6,7 @@
 /// client platform string is intentionally undefined rather than a
 /// misleading `'web'` default.
 String recordingClientPlatformValue() => throw UnsupportedError(
-      'recordingClientPlatformValue: no platform-specific implementation '
-      'was selected by the conditional import. Enjoy Player targets '
-      'Android, iOS, macOS, and Windows only.',
-    );
+  'recordingClientPlatformValue: no platform-specific implementation '
+  'was selected by the conditional import. Enjoy Player targets '
+  'Android, iOS, macOS, and Windows only.',
+);

--- a/lib/data/api/services/auth_api.dart
+++ b/lib/data/api/services/auth_api.dart
@@ -15,7 +15,7 @@ class AuthApi {
     String? platform,
   }) => _client.postJson(
     '$_authPrefix/google',
-    body: {'idToken': idToken, if (platform != null) 'platform': platform},
+    body: {'idToken': idToken, 'platform': ?platform},
     requireAuth: false,
   );
 

--- a/lib/data/db/app_database.dart
+++ b/lib/data/db/app_database.dart
@@ -52,12 +52,12 @@ part 'app_database.g.dart';
   ],
 )
 class AppDatabase extends _$AppDatabase {
-  /// Default Drift database name (guest / signed-out local data).
-  static const String guestDatabaseName = 'enjoy_player';
-
   AppDatabase({QueryExecutor? executor, String name = guestDatabaseName})
     : _dbName = name,
       super(executor ?? driftDatabase(name: name));
+
+  /// Default Drift database name (guest / signed-out local data).
+  static const String guestDatabaseName = 'enjoy_player';
 
   /// Drift / sqlite file name (no path) for this instance.
   ///

--- a/lib/data/db/app_database_provider.dart
+++ b/lib/data/db/app_database_provider.dart
@@ -77,7 +77,7 @@ AppDatabase appDatabase(Ref ref) {
   if (existing != null) {
     _userSessionDatabases[sessionName] = existing;
     ref.onDispose(() {
-      _userSessionDatabases.remove(sessionName)?.close();
+      unawaited(_userSessionDatabases.remove(sessionName)?.close());
     });
     return existing;
   }
@@ -91,7 +91,7 @@ AppDatabase appDatabase(Ref ref) {
   final db = AppDatabase(name: sessionName);
   _userSessionDatabases[sessionName] = db;
   ref.onDispose(() {
-    _userSessionDatabases.remove(sessionName)?.close();
+    unawaited(_userSessionDatabases.remove(sessionName)?.close());
   });
   return db;
 }

--- a/lib/data/db/migration_backup.dart
+++ b/lib/data/db/migration_backup.dart
@@ -79,9 +79,7 @@ Future<Map<String, dynamic>> _exportTable(
   String tableName,
 ) async {
   try {
-    final rows = await db
-        .customSelect('SELECT * FROM $tableName')
-        .get();
+    final rows = await db.customSelect('SELECT * FROM $tableName').get();
     return {
       'rowCount': rows.length,
       'rows': rows.map((row) => row.data).toList(growable: false),

--- a/lib/features/ai/data/azure_assessment_wav_normalizer.dart
+++ b/lib/features/ai/data/azure_assessment_wav_normalizer.dart
@@ -48,7 +48,10 @@ Future<({int exitCode, String stderr})> _runFfmpegWindowsInIsolate(
     'pcm_s16le',
     args.outputWavPath,
   ]);
-  return (exitCode: r.exitCode, stderr: r.stderr is String ? r.stderr as String : '');
+  return (
+    exitCode: r.exitCode,
+    stderr: r.stderr is String ? r.stderr as String : '',
+  );
 }
 
 Future<bool> _runFfmpegKit({

--- a/lib/features/ai/domain/models/asr_result.dart
+++ b/lib/features/ai/domain/models/asr_result.dart
@@ -1,19 +1,5 @@
 /// Whisper-style JSON response (keys camelCase after [ApiClient] decode).
 final class AsrResult {
-  const AsrResult({
-    required this.text,
-    this.segments,
-    this.language,
-    this.duration,
-    this.wordCount,
-  });
-
-  final String text;
-  final List<AsrSegment>? segments;
-  final String? language;
-  final double? duration;
-  final int? wordCount;
-
   factory AsrResult.fromJson(Map<String, dynamic> json) {
     final segs = json['segments'] as List<dynamic>?;
     final transcriptionInfo = _jsonMap(json['transcriptionInfo']);
@@ -29,9 +15,31 @@ final class AsrResult {
       wordCount: json['wordCount'] as int? ?? json['word_count'] as int?,
     );
   }
+  const AsrResult({
+    required this.text,
+    this.segments,
+    this.language,
+    this.duration,
+    this.wordCount,
+  });
+
+  final String text;
+  final List<AsrSegment>? segments;
+  final String? language;
+  final double? duration;
+  final int? wordCount;
 }
 
 final class AsrSegment {
+  factory AsrSegment.fromJson(Map<String, dynamic> json) {
+    final w = json['words'] as List<dynamic>?;
+    return AsrSegment(
+      start: (json['start'] as num?)?.toDouble() ?? 0,
+      end: (json['end'] as num?)?.toDouble() ?? 0,
+      text: json['text'] as String? ?? '',
+      words: w?.map((e) => AsrWord.fromJson(_jsonMap(e) ?? const {})).toList(),
+    );
+  }
   const AsrSegment({
     required this.start,
     required this.end,
@@ -43,16 +51,6 @@ final class AsrSegment {
   final double end;
   final String text;
   final List<AsrWord>? words;
-
-  factory AsrSegment.fromJson(Map<String, dynamic> json) {
-    final w = json['words'] as List<dynamic>?;
-    return AsrSegment(
-      start: (json['start'] as num?)?.toDouble() ?? 0,
-      end: (json['end'] as num?)?.toDouble() ?? 0,
-      text: json['text'] as String? ?? '',
-      words: w?.map((e) => AsrWord.fromJson(_jsonMap(e) ?? const {})).toList(),
-    );
-  }
 }
 
 /// JSON nested objects decode as [Map<dynamic, dynamic>]; normalize for casts.
@@ -64,12 +62,6 @@ Map<String, dynamic>? _jsonMap(dynamic value) {
 }
 
 final class AsrWord {
-  const AsrWord({required this.word, required this.start, required this.end});
-
-  final String word;
-  final double start;
-  final double end;
-
   factory AsrWord.fromJson(Map<String, dynamic> json) {
     return AsrWord(
       word: json['word'] as String? ?? '',
@@ -77,4 +69,9 @@ final class AsrWord {
       end: (json['end'] as num?)?.toDouble() ?? 0,
     );
   }
+  const AsrWord({required this.word, required this.start, required this.end});
+
+  final String word;
+  final double start;
+  final double end;
 }

--- a/lib/features/ai/domain/models/dictionary_result.dart
+++ b/lib/features/ai/domain/models/dictionary_result.dart
@@ -1,21 +1,5 @@
 /// Worker `/dictionary/query` result (camelCase JSON).
 final class DictionaryResult {
-  const DictionaryResult({
-    required this.word,
-    required this.sourceLanguage,
-    required this.targetLanguage,
-    this.lemma,
-    this.ipa,
-    required this.senses,
-  });
-
-  final String word;
-  final String sourceLanguage;
-  final String targetLanguage;
-  final String? lemma;
-  final String? ipa;
-  final List<DictionarySense> senses;
-
   factory DictionaryResult.fromJson(Map<String, dynamic> json) {
     final sensesRaw = json['senses'] as List<dynamic>? ?? const [];
     return DictionaryResult(
@@ -32,23 +16,24 @@ final class DictionaryResult {
           .toList(),
     );
   }
+  const DictionaryResult({
+    required this.word,
+    required this.sourceLanguage,
+    required this.targetLanguage,
+    this.lemma,
+    this.ipa,
+    required this.senses,
+  });
+
+  final String word;
+  final String sourceLanguage;
+  final String targetLanguage;
+  final String? lemma;
+  final String? ipa;
+  final List<DictionarySense> senses;
 }
 
 final class DictionarySense {
-  const DictionarySense({
-    required this.definition,
-    this.translation,
-    this.partOfSpeech,
-    this.examples,
-    this.notes,
-  });
-
-  final String definition;
-  final String? translation;
-  final String? partOfSpeech;
-  final List<DictionaryExample>? examples;
-  final String? notes;
-
   factory DictionarySense.fromJson(Map<String, dynamic> json) {
     final ex = json['examples'] as List<dynamic>?;
     return DictionarySense(
@@ -64,18 +49,30 @@ final class DictionarySense {
           .toList(),
     );
   }
+  const DictionarySense({
+    required this.definition,
+    this.translation,
+    this.partOfSpeech,
+    this.examples,
+    this.notes,
+  });
+
+  final String definition;
+  final String? translation;
+  final String? partOfSpeech;
+  final List<DictionaryExample>? examples;
+  final String? notes;
 }
 
 final class DictionaryExample {
-  const DictionaryExample({required this.source, this.target});
-
-  final String source;
-  final String? target;
-
   factory DictionaryExample.fromJson(Map<String, dynamic> json) {
     return DictionaryExample(
       source: json['source'] as String? ?? '',
       target: json['target'] as String?,
     );
   }
+  const DictionaryExample({required this.source, this.target});
+
+  final String source;
+  final String? target;
 }

--- a/lib/features/auth/application/auth_controller.dart
+++ b/lib/features/auth/application/auth_controller.dart
@@ -104,10 +104,7 @@ class AuthCtrl extends _$AuthCtrl {
     } on SignInWithAppleAuthorizationException catch (e) {
       if (e.code == AuthorizationErrorCode.canceled) return;
       if (gen != _flowGeneration) return;
-      throw AuthFailure(
-        e.message,
-        code: AuthFailureCode.invalidCredentials,
-      );
+      throw AuthFailure(e.message, code: AuthFailureCode.invalidCredentials);
     } on AuthFailure {
       rethrow;
     } catch (e, st) {

--- a/lib/features/auth/application/auth_deep_link_listener.dart
+++ b/lib/features/auth/application/auth_deep_link_listener.dart
@@ -32,13 +32,13 @@ class _AuthDeepLinkListenerState extends ConsumerState<AuthDeepLinkListener> {
   @override
   void initState() {
     super.initState();
-    _appLinks.getInitialLink().then(_onUri, onError: _onInitialLinkError);
+    unawaited(_appLinks.getInitialLink().then(_onUri, onError: _onInitialLinkError));
     _streamSub = _appLinks.uriLinkStream.listen(_onUri);
   }
 
   @override
   void dispose() {
-    _streamSub?.cancel();
+    unawaited(_streamSub?.cancel());
     _streamSub = null;
     super.dispose();
   }

--- a/lib/features/auth/data/apple_sign_in_service.dart
+++ b/lib/features/auth/data/apple_sign_in_service.dart
@@ -47,10 +47,7 @@ class AppleSignInService {
     final given = credential.givenName;
     final family = credential.familyName;
     if (given != null || family != null) {
-      fullName = {
-        if (given != null) 'givenName': given,
-        if (family != null) 'familyName': family,
-      };
+      fullName = {'givenName': ?given, 'familyName': ?family};
     }
     return AppleSignInCredentials(
       identityToken: identityToken,

--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -33,12 +33,10 @@ AuthRepository authRepository(Ref ref) {
 
 class AuthRepository {
   AuthRepository({
-    required AuthApi authApi,
-    required SecureTokenStore tokenStore,
-    required Future<String> Function() getBaseUrl,
-  }) : _authApi = authApi,
-       _tokenStore = tokenStore,
-       _getBaseUrl = getBaseUrl;
+    required this._authApi,
+    required this._tokenStore,
+    required this._getBaseUrl,
+  });
 
   final AuthApi _authApi;
   final SecureTokenStore _tokenStore;

--- a/lib/features/auth/domain/auth_token_response.dart
+++ b/lib/features/auth/domain/auth_token_response.dart
@@ -4,20 +4,6 @@ library;
 import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 
 class AuthTokenResponse {
-  const AuthTokenResponse({
-    required this.accessToken,
-    required this.refreshToken,
-    required this.expiresIn,
-    this.tokenType = 'Bearer',
-    this.user,
-  });
-
-  final String accessToken;
-  final String refreshToken;
-  final int expiresIn;
-  final String tokenType;
-  final UserProfile? user;
-
   factory AuthTokenResponse.fromJson(Map<String, dynamic> json) {
     final access = json['accessToken'] as String?;
     final refresh = json['refreshToken'] as String?;
@@ -48,19 +34,22 @@ class AuthTokenResponse {
       user: user,
     );
   }
+  const AuthTokenResponse({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.expiresIn,
+    this.tokenType = 'Bearer',
+    this.user,
+  });
+
+  final String accessToken;
+  final String refreshToken;
+  final int expiresIn;
+  final String tokenType;
+  final UserProfile? user;
 }
 
 class OtpSendResponse {
-  const OtpSendResponse({
-    required this.requestId,
-    required this.expiresIn,
-    required this.resendAfter,
-  });
-
-  final String requestId;
-  final int expiresIn;
-  final int resendAfter;
-
   factory OtpSendResponse.fromJson(Map<String, dynamic> json) {
     final requestId = json['requestId'] as String?;
     final expiresIn = json['expiresIn'];
@@ -77,4 +66,13 @@ class OtpSendResponse {
       resendAfter: resendAfter.toInt(),
     );
   }
+  const OtpSendResponse({
+    required this.requestId,
+    required this.expiresIn,
+    required this.resendAfter,
+  });
+
+  final String requestId;
+  final int expiresIn;
+  final int resendAfter;
 }

--- a/lib/features/auth/domain/user_profile.dart
+++ b/lib/features/auth/domain/user_profile.dart
@@ -11,6 +11,23 @@ SubscriptionTier? _subscriptionTierFromJson(Object? value) {
 }
 
 class UserProfile {
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      id: json['id']?.toString() ?? '',
+      email: json['email'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      avatarUrl: json['avatarUrl'] as String?,
+      balance: _doubleFromJson(json['balance']),
+      hasMixin: json['hasMixin'] as bool?,
+      subscriptionTier: _subscriptionTierFromJson(json['subscriptionTier']),
+      subscriptionExpireDate: json['subscriptionExpireDate'] as String?,
+      locale: json['locale'] as String?,
+      learningLanguage: json['learningLanguage'] as String?,
+      nativeLanguage: json['nativeLanguage'] as String?,
+      goal: _intFromJson(json['goal']),
+      createdAt: json['createdAt'] as String?,
+    );
+  }
   const UserProfile({
     required this.id,
     required this.email,
@@ -40,24 +57,6 @@ class UserProfile {
   final String? nativeLanguage;
   final int? goal;
   final String? createdAt;
-
-  factory UserProfile.fromJson(Map<String, dynamic> json) {
-    return UserProfile(
-      id: json['id']?.toString() ?? '',
-      email: json['email'] as String? ?? '',
-      name: json['name'] as String? ?? '',
-      avatarUrl: json['avatarUrl'] as String?,
-      balance: _doubleFromJson(json['balance']),
-      hasMixin: json['hasMixin'] as bool?,
-      subscriptionTier: _subscriptionTierFromJson(json['subscriptionTier']),
-      subscriptionExpireDate: json['subscriptionExpireDate'] as String?,
-      locale: json['locale'] as String?,
-      learningLanguage: json['learningLanguage'] as String?,
-      nativeLanguage: json['nativeLanguage'] as String?,
-      goal: _intFromJson(json['goal']),
-      createdAt: json['createdAt'] as String?,
-    );
-  }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{

--- a/lib/features/auth/presentation/widgets/auth_required_callout.dart
+++ b/lib/features/auth/presentation/widgets/auth_required_callout.dart
@@ -1,6 +1,8 @@
 /// Reusable “sign in to use this feature” UI for Enjoy account–gated flows.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -77,7 +79,7 @@ class AuthRequiredCallout extends ConsumerWidget {
   final bool compact;
 
   void _openSignIn(BuildContext context) {
-    context.push('/sign-in?from=${surface.fromQueryParam}');
+    unawaited(context.push('/sign-in?from=${surface.fromQueryParam}'));
   }
 
   @override

--- a/lib/features/cloud/presentation/cloud_library_body.dart
+++ b/lib/features/cloud/presentation/cloud_library_body.dart
@@ -1,6 +1,8 @@
 /// Remote cloud index tab bodies (paginated audio / video).
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -48,7 +50,7 @@ class CloudLibraryBodyState extends ConsumerState<CloudLibraryBody> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _loadInitial();
+      unawaited(_loadInitial());
     });
   }
 
@@ -126,9 +128,9 @@ class CloudLibraryBodyState extends ConsumerState<CloudLibraryBody> {
   /// Refreshes the audio or video tab matching [tabController.index].
   void refreshActiveTab() {
     if (widget.tabController.index == 0) {
-      _loadAudioPage(reset: true);
+      unawaited(_loadAudioPage(reset: true));
     } else {
-      _loadVideoPage(reset: true);
+      unawaited(_loadVideoPage(reset: true));
     }
   }
 
@@ -218,7 +220,7 @@ class _CloudAudioListState extends ConsumerState<_CloudAudioList> {
         !widget.loading &&
         _scroll.hasClients &&
         _scroll.position.pixels > _scroll.position.maxScrollExtent - 200) {
-      widget.onLoadMore();
+      unawaited(widget.onLoadMore());
     }
   }
 
@@ -290,7 +292,7 @@ class _CloudAudioRowState extends ConsumerState<_CloudAudioRow> {
   @override
   void initState() {
     super.initState();
-    _load();
+    unawaited(_load());
   }
 
   Future<void> _load() async {
@@ -417,7 +419,7 @@ class _CloudVideoGridState extends ConsumerState<_CloudVideoGrid> {
         !widget.loading &&
         _scroll.hasClients &&
         _scroll.position.pixels > _scroll.position.maxScrollExtent - 200) {
-      widget.onLoadMore();
+      unawaited(widget.onLoadMore());
     }
   }
 
@@ -499,7 +501,7 @@ class _CloudVideoTileState extends ConsumerState<_CloudVideoTile> {
   @override
   void initState() {
     super.initState();
-    _load();
+    unawaited(_load());
   }
 
   Future<void> _load() async {

--- a/lib/features/community/domain/active_user.dart
+++ b/lib/features/community/domain/active_user.dart
@@ -20,12 +20,6 @@ int? _intFromJson(Object? value) {
 }
 
 class ActiveUser {
-  const ActiveUser({required this.id, required this.name, this.avatarUrl});
-
-  final String id;
-  final String name;
-  final String? avatarUrl;
-
   factory ActiveUser.fromJson(Map<String, dynamic> json) {
     return ActiveUser(
       id: json['id']?.toString() ?? '',
@@ -33,23 +27,14 @@ class ActiveUser {
       avatarUrl: json['avatarUrl'] as String?,
     );
   }
+  const ActiveUser({required this.id, required this.name, this.avatarUrl});
+
+  final String id;
+  final String name;
+  final String? avatarUrl;
 }
 
 class ActiveUsersResponse {
-  const ActiveUsersResponse({
-    required this.users,
-    required this.count,
-    this.recordingsCountToday,
-    this.recordingsDurationToday,
-  });
-
-  final List<ActiveUser> users;
-  final int count;
-  final int? recordingsCountToday;
-
-  /// Total practice duration for the community today, milliseconds.
-  final int? recordingsDurationToday;
-
   factory ActiveUsersResponse.fromJson(Map<String, dynamic> json) {
     final rawUsers = json['users'];
     final users = <ActiveUser>[];
@@ -68,4 +53,17 @@ class ActiveUsersResponse {
       recordingsDurationToday: _intFromJson(json['recordingsDurationToday']),
     );
   }
+  const ActiveUsersResponse({
+    required this.users,
+    required this.count,
+    this.recordingsCountToday,
+    this.recordingsDurationToday,
+  });
+
+  final List<ActiveUser> users;
+  final int count;
+  final int? recordingsCountToday;
+
+  /// Total practice duration for the community today, milliseconds.
+  final int? recordingsDurationToday;
 }

--- a/lib/features/credits/domain/credits_usage_log.dart
+++ b/lib/features/credits/domain/credits_usage_log.dart
@@ -2,6 +2,27 @@
 library;
 
 class CreditsUsageLog {
+  factory CreditsUsageLog.fromJson(Map<String, dynamic> json) {
+    final metaRaw = json['meta'];
+    Map<String, Object?>? meta;
+    if (metaRaw is Map) {
+      meta = metaRaw.map((k, v) => MapEntry(k.toString(), v as Object?));
+    }
+
+    return CreditsUsageLog(
+      id: json['id']?.toString() ?? '',
+      userId: json['userId']?.toString() ?? '',
+      date: json['date']?.toString() ?? '',
+      timestampMs: _intFromJson(json['timestamp']) ?? 0,
+      serviceType: json['serviceType']?.toString() ?? '',
+      tier: json['tier']?.toString() ?? '',
+      creditsRequired: _intFromJson(json['required']) ?? 0,
+      usedBefore: _intFromJson(json['usedBefore']) ?? 0,
+      usedAfter: _intFromJson(json['usedAfter']) ?? 0,
+      allowed: _boolFromJson(json['allowed']) ?? false,
+      meta: meta,
+    );
+  }
   const CreditsUsageLog({
     required this.id,
     required this.userId,
@@ -29,28 +50,6 @@ class CreditsUsageLog {
   final int usedAfter;
   final bool allowed;
   final Map<String, Object?>? meta;
-
-  factory CreditsUsageLog.fromJson(Map<String, dynamic> json) {
-    final metaRaw = json['meta'];
-    Map<String, Object?>? meta;
-    if (metaRaw is Map) {
-      meta = metaRaw.map((k, v) => MapEntry(k.toString(), v as Object?));
-    }
-
-    return CreditsUsageLog(
-      id: json['id']?.toString() ?? '',
-      userId: json['userId']?.toString() ?? '',
-      date: json['date']?.toString() ?? '',
-      timestampMs: _intFromJson(json['timestamp']) ?? 0,
-      serviceType: json['serviceType']?.toString() ?? '',
-      tier: json['tier']?.toString() ?? '',
-      creditsRequired: _intFromJson(json['required']) ?? 0,
-      usedBefore: _intFromJson(json['usedBefore']) ?? 0,
-      usedAfter: _intFromJson(json['usedAfter']) ?? 0,
-      allowed: _boolFromJson(json['allowed']) ?? false,
-      meta: meta,
-    );
-  }
 }
 
 int? _intFromJson(Object? value) {

--- a/lib/features/discover/application/discover_providers.dart
+++ b/lib/features/discover/application/discover_providers.dart
@@ -41,6 +41,16 @@ Stream<List<DiscoverChannel>> discoverSubscriptions(Ref ref) {
   return ref.watch(discoverRepositoryProvider).watchSubscriptions();
 }
 
+/// Waits until [channelId] appears on [discoverSubscriptionsProvider]'s stream.
+Future<void> waitForDiscoverSubscription(WidgetRef ref, String channelId) async {
+  final repo = ref.read(discoverRepositoryProvider);
+  if (await repo.getSubscription(channelId) != null) return;
+
+  await repo.watchSubscriptions().firstWhere(
+    (subs) => subs.any((s) => s.channelId == channelId),
+  );
+}
+
 @Riverpod(keepAlive: true)
 Stream<List<FeedEntry>> discoverTimeline(Ref ref) {
   return ref.watch(discoverRepositoryProvider).watchTimeline();

--- a/lib/features/discover/domain/recommended_channel.dart
+++ b/lib/features/discover/domain/recommended_channel.dart
@@ -2,6 +2,20 @@
 library;
 
 class RecommendedChannel {
+  factory RecommendedChannel.fromJson(Map<String, dynamic> json) {
+    final tagsRaw = json['tags'];
+    return RecommendedChannel(
+      channelId: json['channelId'] as String,
+      name: json['name'] as String,
+      handle: json['handle'] as String?,
+      description: json['description'] as String?,
+      thumbnailUrl: json['thumbnailUrl'] as String?,
+      language: json['language'] as String? ?? 'en',
+      tags: tagsRaw is List
+          ? tagsRaw.map((e) => e.toString()).toList(growable: false)
+          : const [],
+    );
+  }
   const RecommendedChannel({
     required this.channelId,
     required this.name,
@@ -19,19 +33,4 @@ class RecommendedChannel {
   final String? thumbnailUrl;
   final String language;
   final List<String> tags;
-
-  factory RecommendedChannel.fromJson(Map<String, dynamic> json) {
-    final tagsRaw = json['tags'];
-    return RecommendedChannel(
-      channelId: json['channelId'] as String,
-      name: json['name'] as String,
-      handle: json['handle'] as String?,
-      description: json['description'] as String?,
-      thumbnailUrl: json['thumbnailUrl'] as String?,
-      language: json['language'] as String? ?? 'en',
-      tags: tagsRaw is List
-          ? tagsRaw.map((e) => e.toString()).toList(growable: false)
-          : const [],
-    );
-  }
 }

--- a/lib/features/discover/presentation/discover_actions.dart
+++ b/lib/features/discover/presentation/discover_actions.dart
@@ -26,8 +26,7 @@ Future<void> subscribeRecommendedChannel(
     return;
   }
 
-  // Let the subscription stream rebuild finish before refresh + notice.
-  await Future<void>.delayed(Duration.zero);
+  await waitForDiscoverSubscription(ref, channel.channelId);
   if (!context.mounted) return;
 
   try {

--- a/lib/features/discover/presentation/discover_subscription_row.dart
+++ b/lib/features/discover/presentation/discover_subscription_row.dart
@@ -1,6 +1,8 @@
 /// Single row in the Discover subscriptions management list.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -93,7 +95,7 @@ class DiscoverSubscriptionRow extends ConsumerWidget {
         onTap: navigateToFeed
             ? () {
                 Haptics.selection(context);
-                context.push('/discover/channel/${channel.channelId}');
+                unawaited(context.push('/discover/channel/${channel.channelId}'));
               }
             : null,
         child: row,

--- a/lib/features/hotkeys/presentation/app_hotkeys_keyboard_listener.dart
+++ b/lib/features/hotkeys/presentation/app_hotkeys_keyboard_listener.dart
@@ -106,7 +106,7 @@ class _AppHotkeysKeyboardListenerState
       switch (action) {
         case EscapeDismissalAction.closeCheatsheet:
           if (navCtx != null) {
-            Navigator.of(navCtx, rootNavigator: true).maybePop();
+            unawaited(Navigator.of(navCtx, rootNavigator: true).maybePop());
           }
           return true;
         case EscapeDismissalAction.exitFullscreen:
@@ -139,7 +139,7 @@ class _AppHotkeysKeyboardListenerState
     if (_matches(event, ctrl, 'global.help')) {
       if (navCtx == null) return false;
       if (hotkeysCheatsheetOpen.value) {
-        Navigator.of(navCtx, rootNavigator: true).maybePop();
+        unawaited(Navigator.of(navCtx, rootNavigator: true).maybePop());
         return true;
       }
       unawaited(showHotkeysHelpDialog(navCtx));

--- a/lib/features/hotkeys/presentation/hotkeys_help_dialog.dart
+++ b/lib/features/hotkeys/presentation/hotkeys_help_dialog.dart
@@ -1,6 +1,8 @@
 /// Read-only list of shortcuts (web `HotkeysHelpModal` parity) — premium cheatsheet.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -179,7 +181,7 @@ class _HotkeysHelpDialogState extends ConsumerState<HotkeysHelpDialog> {
                     onPressed: () {
                       final router = GoRouter.of(context);
                       Navigator.of(context).pop();
-                      router.push('/settings/keyboard');
+                      unawaited(router.push('/settings/keyboard'));
                     },
                     child: Text(l10n.hotkeysHelpCustomize),
                   ),

--- a/lib/features/library/data/library_repository.dart
+++ b/lib/features/library/data/library_repository.dart
@@ -107,8 +107,8 @@ class MediaLibraryRepository {
         emit(controller);
       }, onError: controller.addError);
       controller.onCancel = () {
-        subV.cancel();
-        subA.cancel();
+        unawaited(subV.cancel());
+        unawaited(subA.cancel());
       };
     });
   }
@@ -547,9 +547,7 @@ Duration? _probeDurationInIsolate(String ffmpeg, String input) {
   }
   final stderr = result.stderr is String
       ? result.stderr as String
-      : String.fromCharCodes(
-          (result.stderr as List<int>?) ?? const <int>[],
-        );
+      : String.fromCharCodes((result.stderr as List<int>?) ?? const <int>[]);
   final sec = FfmpegMediaProbe.parseDurationSeconds(stderr);
   if (sec == null || sec <= 0) return null;
   return Duration(seconds: sec);

--- a/lib/features/library/domain/learning_statistics.dart
+++ b/lib/features/library/domain/learning_statistics.dart
@@ -38,6 +38,13 @@ class PeriodStats {
 }
 
 class LearningStatistics {
+  factory LearningStatistics.fromJson(Map<String, dynamic> json) {
+    return LearningStatistics(
+      today: PeriodStats.fromJson(_jsonObjectAsStringMap(json['today'])),
+      week: PeriodStats.fromJson(_jsonObjectAsStringMap(json['week'])),
+      month: PeriodStats.fromJson(_jsonObjectAsStringMap(json['month'])),
+    );
+  }
   const LearningStatistics({
     required this.today,
     required this.week,
@@ -53,12 +60,4 @@ class LearningStatistics {
     week: PeriodStats.zero(),
     month: PeriodStats.zero(),
   );
-
-  factory LearningStatistics.fromJson(Map<String, dynamic> json) {
-    return LearningStatistics(
-      today: PeriodStats.fromJson(_jsonObjectAsStringMap(json['today'])),
-      week: PeriodStats.fromJson(_jsonObjectAsStringMap(json['week'])),
-      month: PeriodStats.fromJson(_jsonObjectAsStringMap(json['month'])),
-    );
-  }
 }

--- a/lib/features/library/presentation/widgets/compact_library_search_bar.dart
+++ b/lib/features/library/presentation/widgets/compact_library_search_bar.dart
@@ -61,8 +61,7 @@ class _CompactLibrarySearchBarState
         focusNode: compactFocusNode,
         controller: _controller,
         onChanged: (v) => ref.read(librarySearchProvider.notifier).setQuery(v),
-        onSubmitted: (_) =>
-            ref.read(librarySearchProvider.notifier).commit(),
+        onSubmitted: (_) => ref.read(librarySearchProvider.notifier).commit(),
         style: tt.bodyMedium,
         textInputAction: TextInputAction.search,
         decoration: InputDecoration(

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -25,8 +25,7 @@ class YoutubePlayerEngine implements PlayerEngine {
     _webView = YoutubeWebViewController(
       session: _session,
       onStallRecovery: () => _webView.recoverStalledPlayback(),
-      onLogInitPhase: (phase) =>
-          _session.logInitPhase(phase, _logYoutube.info),
+      onLogInitPhase: (phase) => _session.logInitPhase(phase, _logYoutube.info),
     );
   }
 
@@ -116,7 +115,10 @@ class YoutubePlayerEngine implements PlayerEngine {
           children: [
             const ColoredBox(color: Colors.black),
             if (shouldMountWebView) buildWebViewHost(),
-            YoutubeVideoPoster(primaryUrl: _session.posterUrl, visible: showPoster),
+            YoutubeVideoPoster(
+              primaryUrl: _session.posterUrl,
+              visible: showPoster,
+            ),
           ],
         );
       },
@@ -244,10 +246,7 @@ class YoutubePlayerEngine implements PlayerEngine {
     _webView.onWebViewDisposed(controller);
   }
 
-  Future<void> onPageFinished(
-    InAppWebViewController controller,
-    String? url,
-  ) =>
+  Future<void> onPageFinished(InAppWebViewController controller, String? url) =>
       _webView.onPageFinished(controller, url);
 
   Future<void> exitNativeFullscreen(InAppWebViewController controller) =>

--- a/lib/features/player/application/engines/youtube/youtube_session.dart
+++ b/lib/features/player/application/engines/youtube/youtube_session.dart
@@ -13,8 +13,7 @@ class YoutubeSession {
       StreamController<Duration>.broadcast();
   final StreamController<Duration> durationCtrl =
       StreamController<Duration>.broadcast();
-  final StreamController<bool> playingCtrl =
-      StreamController<bool>.broadcast();
+  final StreamController<bool> playingCtrl = StreamController<bool>.broadcast();
   final StreamController<bool> bufferingCtrl =
       StreamController<bool>.broadcast();
 

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -24,15 +24,15 @@ class YoutubeWebViewController {
     required this.onStallRecovery,
     required this.onLogInitPhase,
   }) : _stallWatchdog = YoutubePlaybackStallWatchdog(
-          timeout: const Duration(seconds: 12),
-          onStall: (videoId) {
-            if (session.playing) return;
-            _logWebView.warning(
-              'youtube playback stalled after load_stop vid=$videoId',
-            );
-            onStallRecovery();
-          },
-        ) {
+         timeout: const Duration(seconds: 12),
+         onStall: (videoId) {
+           if (session.playing) return;
+           _logWebView.warning(
+             'youtube playback stalled after load_stop vid=$videoId',
+           );
+           unawaited(onStallRecovery());
+         },
+       ) {
     _events = YoutubeWebViewEvents(
       session: session,
       webController: () => _webController,
@@ -149,9 +149,7 @@ class YoutubeWebViewController {
     _pollLoop.stop();
   }
 
-  Future<void> onSignInNavigationBlocked(
-    InAppWebViewController controller,
-  ) =>
+  Future<void> onSignInNavigationBlocked(InAppWebViewController controller) =>
       _navigation.onSignInNavigationBlocked(
         controller,
         prepareWatchReload: () => prepareWatchReload(resetFirstPlaying: false),

--- a/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
@@ -67,7 +67,9 @@ class YoutubeWebViewNavigation {
     final gen = captureVerifyGeneration();
     await Future<void>.delayed(delay);
     if (isVerifyGenerationStale(gen)) return;
-    if (session.disposed || session.videoId.isEmpty || webController() == null) {
+    if (session.disposed ||
+        session.videoId.isEmpty ||
+        webController() == null) {
       return;
     }
     if (session.loggedFirstPlaying) return;
@@ -85,9 +87,7 @@ class YoutubeWebViewNavigation {
     if (session.nonWatchRecoveryScheduled) return;
     session.nonWatchRecoveryScheduled = true;
     _logNav.info('youtube non-watch load_stop; verifying watch page');
-    unawaited(
-      ensureWatchPageLoadedAfterDelay(skipIfLoadStopReceived: true),
-    );
+    unawaited(ensureWatchPageLoadedAfterDelay(skipIfLoadStopReceived: true));
   }
 
   void schedulePlaybackNudge() {
@@ -110,9 +110,7 @@ class YoutubeWebViewNavigation {
     final controller = webController();
     final vid = session.videoId;
     if (controller == null || vid.isEmpty || session.disposed) return;
-    _logNav.warning(
-      'youtube WebView process terminated; reloading vid=$vid',
-    );
+    _logNav.warning('youtube WebView process terminated; reloading vid=$vid');
     prepareWatchReload();
     session.emitBuffering(true);
     session.emitPlaying(false);

--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -74,7 +74,8 @@ class YoutubeWebViewPollLoop {
               session.emitPlaying(false);
             } else if (jsPaused && session.playing && !jsEnded) {
               session.pausedPollStreak++;
-              if (session.pausedPollStreak >= YoutubeSession.pauseConfirmPollTicks) {
+              if (session.pausedPollStreak >=
+                  YoutubeSession.pauseConfirmPollTicks) {
                 session.pausedPollStreak = 0;
                 session.emitPlaying(false);
                 stop();

--- a/lib/features/player/application/player_open_coordinator.dart
+++ b/lib/features/player/application/player_open_coordinator.dart
@@ -116,7 +116,9 @@ Future<void> runPlayerOpen(PlayerOpenHost host, Ref ref, String mediaId) async {
   if (host.isOpenStale(gen)) return;
 
   if (persisted != null && persisted.echoActive) {
-    ref.read(echoModeProvider.notifier).restoreFromSession(
+    ref
+        .read(echoModeProvider.notifier)
+        .restoreFromSession(
           startLine: persisted.echoStartLine,
           endLine: persisted.echoEndLine,
           echoStartMs: persisted.echoStartMs ?? 0,
@@ -156,17 +158,15 @@ Future<void> runPlayerOpen(PlayerOpenHost host, Ref ref, String mediaId) async {
   );
 
   if (playable is YoutubePlayableSource) {
-    scheduleYoutubeMetadataRefresh(
-      ref,
-      mediaId: mediaId,
-      openGeneration: gen,
-    );
+    scheduleYoutubeMetadataRefresh(ref, mediaId: mediaId, openGeneration: gen);
   }
 
   if (kind == MediaKind.video &&
       video != null &&
       engine.supportsVideoPosterCapture) {
-    ref.read(videoPosterCaptureServiceProvider).scheduleCapture(
+    ref
+        .read(videoPosterCaptureServiceProvider)
+        .scheduleCapture(
           mediaId: mediaId,
           video: video,
           restoredPositionMs: posMs,

--- a/lib/features/player/application/player_open_side_effects.dart
+++ b/lib/features/player/application/player_open_side_effects.dart
@@ -129,7 +129,9 @@ Future<void> _runYoutubeMetadataRefresh(
       .refreshYoutubeMetadataIfNeeded(mediaId);
   if (patch == null) return;
 
-  ref.read(playerMetadataProvider.notifier).patchIfCurrent(
+  ref
+      .read(playerMetadataProvider.notifier)
+      .patchIfCurrent(
         mediaId: mediaId,
         openGeneration: openGeneration,
         title: patch.title,

--- a/lib/features/player/application/player_preferences_provider.dart
+++ b/lib/features/player/application/player_preferences_provider.dart
@@ -1,6 +1,7 @@
 /// Persisted volume / speed / repeat (maps web persisted settings).
 library;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -20,7 +21,7 @@ class PlayerPreferencesCtrl extends _$PlayerPreferencesCtrl {
 
   @override
   PlayerPreferences build() {
-    Future<void>.microtask(_hydrate);
+    unawaited(Future<void>.microtask(_hydrate));
     return PlayerPreferences.defaults;
   }
 

--- a/lib/features/player/presentation/widgets/global_transport_bar.dart
+++ b/lib/features/player/presentation/widgets/global_transport_bar.dart
@@ -143,7 +143,7 @@ class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
 
   void _openPlaybackRateSheet() {
     final t = EnjoyThemeTokens.of(context);
-    showEnjoySheet<void>(
+    unawaited(showEnjoySheet<void>(
       context: context,
       builder: (sheetCtx) {
         final prefs = ref.read(playerPreferencesCtrlProvider);
@@ -183,9 +183,11 @@ class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
                     title: Text(l10n.playbackRateTimes(_formatRateCore(r))),
                     onTap: () {
                       Haptics.selection(sheetCtx);
-                      ref
-                          .read(playerPreferencesCtrlProvider.notifier)
-                          .setPlaybackRate(r);
+                      unawaited(
+                        ref
+                            .read(playerPreferencesCtrlProvider.notifier)
+                            .setPlaybackRate(r),
+                      );
                       Navigator.pop(sheetCtx);
                     },
                   ),
@@ -195,7 +197,7 @@ class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
           ),
         );
       },
-    );
+    ));
   }
 
   @override

--- a/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
@@ -1,6 +1,8 @@
 /// Progress slider + elapsed / total times for the transport bar.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
@@ -134,9 +136,11 @@ class _TransportProgressStripState
                         Haptics.selection(context);
                       }
                     }
-                    ref
-                        .read(playerInteractionsProvider.notifier)
-                        .seekToProgressFraction(v);
+                    unawaited(
+                      ref
+                          .read(playerInteractionsProvider.notifier)
+                          .seekToProgressFraction(v),
+                    );
                   },
                 ),
               ),

--- a/lib/features/player/presentation/widgets/transport/transport_volume_button.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_volume_button.dart
@@ -1,7 +1,7 @@
 /// Volume icon + vertical slider overlay for the transport bar.
 library;
 
-import 'dart:async' show Timer;
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -68,7 +68,7 @@ class _TransportVolumeButtonState extends ConsumerState<TransportVolumeButton> {
 
   void _toggleMute() {
     _cancelHideTimer();
-    ref.read(playerPreferencesCtrlProvider.notifier).toggleMute();
+    unawaited(ref.read(playerPreferencesCtrlProvider.notifier).toggleMute());
   }
 
   /// Returns (left, top) in global coordinates for the popup card.

--- a/lib/features/player/presentation/youtube_login_screen.dart
+++ b/lib/features/player/presentation/youtube_login_screen.dart
@@ -1,6 +1,8 @@
 /// Full-screen WebView for Google / YouTube sign-in (shared cookie jar with player WebView).
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -49,7 +51,7 @@ class _YoutubeLoginScreenState extends ConsumerState<YoutubeLoginScreen> {
                     icon: const Icon(Icons.close_rounded, size: 24),
                     color: colorScheme.onSurface,
                     onPressed: () {
-                      HapticFeedback.lightImpact();
+                      unawaited(HapticFeedback.lightImpact());
                       ref.invalidate(youtubeLoginStateProvider);
                       context.pop();
                     },
@@ -71,7 +73,7 @@ class _YoutubeLoginScreenState extends ConsumerState<YoutubeLoginScreen> {
                     icon: const Icon(Icons.logout_rounded, size: 22),
                     color: colorScheme.onSurfaceVariant,
                     onPressed: () async {
-                      HapticFeedback.lightImpact();
+                      unawaited(HapticFeedback.lightImpact());
                       await CookieManager.instance(
                         webViewEnvironment: appWebViewEnvironment,
                       ).deleteAllCookies();

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -1459,8 +1459,9 @@ class _AiApiBaseUrlEditorState extends ConsumerState<_AiApiBaseUrlEditor> {
                           await ref
                               .read(aiApiBaseUrlProvider.notifier)
                               .clearOverride();
-                          final url = await ref
-                              .read(aiApiBaseUrlProvider.future);
+                          final url = await ref.read(
+                            aiApiBaseUrlProvider.future,
+                          );
                           if (mounted) {
                             _controller.text = url;
                           }

--- a/lib/features/settings/presentation/widgets/about_section_card.dart
+++ b/lib/features/settings/presentation/widgets/about_section_card.dart
@@ -1,6 +1,8 @@
 /// About card — app identity, version, and open-source link.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -278,12 +280,14 @@ class _AboutSectionCardState extends ConsumerState<AboutSectionCard> {
                                       data: (enabled) => Switch.adaptive(
                                         value: enabled,
                                         onChanged: (value) {
-                                          ref
-                                              .read(
-                                                diagnosticsVerboseProvider
-                                                    .notifier,
-                                              )
-                                              .setEnabled(value);
+                                          unawaited(
+                                            ref
+                                                .read(
+                                                  diagnosticsVerboseProvider
+                                                      .notifier,
+                                                )
+                                                .setEnabled(value),
+                                          );
                                         },
                                       ),
                                       loading: () => const SizedBox(

--- a/lib/features/shadow_reading/presentation/shadow_reading_panel.dart
+++ b/lib/features/shadow_reading/presentation/shadow_reading_panel.dart
@@ -178,7 +178,9 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
 
   void _startElapsedTicker() {
     _stopElapsedTicker();
-    _elapsedTicker = createTicker(_onElapsedTick)..start();
+    final ticker = createTicker(_onElapsedTick);
+    unawaited(ticker.start());
+    _elapsedTicker = ticker;
   }
 
   void _clearRecordingTiming() {

--- a/lib/features/sync/application/pending_rekey_provider.dart
+++ b/lib/features/sync/application/pending_rekey_provider.dart
@@ -20,19 +20,19 @@ final pendingRekeyRowCountProvider = StreamProvider<int>((ref) {
       (db.select(db.audios)
             ..where((t) => t.syncStatus.equals('local-pending-rekey')))
           .watch()
-          .listen((_) => emit());
+          .listen((_) => unawaited(emit()));
   final subV =
       (db.select(db.videos)
             ..where((t) => t.syncStatus.equals('local-pending-rekey')))
           .watch()
-          .listen((_) => emit());
+          .listen((_) => unawaited(emit()));
 
   ref.onDispose(() {
-    subA.cancel();
-    subV.cancel();
-    controller.close();
+    unawaited(subA.cancel());
+    unawaited(subV.cancel());
+    unawaited(controller.close());
   });
 
-  emit();
+  unawaited(emit());
   return controller.stream;
 });

--- a/lib/features/sync/application/rekey_local_rows.dart
+++ b/lib/features/sync/application/rekey_local_rows.dart
@@ -272,7 +272,7 @@ Future<void> _retargetMediaForeignKeys(
 Future<int> countPendingRekeyRows(AppDatabase db) async {
   final v = await db
       .customSelect(
-        "SELECT COUNT(*) AS c FROM videos WHERE sync_status = ?",
+        'SELECT COUNT(*) AS c FROM videos WHERE sync_status = ?',
         variables: [Variable.withString('local-pending-rekey')],
         readsFrom: {db.videos},
       )
@@ -280,7 +280,7 @@ Future<int> countPendingRekeyRows(AppDatabase db) async {
       .getSingle();
   final a = await db
       .customSelect(
-        "SELECT COUNT(*) AS c FROM audios WHERE sync_status = ?",
+        'SELECT COUNT(*) AS c FROM audios WHERE sync_status = ?',
         variables: [Variable.withString('local-pending-rekey')],
         readsFrom: {db.audios},
       )

--- a/lib/features/sync/application/sync_controller.dart
+++ b/lib/features/sync/application/sync_controller.dart
@@ -66,9 +66,7 @@ class SyncCtrl extends _$SyncCtrl {
       // get the guest DB. Defer to a post-frame + a microtask and then
       // re-check; retry up to [_kSignInDbResolveMaxFrames] frames before
       // giving up and logging.
-      for (var attempt = 0;
-          attempt < _kSignInDbResolveMaxFrames;
-          attempt++) {
+      for (var attempt = 0; attempt < _kSignInDbResolveMaxFrames; attempt++) {
         await Future<void>.delayed(Duration.zero);
         if (ref.read(authCtrlProvider).valueOrNull is! AuthSignedIn) return;
         final db = ref.read(appDatabaseProvider);

--- a/lib/features/sync/data/recording_target_sync_service.dart
+++ b/lib/features/sync/data/recording_target_sync_service.dart
@@ -40,10 +40,14 @@ class RecordingTargetSyncService {
     final errors = <String>[];
     var synced = 0;
     var failed = 0;
-    final cursorKey =
-        SettingsKeys.syncCursorRecordingTarget(targetType, targetId);
-    final cooldownKey =
-        SettingsKeys.syncLastPullAtRecordingTarget(targetType, targetId);
+    final cursorKey = SettingsKeys.syncCursorRecordingTarget(
+      targetType,
+      targetId,
+    );
+    final cooldownKey = SettingsKeys.syncLastPullAtRecordingTarget(
+      targetType,
+      targetId,
+    );
 
     // Cooldown: short-circuit when we just pulled for this target.
     final clock = now ?? DateTime.now();
@@ -51,8 +55,7 @@ class RecordingTargetSyncService {
     final lastPull = lastPullRaw == null
         ? null
         : DateTime.tryParse(lastPullRaw)?.toUtc();
-    if (lastPull != null &&
-        clock.toUtc().difference(lastPull) < _kCooldown) {
+    if (lastPull != null && clock.toUtc().difference(lastPull) < _kCooldown) {
       _log.fine(
         'pullRecordingsForTarget($targetType:$targetId): skipped, '
         'cooldown active (last pull $lastPull, now $clock)',

--- a/lib/features/sync/data/sync_queue_repository.dart
+++ b/lib/features/sync/data/sync_queue_repository.dart
@@ -55,13 +55,8 @@ class SyncQueueRepository {
             .getSingleOrNull();
 
     if (existing != null) {
-      await (_db.update(
-        _db.syncQueue,
-      )..where((t) => t.id.equals(existing.id))).write(
-        SyncQueueCompanion(
-          payloadJson: Value(payloadJson),
-        ),
-      );
+      await (_db.update(_db.syncQueue)..where((t) => t.id.equals(existing.id)))
+          .write(SyncQueueCompanion(payloadJson: Value(payloadJson)));
       return existing.id;
     }
 

--- a/lib/features/transcript/application/transcript_line_alignment.dart
+++ b/lib/features/transcript/application/transcript_line_alignment.dart
@@ -9,11 +9,6 @@ import 'package:enjoy_player/features/player/application/echo_mode_provider.dart
 ///
 /// [secondary] is copied and sorted by [TranscriptLine.startSeconds] once.
 class TranscriptSecondaryMatcher {
-  TranscriptSecondaryMatcher._(this._sec);
-
-  /// Sorted by [TranscriptLine.startSeconds] ascending.
-  final List<TranscriptLine> _sec;
-
   factory TranscriptSecondaryMatcher.from(List<TranscriptLine> secondary) {
     if (secondary.isEmpty) {
       return TranscriptSecondaryMatcher._(const []);
@@ -22,6 +17,10 @@ class TranscriptSecondaryMatcher {
       ..sort((a, b) => a.startSeconds.compareTo(b.startSeconds));
     return TranscriptSecondaryMatcher._(copy);
   }
+  TranscriptSecondaryMatcher._(this._sec);
+
+  /// Sorted by [TranscriptLine.startSeconds] ascending.
+  final List<TranscriptLine> _sec;
 
   /// Last secondary cue with [TranscriptLine.startSeconds] strictly less than [pEnd].
   TranscriptLine? _lastWithStartBefore(double pEnd) {

--- a/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
+++ b/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
@@ -1,6 +1,7 @@
 /// Bottom sheet for selecting primary + secondary subtitle tracks.
-// ignore_for_file: deprecated_member_use
 library;
+
+import 'dart:async';
 
 import 'package:cross_file/cross_file.dart';
 import 'package:file_picker/file_picker.dart';
@@ -298,37 +299,50 @@ class _SubtitleTrackPickerSheetState
             ),
           )
         else
-          ...tracks.map(
-            (track) => _TrackTile(
-              track: track,
-              contentPadding: _sheetRowPadding(t),
-              groupValue: primaryId,
-              onTap: () => ref
-                  .read(transcriptRepositoryProvider)
-                  .setActiveTranscript(widget.mediaId, track.id),
-              onDelete: () => _deleteTrack(track),
+          RadioGroup<String?>(
+            groupValue: primaryId,
+            onChanged: (id) {
+              if (id == null) return;
+              unawaited(
+                ref
+                    .read(transcriptRepositoryProvider)
+                    .setActiveTranscript(widget.mediaId, id),
+              );
+            },
+            child: Column(
+              children: tracks
+                  .map(
+                    (track) => _TrackTile(
+                      track: track,
+                      contentPadding: _sheetRowPadding(t),
+                      onDelete: () => _deleteTrack(track),
+                    ),
+                  )
+                  .toList(),
             ),
           ),
         SizedBox(height: t.space8),
         _SectionHeader(l10n.subtitlesTranslation),
-        RadioListTile<String?>(
-          contentPadding: _sheetRowPadding(t),
-          value: null,
+        RadioGroup<String?>(
           groupValue: secondaryId,
-          onChanged: (_) => ref
+          onChanged: (id) => ref
               .read(transcriptRepositoryProvider)
-              .setSecondaryTranscript(widget.mediaId, null),
-          title: Text(l10n.subtitlesNone),
-        ),
-        ...tracks.map(
-          (track) => _TrackTile(
-            track: track,
-            contentPadding: _sheetRowPadding(t),
-            groupValue: secondaryId,
-            onTap: () => ref
-                .read(transcriptRepositoryProvider)
-                .setSecondaryTranscript(widget.mediaId, track.id),
-            onDelete: () => _deleteTrack(track),
+              .setSecondaryTranscript(widget.mediaId, id),
+          child: Column(
+            children: [
+              RadioListTile<String?>(
+                contentPadding: _sheetRowPadding(t),
+                value: null,
+                title: Text(l10n.subtitlesNone),
+              ),
+              ...tracks.map(
+                (track) => _TrackTile(
+                  track: track,
+                  contentPadding: _sheetRowPadding(t),
+                  onDelete: () => _deleteTrack(track),
+                ),
+              ),
+            ],
           ),
         ),
         const Divider(),
@@ -516,15 +530,11 @@ class _TrackTile extends StatelessWidget {
   const _TrackTile({
     required this.track,
     required this.contentPadding,
-    required this.groupValue,
-    required this.onTap,
     required this.onDelete,
   });
 
   final TranscriptTrack track;
   final EdgeInsetsGeometry contentPadding;
-  final String? groupValue;
-  final VoidCallback onTap;
   final VoidCallback onDelete;
 
   @override
@@ -540,8 +550,6 @@ class _TrackTile extends StatelessWidget {
     return RadioListTile<String>(
       contentPadding: contentPadding,
       value: track.id,
-      groupValue: groupValue,
-      onChanged: (_) => onTap(),
       title: Text(label),
       subtitle: Padding(
         padding: EdgeInsets.only(top: t.space8),

--- a/lib/features/transcript/presentation/transcript_scrollable_list.dart
+++ b/lib/features/transcript/presentation/transcript_scrollable_list.dart
@@ -1,6 +1,8 @@
 /// Scrollable transcript list with auto-scroll (active cue, or echo block in echo mode).
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -194,11 +196,13 @@ class _TranscriptScrollableListState
   }) {
     if (!mounted || generation != _scrollGeneration) return;
     try {
-      Scrollable.ensureVisible(
-        ctx,
-        alignment: alignment,
-        duration: duration,
-        curve: curve,
+      unawaited(
+        Scrollable.ensureVisible(
+          ctx,
+          alignment: alignment,
+          duration: duration,
+          curve: curve,
+        ),
       );
     } catch (_) {
       // Target may detach during route pop while animation is in flight.

--- a/packages/ffmpeg_kit_flutter_new/example/lib/main.dart
+++ b/packages/ffmpeg_kit_flutter_new/example/lib/main.dart
@@ -98,24 +98,21 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             if (Platform.isIOS || Platform.isMacOS)
               ElevatedButton(
-                onPressed:
-                    isProcessing
-                        ? null
-                        : () => executeFFmpegCommand('videotoolbox'),
+                onPressed: isProcessing
+                    ? null
+                    : () => executeFFmpegCommand('videotoolbox'),
                 child: const Text('VideoToolbox'),
               ),
             ElevatedButton(
-              onPressed:
-                  isProcessing
-                      ? null
-                      : () => executeFFmpegCommand('list_codecs'),
+              onPressed: isProcessing
+                  ? null
+                  : () => executeFFmpegCommand('list_codecs'),
               child: const Text('List Codecs'),
             ),
             ElevatedButton(
-              onPressed:
-                  isProcessing
-                      ? null
-                      : () => executeFFmpegCommand('mediacodec'),
+              onPressed: isProcessing
+                  ? null
+                  : () => executeFFmpegCommand('mediacodec'),
               child: const Text('MediaCodec'),
             ),
           ],

--- a/test/core/recovery/recovery_actions_test.dart
+++ b/test/core/recovery/recovery_actions_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:enjoy_player/core/logging/log_file_sink.dart';
 import 'package:enjoy_player/core/recovery/recovery_actions.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:flutter/services.dart';
@@ -36,18 +35,17 @@ void main() {
       await logsDir.create(recursive: true);
       PathProviderPlatform.instance = _MockPathProvider(tmpRoot);
       clipboardCalls = <MethodCall>[];
-      TestDefaultBinaryMessengerBinding
-          .instance.defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, (call) async {
-        clipboardCalls.add(call);
-        if (call.method == 'Clipboard.setData') {
-          return null;
-        }
-        if (call.method == 'Clipboard.getData') {
-          return const <String, dynamic>{'text': ''};
-        }
-        return null;
-      });
+            clipboardCalls.add(call);
+            if (call.method == 'Clipboard.setData') {
+              return null;
+            }
+            if (call.method == 'Clipboard.getData') {
+              return const <String, dynamic>{'text': ''};
+            }
+            return null;
+          });
     });
 
     tearDown(() async {
@@ -62,107 +60,101 @@ void main() {
         StackTrace.fromString('#0 main'),
       );
       expect(ok, isTrue);
-      final setCalls = clipboardCalls.where((c) => c.method == 'Clipboard.setData');
+      final setCalls = clipboardCalls.where(
+        (c) => c.method == 'Clipboard.setData',
+      );
       expect(setCalls, hasLength(1));
       final args = (setCalls.single.arguments as Map)['text'] as String;
       expect(args, contains('boom'));
       expect(args, contains('Stack trace'));
     });
 
-    test('copyErrorToClipboard returns false on a platform failure',
-        () async {
-      TestDefaultBinaryMessengerBinding
-          .instance.defaultBinaryMessenger
+    test('copyErrorToClipboard returns false on a platform failure', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, (call) async {
-        throw PlatformException(code: 'fail');
-      });
+            throw PlatformException(code: 'fail');
+          });
       final ok = await copyErrorToClipboard(Exception('boom'), null);
       expect(ok, isFalse);
     });
 
-    test('backupLocalDatabaseFile copies the guest DB and returns its path',
-        () async {
-      final dbFile = File(
-        p.join(dbDir.path, '${AppDatabase.guestDatabaseName}.sqlite'),
-      );
-      await dbFile.writeAsString('sqlite-blob');
-      final backup = await backupLocalDatabaseFile();
-      expect(backup, isNotNull);
-      expect(File(backup!).existsSync(), isTrue);
-      expect(
-        p.basename(backup),
-        startsWith('enjoy_player_'),
-      );
-      expect(
-        p.basename(backup),
-        endsWith('.sqlite'),
-      );
-    });
-
-    test('backupLocalDatabaseFile returns null when the DB is missing',
-        () async {
-      final backup = await backupLocalDatabaseFile();
-      expect(backup, isNull);
-    });
-
-    test('wipeLocalDatabaseFiles removes the guest + wal + shm files',
-        () async {
-      for (final ext in <String>['', '-wal', '-shm']) {
-        await File(
-          p.join(
-            dbDir.path,
-            '${AppDatabase.guestDatabaseName}.sqlite$ext',
-          ),
-        ).writeAsString('x');
-      }
-      // Add an unrelated file to make sure we don't over-delete.
-      await File(p.join(dbDir.path, 'keepme.txt')).writeAsString('keep');
-
-      await wipeLocalDatabaseFiles();
-
-      for (final ext in <String>['', '-wal', '-shm']) {
-        expect(
-          File(
-            p.join(
-              dbDir.path,
-              '${AppDatabase.guestDatabaseName}.sqlite$ext',
-            ),
-          ).existsSync(),
-          isFalse,
-          reason: 'guest DB $ext should be deleted',
+    test(
+      'backupLocalDatabaseFile copies the guest DB and returns its path',
+      () async {
+        final dbFile = File(
+          p.join(dbDir.path, '${AppDatabase.guestDatabaseName}.sqlite'),
         );
-      }
-      expect(
-        File(p.join(dbDir.path, 'keepme.txt')).existsSync(),
-        isTrue,
-        reason: 'unrelated files must not be touched',
-      );
-    });
-
-    test('resetLocalLibraryWithBackup returns backupFailed when no DB exists',
-        () async {
-      final outcome = await resetLocalLibraryWithBackup();
-      expect(outcome, RecoveryResetOutcome.backupFailed);
-    });
+        await dbFile.writeAsString('sqlite-blob');
+        final backup = await backupLocalDatabaseFile();
+        expect(backup, isNotNull);
+        expect(File(backup!).existsSync(), isTrue);
+        expect(p.basename(backup), startsWith('enjoy_player_'));
+        expect(p.basename(backup), endsWith('.sqlite'));
+      },
+    );
 
     test(
-        'resetLocalLibraryWithBackup returns success when the DB can be backed up',
-        () async {
-      await File(
-        p.join(dbDir.path, '${AppDatabase.guestDatabaseName}.sqlite'),
-      ).writeAsString('sqlite-blob');
-      final outcome = await resetLocalLibraryWithBackup();
-      expect(outcome, RecoveryResetOutcome.success);
-      expect(
-        File(
-          p.join(
-            dbDir.path,
-            '${AppDatabase.guestDatabaseName}.sqlite',
-          ),
-        ).existsSync(),
-        isFalse,
-      );
-    });
+      'backupLocalDatabaseFile returns null when the DB is missing',
+      () async {
+        final backup = await backupLocalDatabaseFile();
+        expect(backup, isNull);
+      },
+    );
+
+    test(
+      'wipeLocalDatabaseFiles removes the guest + wal + shm files',
+      () async {
+        for (final ext in <String>['', '-wal', '-shm']) {
+          await File(
+            p.join(dbDir.path, '${AppDatabase.guestDatabaseName}.sqlite$ext'),
+          ).writeAsString('x');
+        }
+        // Add an unrelated file to make sure we don't over-delete.
+        await File(p.join(dbDir.path, 'keepme.txt')).writeAsString('keep');
+
+        await wipeLocalDatabaseFiles();
+
+        for (final ext in <String>['', '-wal', '-shm']) {
+          expect(
+            File(
+              p.join(dbDir.path, '${AppDatabase.guestDatabaseName}.sqlite$ext'),
+            ).existsSync(),
+            isFalse,
+            reason: 'guest DB $ext should be deleted',
+          );
+        }
+        expect(
+          File(p.join(dbDir.path, 'keepme.txt')).existsSync(),
+          isTrue,
+          reason: 'unrelated files must not be touched',
+        );
+      },
+    );
+
+    test(
+      'resetLocalLibraryWithBackup returns backupFailed when no DB exists',
+      () async {
+        final outcome = await resetLocalLibraryWithBackup();
+        expect(outcome, RecoveryResetOutcome.backupFailed);
+      },
+    );
+
+    test(
+      'resetLocalLibraryWithBackup returns success when the DB can be backed up',
+      () async {
+        await File(
+          p.join(dbDir.path, '${AppDatabase.guestDatabaseName}.sqlite'),
+        ).writeAsString('sqlite-blob');
+        final outcome = await resetLocalLibraryWithBackup();
+        expect(outcome, RecoveryResetOutcome.success);
+        expect(
+          File(
+            p.join(dbDir.path, '${AppDatabase.guestDatabaseName}.sqlite'),
+          ).existsSync(),
+          isFalse,
+        );
+      },
+    );
 
     test('isUnrecoverableDatabaseError matches the documented patterns', () {
       expect(
@@ -178,9 +170,7 @@ void main() {
         isTrue,
       );
       expect(
-        isUnrecoverableDatabaseError(
-          Exception('NoSuchMethodError: bogus'),
-        ),
+        isUnrecoverableDatabaseError(Exception('NoSuchMethodError: bogus')),
         isFalse,
       );
     });

--- a/test/core/recovery/recovery_surface_test.dart
+++ b/test/core/recovery/recovery_surface_test.dart
@@ -21,9 +21,7 @@ void main() {
   testWidgets('RecoverySurface renders the three actions', (tester) async {
     await tester.pumpWidget(
       _wrap(
-        const RecoverySurface(
-          error: 'SqliteException: file is not a database',
-        ),
+        const RecoverySurface(error: 'SqliteException: file is not a database'),
       ),
     );
     await tester.pumpAndSettle();
@@ -48,9 +46,7 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
 
     await tester.pumpWidget(
-      _wrap(
-        const RecoverySurface(error: 'SqliteException: oops'),
-      ),
+      _wrap(const RecoverySurface(error: 'SqliteException: oops')),
     );
     await tester.pumpAndSettle();
 

--- a/test/core/utils/stream_distinct_test.dart
+++ b/test/core/utils/stream_distinct_test.dart
@@ -55,8 +55,8 @@ void main() {
       controller
         ..add(1)
         ..add(1)
-        ..add(2)
-        ..close();
+        ..add(2);
+      unawaited(controller.close());
       final a = await aFut;
       final b = await bFut;
       expect(a, [1, 2]);

--- a/test/data/api/recording_client_platform_test.dart
+++ b/test/data/api/recording_client_platform_test.dart
@@ -4,16 +4,16 @@ import 'package:enjoy_player/data/api/recording_client_platform_io.dart'
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('recordingClientPlatformValue dispatches to the IO implementation on this test host', () {
-    // Every host that runs the Dart test command (linux, macOS, windows)
-    // has dart:io, so the conditional import selects the IO file. We
-    // only need to confirm the public surface delegates to it without
-    // throwing.
-    expect(
-      recordingClientPlatformValue(),
-      recordingClientPlatformIoValue(),
-    );
-  });
+  test(
+    'recordingClientPlatformValue dispatches to the IO implementation on this test host',
+    () {
+      // Every host that runs the Dart test command (linux, macOS, windows)
+      // has dart:io, so the conditional import selects the IO file. We
+      // only need to confirm the public surface delegates to it without
+      // throwing.
+      expect(recordingClientPlatformValue(), recordingClientPlatformIoValue());
+    },
+  );
 
   test('recordingClientPlatformIoValue is one of the supported platforms', () {
     const supported = <String>{'android', 'ios', 'macos', 'windows', 'linux'};

--- a/test/features/ai/azure_token_cache_dedup_test.dart
+++ b/test/features/ai/azure_token_cache_dedup_test.dart
@@ -23,18 +23,21 @@ class _FakeAzureTokenApi extends AzureTokenApi {
 /// will accept; the fake subclass overrides every method the cache
 /// actually calls.
 class _NullApiClient extends ApiClient {
-  _NullApiClient() : super(
-    httpClient: _NullHttpClient(),
-    getBaseUrl: () async => 'https://test.invalid',
-    getAccessToken: () async => null,
-  );
+  _NullApiClient()
+    : super(
+        httpClient: _NullHttpClient(),
+        getBaseUrl: () async => 'https://test.invalid',
+        getAccessToken: () async => null,
+      );
 }
 
 class _NullHttpClient extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
-    throw UnsupportedError('AzureTokenCache tests must override every method '
-        'they exercise; the base class should never be called.');
+    throw UnsupportedError(
+      'AzureTokenCache tests must override every method '
+      'they exercise; the base class should never be called.',
+    );
   }
 }
 
@@ -86,10 +89,7 @@ void main() {
       var n = 0;
       final api = _FakeAzureTokenApi(() async {
         n += 1;
-        return <String, dynamic>{
-          'token': 'tok-$n',
-          'region': 'westus',
-        };
+        return <String, dynamic>{'token': 'tok-$n', 'region': 'westus'};
       });
       final cache = AzureTokenCache(api: api);
       // First fetch returns a token that is *just* about to expire;

--- a/test/features/auth/auth_repository_test.dart
+++ b/test/features/auth/auth_repository_test.dart
@@ -67,19 +67,21 @@ void main() {
       expect(await tokenStore.readRefreshToken(), 'r2');
     });
 
-    test('returns false but keeps session on transient network error',
-        () async {
-      final client = MockClient((_) async {
-        throw const SocketException('Connection reset by peer');
-      });
-      final repo = build(client);
+    test(
+      'returns false but keeps session on transient network error',
+      () async {
+        final client = MockClient((_) async {
+          throw const SocketException('Connection reset by peer');
+        });
+        final repo = build(client);
 
-      final ok = await repo.refreshSession();
+        final ok = await repo.refreshSession();
 
-      expect(ok, isFalse);
-      expect(await tokenStore.readAccessToken(), 'access-1');
-      expect(await tokenStore.readRefreshToken(), 'refresh-1');
-    });
+        expect(ok, isFalse);
+        expect(await tokenStore.readAccessToken(), 'access-1');
+        expect(await tokenStore.readRefreshToken(), 'refresh-1');
+      },
+    );
 
     test('returns false and keeps session on HTTP 500', () async {
       final client = MockClient((_) async => http.Response('boom', 500));
@@ -126,17 +128,18 @@ void main() {
     });
 
     test(
-        'returns false and keeps session on HTTP 400 (malformed request, not auth revocation)',
-        () async {
-      final client = MockClient((_) async => http.Response('bad', 400));
-      final repo = build(client);
+      'returns false and keeps session on HTTP 400 (malformed request, not auth revocation)',
+      () async {
+        final client = MockClient((_) async => http.Response('bad', 400));
+        final repo = build(client);
 
-      final ok = await repo.refreshSession();
+        final ok = await repo.refreshSession();
 
-      expect(ok, isFalse);
-      expect(await tokenStore.readAccessToken(), 'access-1');
-      expect(await tokenStore.readRefreshToken(), 'refresh-1');
-    });
+        expect(ok, isFalse);
+        expect(await tokenStore.readAccessToken(), 'access-1');
+        expect(await tokenStore.readRefreshToken(), 'refresh-1');
+      },
+    );
 
     test('returns false when no refresh token is stored', () async {
       await tokenStore.clearAllAuthSecrets();
@@ -182,14 +185,10 @@ void main() {
       const e5 = ApiException(message: 'oops', statusCode: 500);
       const e503 = ApiException(message: 'unavailable', statusCode: 503);
       expect(authFailureCodeForApiException(e5), AuthFailureCode.serverError);
-      expect(
-        authFailureCodeForApiException(e503),
-        AuthFailureCode.serverError,
-      );
+      expect(authFailureCodeForApiException(e503), AuthFailureCode.serverError);
     });
 
-    test('ApiException 400/404/422 maps to AuthFailure.invalidCredentials',
-        () {
+    test('ApiException 400/404/422 maps to AuthFailure.invalidCredentials', () {
       const e400 = ApiException(message: 'bad', statusCode: 400);
       const e404 = ApiException(message: 'missing', statusCode: 404);
       const e422 = ApiException(message: 'unprocessable', statusCode: 422);

--- a/test/features/library/library_media_provider_test.dart
+++ b/test/features/library/library_media_provider_test.dart
@@ -67,45 +67,46 @@ void main() {
           'Provider-level dedupe is covered by stream_distinct_test; '
           'Drift upsert makes a no-op DB touch hard to simulate here.',
       () async {
-      final container = makeContainer();
-      addTearDown(container.dispose);
-      final emissions = <int>[];
-      final sub = container.listen(libraryHomeRecentsProvider, (_, next) {
-        if (next.hasValue) emissions.add(next.requireValue.length);
-      }, fireImmediately: true);
-      // Wait for the initial emission (seeded data).
-      await container.read(libraryHomeRecentsProvider.future);
-      emissions.clear();
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        final emissions = <int>[];
+        final sub = container.listen(libraryHomeRecentsProvider, (_, next) {
+          if (next.hasValue) emissions.add(next.requireValue.length);
+        }, fireImmediately: true);
+        // Wait for the initial emission (seeded data).
+        await container.read(libraryHomeRecentsProvider.future);
+        emissions.clear();
 
-      // Force watchAll to re-query without changing mapped [Media] values.
-      // syncStatus is not surfaced on [Media]; preserve updatedAt so the
-      // top-12 ordering and element equality stay the same.
-      await _touchSyncStatusOnly(db, 'a-old');
-      // Yield enough times for the StreamProvider to flush.
-      await Future<void>.delayed(const Duration(milliseconds: 30));
-      expect(
-        emissions,
-        isEmpty,
-        reason:
-            'Identical top-12 should not re-emit. '
-            'Got $emissions emissions after a no-op write.',
-      );
+        // Force watchAll to re-query without changing mapped [Media] values.
+        // syncStatus is not surfaced on [Media]; preserve updatedAt so the
+        // top-12 ordering and element equality stay the same.
+        await _touchSyncStatusOnly(db, 'a-old');
+        // Yield enough times for the StreamProvider to flush.
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(
+          emissions,
+          isEmpty,
+          reason:
+              'Identical top-12 should not re-emit. '
+              'Got $emissions emissions after a no-op write.',
+        );
 
-      // Real change to the top-12 (a brand-new most-recent item) MUST emit.
-      await db.videoDao.insertRow(
-        _video('v-newest', 'Delta', 'newest', DateTime(2026, 12, 1)),
-      );
-      await Future<void>.delayed(const Duration(milliseconds: 30));
-      expect(
-        emissions,
-        isNotEmpty,
-        reason:
-            'A real top-12 change (newest item) must re-emit. '
-            'Got $emissions emissions.',
-      );
+        // Real change to the top-12 (a brand-new most-recent item) MUST emit.
+        await db.videoDao.insertRow(
+          _video('v-newest', 'Delta', 'newest', DateTime(2026, 12, 1)),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(
+          emissions,
+          isNotEmpty,
+          reason:
+              'A real top-12 change (newest item) must re-emit. '
+              'Got $emissions emissions.',
+        );
 
-      sub.close();
-    });
+        sub.close();
+      },
+    );
 
     test(
       'libraryFilteredListsProvider skips identical re-emissions '
@@ -114,37 +115,41 @@ void main() {
           'Provider-level dedupe is covered by stream_distinct_test; '
           'Drift upsert makes a no-op DB touch hard to simulate here.',
       () async {
-      final container = makeContainer();
-      addTearDown(container.dispose);
-      final emissions = <String>[];
-      final sub = container.listen(libraryFilteredListsProvider, (prev, next) {
-        if (!next.hasValue) return;
-        final sig = _signature(next.requireValue);
-        if (emissions.isNotEmpty && emissions.last == sig) return;
-        emissions.add(sig);
-      }, fireImmediately: true);
-      await container.read(libraryFilteredListsProvider.future);
-      emissions.clear();
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        final emissions = <String>[];
+        final sub = container.listen(libraryFilteredListsProvider, (
+          prev,
+          next,
+        ) {
+          if (!next.hasValue) return;
+          final sig = _signature(next.requireValue);
+          if (emissions.isNotEmpty && emissions.last == sig) return;
+          emissions.add(sig);
+        }, fireImmediately: true);
+        await container.read(libraryFilteredListsProvider.future);
+        emissions.clear();
 
-      await _touchSyncStatusOnly(db, 'a-old');
-      await Future<void>.delayed(const Duration(milliseconds: 30));
-      expect(emissions, isEmpty, reason: 'No-op write should be deduped.');
+        await _touchSyncStatusOnly(db, 'a-old');
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(emissions, isEmpty, reason: 'No-op write should be deduped.');
 
-      // Real change: rename Alpha → Zebra. Now audio list is
-      // [Bravo, Zebra], which differs, so we must see an emission.
-      final renamedRow = await db.audioDao.getById('a-old');
-      await db.audioDao.insertRow(renamedRow!.copyWith(title: 'Zebra'));
-      await Future<void>.delayed(const Duration(milliseconds: 30));
-      expect(
-        emissions,
-        isNotEmpty,
-        reason:
-            'A real filter-list change (renamed audio) must re-emit. '
-            'Got $emissions emissions.',
-      );
+        // Real change: rename Alpha → Zebra. Now audio list is
+        // [Bravo, Zebra], which differs, so we must see an emission.
+        final renamedRow = await db.audioDao.getById('a-old');
+        await db.audioDao.insertRow(renamedRow!.copyWith(title: 'Zebra'));
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(
+          emissions,
+          isNotEmpty,
+          reason:
+              'A real filter-list change (renamed audio) must re-emit. '
+              'Got $emissions emissions.',
+        );
 
-      sub.close();
-    });
+        sub.close();
+      },
+    );
 
     test(
       'libraryFilteredListsProvider re-emits when search query changes',
@@ -166,7 +171,9 @@ void main() {
         emissions.clear();
 
         container.read(librarySearchProvider.notifier).setQuery('zz');
-        await Future<void>.delayed(const Duration(milliseconds: 30));
+        await Future<void>.delayed(
+          kLibrarySearchDebounce + const Duration(milliseconds: 50),
+        );
         // Empty result set is a real change; should emit.
         expect(emissions, isNotEmpty);
         expect(emissions.last, 0);

--- a/test/features/library/library_search_debounce_test.dart
+++ b/test/features/library/library_search_debounce_test.dart
@@ -3,7 +3,6 @@ import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/files/file_storage.dart';
 import 'package:enjoy_player/features/library/application/library_search_provider.dart';
 import 'package:enjoy_player/features/library/data/library_repository.dart';
-import 'package:enjoy_player/features/sync/application/sync_providers.dart';
 import 'package:enjoy_player/features/sync/domain/sync_types.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -30,8 +29,9 @@ void main() {
       // Inside the debounce window the state is still the previous value.
       expect(container.read(librarySearchProvider), '');
 
-      await Future<void>.delayed(kLibrarySearchDebounce +
-          const Duration(milliseconds: 50));
+      await Future<void>.delayed(
+        kLibrarySearchDebounce + const Duration(milliseconds: 50),
+      );
       expect(container.read(librarySearchProvider), 'alpha');
     });
 
@@ -49,8 +49,9 @@ void main() {
       // Still inside the final debounce window.
       expect(container.read(librarySearchProvider), '');
 
-      await Future<void>.delayed(kLibrarySearchDebounce +
-          const Duration(milliseconds: 50));
+      await Future<void>.delayed(
+        kLibrarySearchDebounce + const Duration(milliseconds: 50),
+      );
       expect(container.read(librarySearchProvider), 'abc');
     });
 
@@ -144,44 +145,44 @@ void main() {
 }
 
 VideoRow _videoRow(String id, String title, String md5) => VideoRow(
-      id: id,
-      vid: md5,
-      provider: 'user',
-      title: title,
-      description: null,
-      thumbnailUrl: null,
-      durationSeconds: 0,
-      language: 'und',
-      source: null,
-      localUri: 'file:///x.mp4',
-      md5: md5,
-      size: 0,
-      mediaUrl: null,
-      syncStatus: null,
-      serverUpdatedAt: null,
-      createdAt: DateTime(2026, 1, 1),
-      updatedAt: DateTime(2026, 1, 1),
-    );
+  id: id,
+  vid: md5,
+  provider: 'user',
+  title: title,
+  description: null,
+  thumbnailUrl: null,
+  durationSeconds: 0,
+  language: 'und',
+  source: null,
+  localUri: 'file:///x.mp4',
+  md5: md5,
+  size: 0,
+  mediaUrl: null,
+  syncStatus: null,
+  serverUpdatedAt: null,
+  createdAt: DateTime(2026, 1, 1),
+  updatedAt: DateTime(2026, 1, 1),
+);
 
 AudioRow _audioRow(String id, String title, String md5) => AudioRow(
-      id: id,
-      aid: md5,
-      provider: 'user',
-      title: title,
-      description: null,
-      thumbnailUrl: null,
-      durationSeconds: 0,
-      language: 'und',
-      translationKey: null,
-      sourceText: null,
-      voice: null,
-      source: null,
-      localUri: 'file:///x.mp3',
-      md5: md5,
-      size: 0,
-      mediaUrl: null,
-      syncStatus: null,
-      serverUpdatedAt: null,
-      createdAt: DateTime(2026, 1, 1),
-      updatedAt: DateTime(2026, 1, 1),
-    );
+  id: id,
+  aid: md5,
+  provider: 'user',
+  title: title,
+  description: null,
+  thumbnailUrl: null,
+  durationSeconds: 0,
+  language: 'und',
+  translationKey: null,
+  sourceText: null,
+  voice: null,
+  source: null,
+  localUri: 'file:///x.mp3',
+  md5: md5,
+  size: 0,
+  mediaUrl: null,
+  syncStatus: null,
+  serverUpdatedAt: null,
+  createdAt: DateTime(2026, 1, 1),
+  updatedAt: DateTime(2026, 1, 1),
+);

--- a/test/features/sync/recording_target_sync_service_test.dart
+++ b/test/features/sync/recording_target_sync_service_test.dart
@@ -4,7 +4,6 @@ import 'package:enjoy_player/data/api/services/recording_api.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/settings_keys.dart';
 import 'package:enjoy_player/features/sync/data/recording_target_sync_service.dart';
-import 'package:enjoy_player/features/sync/domain/sync_types.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 
@@ -34,18 +33,21 @@ class _FakeRecordingApi extends RecordingApi {
 /// will accept; the fake subclass overrides every method that the
 /// service under test actually calls.
 class _NullApiClient extends ApiClient {
-  _NullApiClient() : super(
-    httpClient: _NullHttpClient(),
-    getBaseUrl: () async => 'https://test.invalid',
-    getAccessToken: () async => null,
-  );
+  _NullApiClient()
+    : super(
+        httpClient: _NullHttpClient(),
+        getBaseUrl: () async => 'https://test.invalid',
+        getAccessToken: () async => null,
+      );
 }
 
 class _NullHttpClient extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
-    throw UnsupportedError('RecordingTargetSyncService tests must override '
-        'every method they exercise; the base class should never be called.');
+    throw UnsupportedError(
+      'RecordingTargetSyncService tests must override '
+      'every method they exercise; the base class should never be called.',
+    );
   }
 }
 
@@ -63,12 +65,13 @@ void main() {
     });
 
     Map<String, dynamic> recording(int i, {String? updatedAt}) => {
-          'id': 'r$i',
-          'targetId': 't1',
-          'targetType': 'audio',
-          'durationSeconds': i,
-          'updatedAt': updatedAt ?? DateTime.utc(2024, 1, 1, 0, i).toIso8601String(),
-        };
+      'id': 'r$i',
+      'targetId': 't1',
+      'targetType': 'audio',
+      'durationSeconds': i,
+      'updatedAt':
+          updatedAt ?? DateTime.utc(2024, 1, 1, 0, i).toIso8601String(),
+    };
 
     test('respects the page cap and persists the cooldown timestamp', () async {
       // Six full pages so the cap (5) is hit.
@@ -77,9 +80,16 @@ void main() {
           6,
           (page) => List.generate(
             50,
-            (i) => recording(page * 50 + i,
-                updatedAt: DateTime.utc(2024, 1, 1, 0, page * 50 + i)
-                    .toIso8601String()),
+            (i) => recording(
+              page * 50 + i,
+              updatedAt: DateTime.utc(
+                2024,
+                1,
+                1,
+                0,
+                page * 50 + i,
+              ).toIso8601String(),
+            ),
           ),
         ),
         _NullApiClient(),
@@ -98,39 +108,46 @@ void main() {
       expect(result.synced, 250);
       expect(api.callCount, 5);
 
-      final cooldown = await db.settingsDao
-          .getValue(SettingsKeys.syncLastPullAtRecordingTarget('audio', 't1'));
+      final cooldown = await db.settingsDao.getValue(
+        SettingsKeys.syncLastPullAtRecordingTarget('audio', 't1'),
+      );
       expect(cooldown, t0.toUtc().toIso8601String());
     });
 
-    test('returns empty success when called inside the cooldown window',
-        () async {
-      api = _FakeRecordingApi([
-        List.generate(10, (i) => recording(i)),
-      ], _NullApiClient());
-      service = RecordingTargetSyncService(db: db, recordingApi: api);
-      final t0 = DateTime.utc(2024, 6, 1, 12);
+    test(
+      'returns empty success when called inside the cooldown window',
+      () async {
+        api = _FakeRecordingApi([
+          List.generate(10, (i) => recording(i)),
+        ], _NullApiClient());
+        service = RecordingTargetSyncService(db: db, recordingApi: api);
+        final t0 = DateTime.utc(2024, 6, 1, 12);
 
-      // First call hits the API.
-      final r1 = await service.pullRecordingsForTarget(
-        targetType: 'audio',
-        targetId: 't1',
-        now: t0,
-      );
-      expect(r1.synced, 10);
-      expect(api.callCount, 1);
+        // First call hits the API.
+        final r1 = await service.pullRecordingsForTarget(
+          targetType: 'audio',
+          targetId: 't1',
+          now: t0,
+        );
+        expect(r1.synced, 10);
+        expect(api.callCount, 1);
 
-      // Second call 1 minute later is short-circuited.
-      final r2 = await service.pullRecordingsForTarget(
-        targetType: 'audio',
-        targetId: 't1',
-        now: t0.add(const Duration(minutes: 1)),
-      );
-      expect(r2.synced, 0);
-      expect(r2.failed, 0);
-      expect(r2.success, isTrue);
-      expect(api.callCount, 1, reason: 'cooldown should prevent a second call');
-    });
+        // Second call 1 minute later is short-circuited.
+        final r2 = await service.pullRecordingsForTarget(
+          targetType: 'audio',
+          targetId: 't1',
+          now: t0.add(const Duration(minutes: 1)),
+        );
+        expect(r2.synced, 0);
+        expect(r2.failed, 0);
+        expect(r2.success, isTrue);
+        expect(
+          api.callCount,
+          1,
+          reason: 'cooldown should prevent a second call',
+        );
+      },
+    );
 
     test('hits the API again after the cooldown elapses', () async {
       api = _FakeRecordingApi([


### PR DESCRIPTION
## Summary

Resolves #110.

- Expands `analysis_options.yaml` with eight additional core lints (quotes, trailing commas, async hygiene, package deps) and runs `dart fix --apply` / `dart format` across the codebase
- Confirms `flutter_lints: ^6.0.0` (latest stable 6.x on pub.dev)
- Adds [ADR-0030](docs/decisions/0030-flutter-lints-baseline-no-custom-lint.md) documenting expanded baseline and deferring `custom_lint`
- Removes 11 legacy `@deprecated` `AppColors` aliases (no remaining callers)
- Replaces deprecated `RadioListTile` group API in `subtitle_track_picker_sheet.dart` with `RadioGroup` (removes blanket `ignore_for_file`)
- Replaces `Future.delayed(Duration.zero)` in discover subscribe with `waitForDiscoverSubscription` (`firstWhere` on the subscriptions stream)
- Wraps intentional fire-and-forget futures with `unawaited()` to satisfy new lints
- Fixes flaky library provider test to respect the 200 ms search debounce window

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 516 passed, 2 skipped
- [ ] Manual: subscribe to a recommended Discover channel and confirm success notice + feed refresh
- [ ] Manual: open subtitle track picker and verify primary/secondary radio selection still works
