### PR TITLE
refactor(platform): extract isMobilePlatform predicate

### DIFF
--- a/lib/core/interaction/haptics.dart
+++ b/lib/core/interaction/haptics.dart
@@ -3,16 +3,13 @@ library;
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show HapticFeedback;
 
+import 'package:enjoy_player/core/platform/mobile_platform.dart';
+
 abstract final class Haptics {
-  static bool _hapticCapable() {
-    return defaultTargetPlatform == TargetPlatform.iOS ||
-        defaultTargetPlatform == TargetPlatform.android;
-  }
+  static bool _hapticCapable() => isMobilePlatform;
 
   static bool _reducedMotion(BuildContext? context) {
     if (context == null) return false;

--- a/lib/core/platform/mobile_platform.dart
+++ b/lib/core/platform/mobile_platform.dart
@@ -1,0 +1,15 @@
+/// Phone/tablet platform predicate — mirrors [isDesktop] in
+/// `lib/core/window/desktop_window.dart`.
+library;
+
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
+
+/// Whether the current platform is a phone/tablet form factor (iOS or
+/// Android), as opposed to desktop or web.
+///
+/// Also used as the "does this device support [HapticFeedback]?" check —
+/// today the two questions have the same answer on every supported platform.
+bool get isMobilePlatform =>
+    defaultTargetPlatform == TargetPlatform.iOS ||
+    defaultTargetPlatform == TargetPlatform.android;

--- a/lib/core/theme/widgets/media_card.dart
+++ b/lib/core/theme/widgets/media_card.dart
@@ -8,11 +8,10 @@ library;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/core/interaction/haptics.dart';
+import 'package:enjoy_player/core/platform/mobile_platform.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
 import 'package:enjoy_player/core/theme/widgets/sheet_drag_handle.dart';
@@ -21,14 +20,9 @@ import 'package:enjoy_player/core/utils/remote_thumbnail_url.dart';
 import '../enjoy_tokens.dart';
 import '../generative_media_cover.dart';
 
-bool _deleteLongPressEnabledForPlatform() {
-  return defaultTargetPlatform == TargetPlatform.android ||
-      defaultTargetPlatform == TargetPlatform.iOS;
-}
-
 /// Inline trash on the card is for pointer UIs; phones use long-press → sheet.
 bool _showPointerDeleteButton() {
-  return !_deleteLongPressEnabledForPlatform();
+  return !isMobilePlatform;
 }
 
 /// Bottom sheet with a single destructive delete action (Android / iOS).
@@ -42,34 +36,36 @@ void _showMobileDeleteMenu(
   final title = (label != null && label.isNotEmpty)
       ? label
       : ml.deleteButtonTooltip;
-  unawaited(showEnjoySheet<void>(
-    context: context,
-    builder: (sheetContext) {
-      final cs = Theme.of(sheetContext).colorScheme;
-      return SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const PaddedSheetDragHandle(),
-            ListTile(
-              leading: Icon(Icons.delete_outline_rounded, color: cs.error),
-              title: Text(
-                title,
-                style: Theme.of(sheetContext).textTheme.titleMedium?.copyWith(
-                  color: cs.error,
-                  fontWeight: FontWeight.w600,
+  unawaited(
+    showEnjoySheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        final cs = Theme.of(sheetContext).colorScheme;
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const PaddedSheetDragHandle(),
+              ListTile(
+                leading: Icon(Icons.delete_outline_rounded, color: cs.error),
+                title: Text(
+                  title,
+                  style: Theme.of(sheetContext).textTheme.titleMedium?.copyWith(
+                    color: cs.error,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  onDelete();
+                },
               ),
-              onTap: () {
-                Navigator.pop(sheetContext);
-                onDelete();
-              },
-            ),
-          ],
-        ),
-      );
-    },
-  ));
+            ],
+          ),
+        );
+      },
+    ),
+  );
 }
 
 Widget _heroArtworkShell(String? mediaId, Widget child) {
@@ -257,8 +253,7 @@ class _MediaCardTileState extends State<MediaCardTile> {
             Haptics.selection(context);
             widget.onTap();
           },
-          onLongPress:
-              widget.onDelete != null && _deleteLongPressEnabledForPlatform()
+          onLongPress: widget.onDelete != null && isMobilePlatform
               ? () => _showMobileDeleteMenu(
                   context,
                   onDelete: widget.onDelete!,
@@ -592,7 +587,7 @@ class _MediaCardRowState extends State<MediaCardRow> {
           onLongPress:
               widget.trailing == null &&
                   widget.onDelete != null &&
-                  _deleteLongPressEnabledForPlatform()
+                  isMobilePlatform
               ? () => _showMobileDeleteMenu(
                   context,
                   onDelete: widget.onDelete!,
@@ -877,17 +872,15 @@ class _Badge extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           if (showLanguageIcon) ...[
-            Icon(
-              Icons.translate_rounded,
-              size: 14,
-              color: cs.primary,
-            ),
+            Icon(Icons.translate_rounded, size: 14, color: cs.primary),
             const SizedBox(width: 4),
           ],
           Text(
             label,
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: onTap != null ? cs.onPrimaryContainer : cs.onSurfaceVariant,
+              color: onTap != null
+                  ? cs.onPrimaryContainer
+                  : cs.onSurfaceVariant,
               fontWeight: onTap != null ? FontWeight.w600 : FontWeight.w400,
             ),
           ),
@@ -914,10 +907,7 @@ class _Badge extends StatelessWidget {
 
 /// Language chip overlaid on grid tile artwork (bottom-left).
 class _ThumbnailLanguageBadge extends StatelessWidget {
-  const _ThumbnailLanguageBadge({
-    required this.label,
-    required this.onTap,
-  });
+  const _ThumbnailLanguageBadge({required this.label, required this.onTap});
 
   final String label;
   final VoidCallback onTap;

--- a/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
@@ -3,12 +3,11 @@ library;
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/interaction/haptics.dart';
+import 'package:enjoy_player/core/platform/mobile_platform.dart';
 import 'package:enjoy_player/core/utils/time_format.dart';
 import 'package:enjoy_player/features/player/application/player_interactions.dart';
 import 'package:enjoy_player/features/player/application/transport_slider_position_provider.dart';
@@ -77,9 +76,7 @@ class _TransportProgressStripState
     extends ConsumerState<TransportProgressStrip> {
   int? _scrubSecond;
 
-  bool get _hapticScrub =>
-      defaultTargetPlatform == TargetPlatform.iOS ||
-      defaultTargetPlatform == TargetPlatform.android;
+  bool get _hapticScrub => isMobilePlatform;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary

Audited #169. Verified the three byte-near-identical copies of the iOS/Android predicate:

- `lib/core/interaction/haptics.dart` — `Haptics._hapticCapable()`
- `lib/core/theme/widgets/media_card.dart` — `_deleteLongPressEnabledForPlatform()`
- `lib/features/player/presentation/widgets/transport/transport_progress_strip.dart` — `_hapticScrub`

Confirmed the operand-order drift the issue calls out (`media_card.dart` checks Android first, the other two check iOS first) — a real, if harmless today, signal that these are independently maintained copies.

## Change

Added `isMobilePlatform` in `lib/core/platform/mobile_platform.dart`, mirroring the existing `isDesktop` getter in `lib/core/window/desktop_window.dart`, and pointed all three call sites at it.

### One naming deviation from the issue (documented in the new file's doc comment)

The issue proposes adding **two** getters — `isHapticCapablePlatform` and `isMobilePlatform` — as separate names for the exact same boolean expression. That would just be introducing a second duplicate under a different name. I added a single `isMobilePlatform` getter and used it for both the haptics and delete-affordance call sites, with a doc comment noting it doubles as the haptic-capability check.

## Verification

- `flutter analyze` — no issues.
- `flutter test` — full suite green (723 passed, 2 pre-existing skips). No dedicated unit tests exercise these three call sites directly (no behavior change was intended or made).

Closes #169
