### PR TITLE
fix(security): secret-scanning pre-commit hook + repo-root Sparkle key resolution (#99)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Pre-commit secret scanner.
+#
+# Blocks commits that introduce leaked publish credentials into the working
+# tree — AWS / Cloudflare R2 access keys, 64-char R2 secrets, and the local
+# credential files themselves. Intentionally simple: no dependencies beyond
+# git + grep so it works in Git Bash, macOS, and Linux.
+#
+# Install once per clone:
+#   git config core.hooksPath .githooks
+#
+# Bypass for a known-good commit (e.g. a hex fixture in tests):
+#   git commit --no-verify
+#
+# See docs/packaging.md → "Publish credentials" for the secret-loading flow.
+set -euo pipefail
+
+# Files that must never be committed (publish_env.local.* are the plaintext
+# credential loaders).
+forbidden_files=(
+  ".github/scripts/publish_env.local.ps1"
+  ".github/scripts/publish_env.local.sh"
+  "dsa_priv.pem"
+  "dsa_pub.pem"
+)
+
+# Patterns that look like real credentials. We match on the long, low-entropy
+# shapes that are essentially never legitimate source: AWS/R2 access key ids
+# (historically AKIA…, but R2 uses 32-hex), 64-hex R2 secret access keys, and
+# the env-var assignment lines that carry them.
+patterns=(
+  'AKIA[0-9A-Z]{16}'
+  '[0-9a-f]{64}'
+  'AWS_SECRET_ACCESS_KEY[[:space:]]*=[[:space:]]*"[0-9a-f]{40,}"'
+  'AWS_ACCESS_KEY_ID[[:space:]]*=[[:space:]]*"[0-9a-f]{32}"'
+  'r2\.cloudflarestorage\.com/[0-9a-f]{20,}'
+)
+
+status=0
+
+# 1. Block forbidden local credential / key files outright.
+while read -r file; do
+  for forbidden in "${forbidden_files[@]}"; do
+    if [[ "$file" == "$forbidden" ]]; then
+      echo "ERROR: refusing to commit tracked credential / key file: $file" >&2
+      echo "       These files must stay local (see .gitignore)." >&2
+      status=1
+    fi
+  done
+done < <(git diff --cached --name-only --diff-filter=ACMR)
+
+# 2. Scan staged file content for credential-shaped strings.
+# Skip binary files and the example templates (they contain the literal
+# patterns as placeholders, e.g. "<R2 access key id>").
+while read -r file; do
+  case "$file" in
+    *.png|*.jpg|*.jpeg|*.gif|*.webp|*.icns|*.ico|*.zip|*.gz|*.lock) continue ;;
+    ".github/scripts/publish_env.example.ps1") continue ;;
+    ".github/scripts/publish_env.example.sh") continue ;;
+    ".githooks/pre-commit") continue ;;
+  esac
+
+  content=$(git diff --cached -- "$file" 2>/dev/null) || continue
+  for pat in "${patterns[@]}"; do
+    if printf '%s' "$content" | grep -Eq "$pat"; then
+      echo "ERROR: possible leaked credential in $file matches /$pat/" >&2
+      echo "       If this is a false positive (e.g. a test fixture), use" >&2
+      echo "       'git commit --no-verify' and leave a note in the message." >&2
+      status=1
+      break
+    fi
+  done
+done < <(git diff --cached --name-only --diff-filter=ACMR)
+
+if [[ $status -ne 0 ]]; then
+  echo "" >&2
+  echo "Commit blocked by secret scanner. Rotate any exposed keys and load" >&2
+  echo "credentials from a secure store (see docs/packaging.md)." >&2
+  exit 1
+fi
+
+exit 0

--- a/.github/scripts/publish_env.example.ps1
+++ b/.github/scripts/publish_env.example.ps1
@@ -1,6 +1,14 @@
 # Copy to publish_env.local.ps1 (gitignored) and fill in values.
 # Used by release.ps1 and CI publish steps.
 #
+# SECURITY: this template is the ONLY place credential placeholders belong.
+# Never paste real AWS/R2 access keys or secret keys into a tracked file —
+# the pre-commit hook (.githooks/pre-commit) blocks credential-shaped
+# strings and the local credential files themselves. Load real values from a
+# secure store (Windows Credential Manager / 1Password CLI / GitHub Actions
+# secrets) into this local copy only. See docs/packaging.md →
+# "Publish credentials" for the recommended flow.
+#
 # Usage (PowerShell, from repo root):
 #   . .\.github\scripts\publish_env.local.ps1
 #   pwsh ./release.ps1 -Publish
@@ -15,5 +23,12 @@ $env:PUBLISH_PREFIX = "player"
 $env:CLOUDFLARE_API_TOKEN = "<token with Cache Purge>"
 $env:CLOUDFLARE_ZONE_ID = "<zone id for enjoy.bot>"
 # $env:ENJOY_PLAYER_DL_BASE = "https://dl.enjoy.bot/player"
-# WinSparkle signing (required for desktop auto-update appcast):
-# $env:SPARKLE_DSA_PRIV_PEM = "C:\path\to\dsa_priv.pem"
+
+# WinSparkle signing (required for desktop auto-update appcast).
+# sign_sparkle_enclosure.sh auto-detects a `dsa_priv.pem` at the repo root,
+# so leave SPARKLE_DSA_PRIV_PEM unset when the key lives there. Only set it
+# explicitly when the key is stored elsewhere — resolve the path relative to
+# the repo root (NEVER hardcode an absolute path like C:\Users\...):
+#   $repoRoot = & git rev-parse --show-toplevel
+#   $env:SPARKLE_DSA_PRIV_PEM = Join-Path $repoRoot "keys/dsa_priv.pem"
+# CI injects the key as base64 via SPARKLE_DSA_PRIV_PEM_BASE64 instead.

--- a/.github/scripts/publish_env.example.sh
+++ b/.github/scripts/publish_env.example.sh
@@ -2,6 +2,12 @@
 # Usage (Git Bash / macOS / Linux, from repo root):
 #   source .github/scripts/publish_env.local.sh
 #   bash .github/scripts/release.sh --platform windows --publish
+#
+# SECURITY: never paste real AWS/R2 credentials into a tracked file. The
+# pre-commit hook (.githooks/pre-commit) blocks credential-shaped strings and
+# the local credential files. Load real values from a secure store (1Password
+# CLI / GitHub Actions secrets) into this local copy only. See
+# docs/packaging.md → "Publish credentials".
 
 export AWS_ACCESS_KEY_ID="<R2 access key id>"
 export AWS_SECRET_ACCESS_KEY="<R2 secret access key>"
@@ -13,4 +19,11 @@ export PUBLISH_PREFIX="player"
 export CLOUDFLARE_API_TOKEN="<token with Cache Purge>"
 export CLOUDFLARE_ZONE_ID="<zone id for enjoy.bot>"
 # export ENJOY_PLAYER_DL_BASE="https://dl.enjoy.bot/player"
-# export SPARKLE_DSA_PRIV_PEM="/path/to/dsa_priv.pem"
+
+# WinSparkle signing (required for desktop auto-update appcast).
+# sign_sparkle_enclosure.sh auto-detects a `dsa_priv.pem` at the repo root,
+# so leave SPARKLE_DSA_PRIV_PEM unset when the key lives there. Only set it
+# explicitly when the key is elsewhere — resolve relative to the repo root
+# (NEVER hardcode an absolute path):
+#   export SPARKLE_DSA_PRIV_PEM="$(git rev-parse --show-toplevel)/keys/dsa_priv.pem"
+# CI injects the key as base64 via SPARKLE_DSA_PRIV_PEM_BASE64 instead.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -144,6 +144,56 @@ Only needed when uploading to `dl.enjoy.bot`. Install **AWS CLI v2**:
 - **macOS**: `brew install awscli`
 - **Windows**: `winget install Amazon.AWSCLI`
 
+Credentials are loaded into the shell environment from a **local, gitignored** file
+(`publish_env.local.ps1` on Windows, `publish_env.local.sh` elsewhere) or, in CI,
+from GitHub Actions secrets. **Never commit real AWS/R2 access keys or secret keys** —
+the pre-commit hook ([`.githooks/pre-commit`](../.githooks/pre-commit)) blocks
+credential-shaped strings (`AKIA…`, 64-hex R2 secrets) and the local credential
+files themselves. If you have ever pasted real keys into a working-tree file,
+**rotate them in Cloudflare R2** and start from a clean local copy.
+
+#### Recommended secret sources
+
+Prefer one of these over a plaintext working-tree file so credentials never touch
+the repository disk:
+
+| Source | When to use | How to load |
+|--------|-------------|-------------|
+| **GitHub Actions secrets** | CI releases | Reference as `${{ secrets.R2_ACCESS_KEY_ID }}` in the workflow; the workflow sets the same `AWS_*` / `PUBLISH_*` env vars |
+| **Windows Credential Manager** | Local Windows releases | Read into the session before running `release.ps1`, e.g. via `cmdkey` or a vault CLI, exporting the same env vars |
+| **1Password CLI** (`op`) | Any local host | `export AWS_SECRET_ACCESS_KEY="$(op read 'op://Private/r2/secret')"` etc. before `release.sh` |
+
+The local `publish_env.local.*` loaders are a convenience for maintainers who
+prefer a dotenv-style flow; keep them on disk only, never in git.
+
+#### WinSparkle DSA private key
+
+`sign_sparkle_enclosure.sh` resolves the DSA private key for Windows appcast
+signing in this order:
+
+1. `SPARKLE_DSA_PRIV_PEM` env var (an absolute path to the key file)
+2. `SPARKLE_DSA_PRIV_PEM_BASE64` env var (base64-encoded key, decoded to a temp file)
+3. `dsa_priv.pem` at the **repo root** (auto-detected — the recommended default)
+
+Because the repo-root path is auto-detected, **do not hardcode an absolute path**
+in your local env file. If the key lives elsewhere, resolve it relative to the
+repo root:
+
+```bash
+# bash / macOS / Linux
+export SPARKLE_DSA_PRIV_PEM="$(git rev-parse --show-toplevel)/keys/dsa_priv.pem"
+```
+
+```powershell
+# PowerShell
+$env:SPARKLE_DSA_PRIV_PEM = Join-Path (git rev-parse --show-toplevel) "keys/dsa_priv.pem"
+```
+
+CI injects the key as base64 via `SPARKLE_DSA_PRIV_PEM_BASE64` (see
+[`sign_sparkle_enclosure.sh`](../.github/scripts/sign_sparkle_enclosure.sh)).
+
+#### Local publish setup
+
 ```powershell
 # Windows
 Copy-Item .github\scripts\publish_env.example.ps1 .github\scripts\publish_env.local.ps1
@@ -161,6 +211,20 @@ cp .github/scripts/publish_env.example.sh .github/scripts/publish_env.local.sh
 # edit values, then:
 bash .github/scripts/release.sh --platform apple --publish
 ```
+
+#### Pre-commit secret scanning
+
+After cloning, enable the local secret scanner so credential-shaped strings
+and the local credential files cannot be committed by accident:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook scans staged content for AWS/R2 access key patterns and blocks the
+forbidden local credential / key files outright. Bypass with `git commit --no-verify`
+only for a known-good false positive (e.g. a hex test fixture), and note it in the
+commit message.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves the **code-actionable** tasks of #99 — the critical security item under the #83 consolidated review. This is the last open sub-issue of #83.

Key rotation itself and end-to-end release verification remain **owner action** (cannot be done in code); this PR implements everything else.

## What changed

| Task (#99) | Status |
|------------|--------|
| Owner action: rotate R2 access key + secret + account id in Cloudflare | ⏳ owner action |
| Load credentials from a secure store (no plaintext in working tree) | ✅ documented in templates + docs |
| Replace hardcoded `dsa_priv.pem` absolute path with `git rev-parse --show-toplevel` resolution | ✅ |
| Add pre-commit hook scanning for `AKIA` / `[0-9a-f]{32}` patterns | ✅ |
| Update `docs/packaging.md` with the new secret-loading flow | ✅ |
| Verify `.gitignore` excludes new local credential files | ✅ verified |
| Verify the new flow end-to-end on a real release cut | ⏳ owner action |

### Pre-commit secret scanner (`.githooks/pre-commit`)
- Blocks AWS/R2 credential-shaped strings: `AKIA[0-9A-Z]{16}`, 64-hex R2 secrets, 32-hex R2 access key ids, `r2.cloudflarestorage.com/<hex>` endpoints
- Blocks the forbidden local credential / key files outright: `publish_env.local.ps1`, `publish_env.local.sh`, `dsa_priv.pem`, `dsa_pub.pem`
- Skips binaries, lockfiles, and the example templates (which carry the patterns as placeholders)
- Zero dependencies beyond git + grep; install with `git config core.hooksPath .githooks`
- Bypass with `git commit --no-verify` for known false positives (e.g. hex test fixtures)

### Sparkle key resolution
`sign_sparkle_enclosure.sh` already auto-detects a repo-root `dsa_priv.pem`, so the hardcoded `C:\Users\me\dev\enjoy_player\dsa_priv.pem` in the local loader was redundant. Replaced with documented repo-root resolution via `git rev-parse --show-toplevel` in the example templates and `docs/packaging.md`. The gitignored local `.ps1` is updated to drop the absolute path (maintainer convenience — not committed).

### Docs
Expanded `docs/packaging.md` → "Publish credentials" with recommended secret sources (GitHub Actions secrets / Windows Credential Manager / 1Password CLI), the WinSparkle key resolution order, and pre-commit hook setup.

## Verification

- `.githooks/pre-commit` blocks the real leaked `publish_env.local.ps1` (matches `[0-9a-f]{64}` + 32-hex access key id) ✅
- Hook passes on clean source: 40-hex git SHAs and example templates with placeholders do **not** trip it ✅
- Hook passes on the 4 files in this PR ✅
- `flutter analyze` — 1 pre-existing info (`test/widget_test.dart:98`, unrelated, present on `main`) ✅
- `flutter test` — **548 pass / 2 skip** ✅
- `.gitignore` confirmed to cover `publish_env.local.*` and `dsa_priv.pem`; working tree shows only the 4 intended files ✅

## Owner-action items remaining (out of scope for code)

1. **Rotate the leaked R2 keys** in Cloudflare — the values currently in the maintainer's local `publish_env.local.ps1` are exposed on disk and must be considered compromised.
2. **End-to-end release cut** to confirm the new loader flow works on a real publish.

After key rotation, this PR can land; the pre-commit hook will prevent recurrence.

Closes #99 (code-actionable tasks).
Part of #83.
