### PR TITLE
refactor(json): extract castJsonObject(OrNull) helper

### DIFF
--- a/lib/core/json/json_cast.dart
+++ b/lib/core/json/json_cast.dart
@@ -1,0 +1,32 @@
+/// Defensive `Map<String, dynamic>` coercion for decoded JSON.
+///
+/// `dart:convert`-decoded JSON objects sometimes surface as
+/// `Map<dynamic, dynamic>` rather than `Map<String, dynamic>` — e.g. after
+/// [package:enjoy_player/data/api/case_conversion.dart] key conversion, or
+/// values crossing a platform channel. A naive `is Map<String, dynamic>`
+/// check silently drops such maps, so every call site needs the same
+/// "accept the fast-path type, else re-key by `.toString()`" coercion.
+library;
+
+/// Returns [value] as a `Map<String, dynamic>`, re-keying a
+/// `Map<dynamic, dynamic>` via `.toString()` on each key. Returns `null` if
+/// [value] is not a [Map] at all (including `null`).
+Map<String, dynamic>? castJsonObjectOrNull(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return Map<String, dynamic>.from(
+      value.map((k, v) => MapEntry(k.toString(), v)),
+    );
+  }
+  return null;
+}
+
+/// Same as [castJsonObjectOrNull], but throws a [FormatException] instead of
+/// returning `null` when [value] is not a JSON object.
+Map<String, dynamic> castJsonObject(Object? value) {
+  final map = castJsonObjectOrNull(value);
+  if (map == null) {
+    throw FormatException('Expected JSON object, got ${value.runtimeType}');
+  }
+  return map;
+}

--- a/lib/data/api/api_client.dart
+++ b/lib/data/api/api_client.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 
+import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/data/api/case_conversion.dart';
@@ -174,16 +175,15 @@ class ApiClient {
 
       if (response.statusCode >= 200 && response.statusCode < 300) {
         final decoded = await _decodeResponseBody(response);
-        if (decoded is! Map) {
+        final map = castJsonObjectOrNull(decoded);
+        if (map == null) {
           throw ApiException(
             message: 'Expected JSON object',
             statusCode: response.statusCode,
             body: decoded,
           );
         }
-        return Map<String, dynamic>.from(
-          decoded.map((k, v) => MapEntry(k.toString(), v)),
-        );
+        return map;
       }
       await _throwApiError(response);
       throw AssertionError('unreachable');
@@ -271,16 +271,15 @@ class ApiClient {
         return const <String, dynamic>{};
       }
       final decoded = await _decodeResponseBody(response);
-      if (decoded is! Map) {
+      final map = castJsonObjectOrNull(decoded);
+      if (map == null) {
         throw ApiException(
           message: 'Expected JSON object',
           statusCode: response.statusCode,
           body: decoded,
         );
       }
-      return Map<String, dynamic>.from(
-        decoded.map((k, v) => MapEntry(k.toString(), v)),
-      );
+      return map;
     }
 
     await _throwApiError(response);
@@ -313,17 +312,15 @@ class ApiClient {
         );
       }
       return decoded.map<Map<String, dynamic>>((e) {
-        if (e is Map<String, dynamic>) return e;
-        if (e is Map) {
-          return Map<String, dynamic>.from(
-            e.map((k, v) => MapEntry(k.toString(), v)),
+        final map = castJsonObjectOrNull(e);
+        if (map == null) {
+          throw ApiException(
+            message: 'Array element is not an object',
+            statusCode: response.statusCode,
+            body: e,
           );
         }
-        throw ApiException(
-          message: 'Array element is not an object',
-          statusCode: response.statusCode,
-          body: e,
-        );
+        return map;
       }).toList();
     }
 

--- a/lib/data/api/services/ai/credits_api.dart
+++ b/lib/data/api/services/ai/credits_api.dart
@@ -1,6 +1,7 @@
 /// `GET /credits/usages` — authenticated Worker credits audit log.
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/data/api/api_client.dart';
 import 'package:enjoy_player/data/api/query_params.dart';
 import 'package:enjoy_player/features/credits/domain/credits_usage_log.dart';
@@ -35,16 +36,9 @@ class CreditsApi {
     final logs = <CreditsUsageLog>[];
     if (raw is List) {
       for (final e in raw) {
-        if (e is Map<String, dynamic>) {
-          logs.add(CreditsUsageLog.fromJson(e));
-        } else if (e is Map) {
-          logs.add(
-            CreditsUsageLog.fromJson(
-              Map<String, dynamic>.from(
-                e.map((k, v) => MapEntry(k.toString(), v)),
-              ),
-            ),
-          );
+        final entry = castJsonObjectOrNull(e);
+        if (entry != null) {
+          logs.add(CreditsUsageLog.fromJson(entry));
         }
       }
     }

--- a/lib/features/ai/data/enjoy/enjoy_llm_capability.dart
+++ b/lib/features/ai/data/enjoy/enjoy_llm_capability.dart
@@ -1,3 +1,4 @@
+import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/data/api/services/ai/chat_api.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/llm_capability.dart';
@@ -8,19 +9,6 @@ final class EnjoyLlmCapability implements LlmCapability {
 
   final ChatApi _api;
 
-  /// JSON from [convertKeysToCamel] uses [Map] values that are often
-  /// `Map<dynamic, dynamic>`, not `Map<String, dynamic>`, so avoid `is`
-  /// checks on the latter for nested objects.
-  Map<String, dynamic>? _stringKeyMap(Object? value) {
-    if (value is Map<String, dynamic>) return value;
-    if (value is Map) {
-      return Map<String, dynamic>.from(
-        value.map((k, v) => MapEntry(k.toString(), v)),
-      );
-    }
-    return null;
-  }
-
   String _contentFromResponse(Map<String, dynamic> map) {
     final choicesRaw = map['choices'];
     if (choicesRaw is! List || choicesRaw.isEmpty) {
@@ -29,14 +17,14 @@ final class EnjoyLlmCapability implements LlmCapability {
         statusCode: 502,
       );
     }
-    final first = _stringKeyMap(choicesRaw.first);
+    final first = castJsonObjectOrNull(choicesRaw.first);
     if (first == null) {
       throw const ApiException(
         message: 'No choices in chat completion',
         statusCode: 502,
       );
     }
-    final message = _stringKeyMap(first['message']);
+    final message = castJsonObjectOrNull(first['message']);
     if (message == null) {
       throw const ApiException(
         message: 'No message in completion choice',

--- a/lib/features/ai/domain/models/asr_result.dart
+++ b/lib/features/ai/domain/models/asr_result.dart
@@ -1,12 +1,14 @@
+import 'package:enjoy_player/core/json/json_cast.dart';
+
 /// Whisper-style JSON response (keys camelCase after [ApiClient] decode).
 final class AsrResult {
   factory AsrResult.fromJson(Map<String, dynamic> json) {
     final segs = json['segments'] as List<dynamic>?;
-    final transcriptionInfo = _jsonMap(json['transcriptionInfo']);
+    final transcriptionInfo = castJsonObjectOrNull(json['transcriptionInfo']);
     return AsrResult(
       text: json['text'] as String? ?? '',
       segments: segs
-          ?.map((e) => AsrSegment.fromJson(_jsonMap(e) ?? const {}))
+          ?.map((e) => AsrSegment.fromJson(castJsonObjectOrNull(e) ?? const {}))
           .toList(),
       language:
           transcriptionInfo?['language'] as String? ??
@@ -37,7 +39,9 @@ final class AsrSegment {
       start: (json['start'] as num?)?.toDouble() ?? 0,
       end: (json['end'] as num?)?.toDouble() ?? 0,
       text: json['text'] as String? ?? '',
-      words: w?.map((e) => AsrWord.fromJson(_jsonMap(e) ?? const {})).toList(),
+      words: w
+          ?.map((e) => AsrWord.fromJson(castJsonObjectOrNull(e) ?? const {}))
+          .toList(),
     );
   }
   const AsrSegment({
@@ -51,14 +55,6 @@ final class AsrSegment {
   final double end;
   final String text;
   final List<AsrWord>? words;
-}
-
-/// JSON nested objects decode as [Map<dynamic, dynamic>]; normalize for casts.
-Map<String, dynamic>? _jsonMap(dynamic value) {
-  if (value == null) return null;
-  if (value is Map<String, dynamic>) return value;
-  if (value is Map) return Map<String, dynamic>.from(value);
-  return null;
 }
 
 final class AsrWord {

--- a/lib/features/community/domain/active_user.dart
+++ b/lib/features/community/domain/active_user.dart
@@ -1,16 +1,7 @@
 /// Active learners payload from `GET /api/v1/users/active` (camelCase JSON).
 library;
 
-Map<String, dynamic>? _jsonObjectAsStringMap(Object? value) {
-  if (value == null) return null;
-  if (value is Map<String, dynamic>) return value;
-  if (value is Map) {
-    return Map<String, dynamic>.from(
-      value.map((k, v) => MapEntry(k.toString(), v)),
-    );
-  }
-  return null;
-}
+import 'package:enjoy_player/core/json/json_cast.dart';
 
 int? _intFromJson(Object? value) {
   if (value == null) return null;
@@ -40,7 +31,7 @@ class ActiveUsersResponse {
     final users = <ActiveUser>[];
     if (rawUsers is List) {
       for (final e in rawUsers) {
-        final m = _jsonObjectAsStringMap(e);
+        final m = castJsonObjectOrNull(e);
         if (m != null) {
           users.add(ActiveUser.fromJson(m));
         }

--- a/lib/features/library/domain/learning_statistics.dart
+++ b/lib/features/library/domain/learning_statistics.dart
@@ -1,19 +1,7 @@
 /// Learning statistics from `GET /api/v1/mine/stats` (camelCase JSON).
 library;
 
-/// Nested maps from [decodeJsonToCamel] are [Map<dynamic, dynamic>], not
-/// [Map<String, dynamic>], so strict `is Map<String, dynamic>` loses `today` /
-/// `week` / `month` and stats read as zero.
-Map<String, dynamic>? _jsonObjectAsStringMap(Object? value) {
-  if (value == null) return null;
-  if (value is Map<String, dynamic>) return value;
-  if (value is Map) {
-    return Map<String, dynamic>.from(
-      value.map((k, v) => MapEntry(k.toString(), v)),
-    );
-  }
-  return null;
-}
+import 'package:enjoy_player/core/json/json_cast.dart';
 
 class PeriodStats {
   const PeriodStats({
@@ -40,9 +28,12 @@ class PeriodStats {
 class LearningStatistics {
   factory LearningStatistics.fromJson(Map<String, dynamic> json) {
     return LearningStatistics(
-      today: PeriodStats.fromJson(_jsonObjectAsStringMap(json['today'])),
-      week: PeriodStats.fromJson(_jsonObjectAsStringMap(json['week'])),
-      month: PeriodStats.fromJson(_jsonObjectAsStringMap(json['month'])),
+      // Nested maps from decodeJsonToCamel may be Map<dynamic, dynamic>; see
+      // castJsonObjectOrNull doc for why a strict `is Map<String, dynamic>`
+      // check would silently read `today` / `week` / `month` as zero.
+      today: PeriodStats.fromJson(castJsonObjectOrNull(json['today'])),
+      week: PeriodStats.fromJson(castJsonObjectOrNull(json['week'])),
+      month: PeriodStats.fromJson(castJsonObjectOrNull(json['month'])),
     );
   }
   const LearningStatistics({

--- a/lib/features/sync/data/recording_target_sync_service.dart
+++ b/lib/features/sync/data/recording_target_sync_service.dart
@@ -1,6 +1,7 @@
 /// Pull recording metadata for one library media target (lazy sync).
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/data/api/services/recording_api.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
@@ -77,7 +78,7 @@ class RecordingTargetSyncService {
           targetId: targetId,
           targetType: targetType,
         );
-        batch = raw.map<Map<String, dynamic>>(_asJsonMap).toList();
+        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
       } catch (e) {
         return SyncResult(
           success: false,
@@ -135,12 +136,6 @@ class RecordingTargetSyncService {
       errors: errors.isEmpty ? null : errors,
     );
   }
-}
-
-Map<String, dynamic> _asJsonMap(Object? e) {
-  if (e is Map<String, dynamic>) return e;
-  if (e is Map) return Map<String, dynamic>.from(e);
-  throw FormatException('Expected JSON object, got ${e.runtimeType}');
 }
 
 String? _maxUpdatedAtIso(List<Map<String, dynamic>> batch) {

--- a/lib/features/sync/data/sync_download_service.dart
+++ b/lib/features/sync/data/sync_download_service.dart
@@ -1,6 +1,7 @@
 /// Download remote entities into Drift (metadata only).
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/settings_keys.dart';
 import 'package:enjoy_player/data/api/services/audio_api.dart';
@@ -52,7 +53,7 @@ class SyncDownloadService {
           limit: _pageSize,
           updatedAfter: cursor,
         );
-        batch = raw.map<Map<String, dynamic>>(_asJsonMap).toList();
+        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
       } catch (e) {
         return SyncResult(
           success: false,
@@ -114,7 +115,7 @@ class SyncDownloadService {
           limit: _pageSize,
           updatedAfter: cursor,
         );
-        batch = raw.map<Map<String, dynamic>>(_asJsonMap).toList();
+        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
       } catch (e) {
         return SyncResult(
           success: false,
@@ -178,7 +179,7 @@ class SyncDownloadService {
           limit: _pageSize,
           updatedAfter: cursor,
         );
-        batch = raw.map<Map<String, dynamic>>(_asJsonMap).toList();
+        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
       } catch (e) {
         return SyncResult(
           success: false,
@@ -231,12 +232,6 @@ class SyncDownloadService {
     final r = await _downloadRecordingsInternal(resetCursor: true);
     return a.merge(v).merge(r);
   }
-}
-
-Map<String, dynamic> _asJsonMap(Object? e) {
-  if (e is Map<String, dynamic>) return e;
-  if (e is Map) return Map<String, dynamic>.from(e);
-  throw FormatException('Expected JSON object, got ${e.runtimeType}');
 }
 
 String? _maxUpdatedAtIso(List<Map<String, dynamic>> batch) {

--- a/lib/features/transcript/data/transcript_timeline_parse.dart
+++ b/lib/features/transcript/data/transcript_timeline_parse.dart
@@ -1,8 +1,11 @@
 /// Parse `timeline` arrays from Enjoy API JSON (after [convertKeysToCamel]).
 ///
 /// Nested cue maps are often [Map<dynamic, dynamic>], not [Map<String, dynamic>],
-/// so a naive `e is Map<String, dynamic>` check drops every line.
+/// so a naive `e is Map<String, dynamic>` check drops every line; see
+/// [castJsonObjectOrNull].
 library;
+
+import 'package:enjoy_player/core/json/json_cast.dart';
 
 import '../../../data/subtitle/transcript_line.dart';
 
@@ -10,19 +13,9 @@ List<TranscriptLine> transcriptLinesFromApiTimeline(dynamic timeline) {
   final lines = <TranscriptLine>[];
   if (timeline is! List) return lines;
   for (final e in timeline) {
-    final m = _stringKeyMapFromJson(e);
+    final m = castJsonObjectOrNull(e);
     if (m == null) continue;
     lines.add(TranscriptLine.fromJson(m));
   }
   return lines;
-}
-
-Map<String, dynamic>? _stringKeyMapFromJson(Object? value) {
-  if (value is Map<String, dynamic>) return value;
-  if (value is Map) {
-    return Map<String, dynamic>.from(
-      value.map((k, v) => MapEntry(k.toString(), v)),
-    );
-  }
-  return null;
 }

--- a/test/core/json/json_cast_test.dart
+++ b/test/core/json/json_cast_test.dart
@@ -1,0 +1,47 @@
+import 'package:enjoy_player/core/json/json_cast.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('castJsonObjectOrNull', () {
+    test('returns a Map<String, dynamic> as-is', () {
+      final input = <String, dynamic>{'a': 1};
+      expect(identical(castJsonObjectOrNull(input), input), isTrue);
+    });
+
+    test('re-keys a Map<dynamic, dynamic> via toString', () {
+      final input = <dynamic, dynamic>{'a': 1, 'b': 2};
+      final result = castJsonObjectOrNull(input);
+      expect(result, {'a': 1, 'b': 2});
+    });
+
+    test('returns null for null', () {
+      expect(castJsonObjectOrNull(null), isNull);
+    });
+
+    test('returns null for a non-Map value', () {
+      expect(castJsonObjectOrNull('not a map'), isNull);
+      expect(castJsonObjectOrNull(42), isNull);
+      expect(castJsonObjectOrNull(<dynamic>[1, 2]), isNull);
+    });
+  });
+
+  group('castJsonObject', () {
+    test('returns a Map<String, dynamic> as-is', () {
+      final input = <String, dynamic>{'a': 1};
+      expect(identical(castJsonObject(input), input), isTrue);
+    });
+
+    test('re-keys a Map<dynamic, dynamic> via toString', () {
+      final input = <dynamic, dynamic>{'a': 1};
+      expect(castJsonObject(input), {'a': 1});
+    });
+
+    test('throws FormatException for null', () {
+      expect(() => castJsonObject(null), throwsFormatException);
+    });
+
+    test('throws FormatException for a non-Map value', () {
+      expect(() => castJsonObject('nope'), throwsFormatException);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Audited #162. The described duplication is real, and worse than "cosmetic": the issue's own analysis flags that the copies had already drifted (some throw, some return `null`, one silently skips invalid list elements), which is a genuine correctness risk, not just style. I verified each of the 9 listed call sites individually before migrating, to make sure I preserved each site's exact existing behavior for invalid input rather than silently unifying it.

## Change

Added `lib/core/json/json_cast.dart` with two functions:

- `castJsonObjectOrNull(Object? value)` — returns `Map<String, dynamic>`, re-keying `Map<dynamic, dynamic>` via `.toString()`, or `null` for anything else (including `null`).
- `castJsonObject(Object? value)` — same, but throws `FormatException` instead of returning `null`.

Migrated every site listed in the issue, preserving behavior exactly:

| Site | Prior behavior on invalid input | After |
|---|---|---|
| `api_client.dart` (`_sendMapWithOptionalRefresh`, `postMultipartJson`) | throws `ApiException(message: 'Expected JSON object', ...)` | same — now via `castJsonObjectOrNull` + explicit throw, so the specific `ApiException` (status code, body) is unchanged |
| `api_client.dart` (`_sendList`) | throws `ApiException(message: 'Array element is not an object', ...)` | same, same reasoning |
| `credits_api.dart` | silently skips non-map log entries (no `else`) | same — `castJsonObjectOrNull` + skip-if-null |
| `active_user.dart`, `learning_statistics.dart`, `transcript_timeline_parse.dart`, `enjoy_llm_capability.dart` | returns `null` | same — direct `castJsonObjectOrNull` swap-in, byte-identical logic |
| `asr_result.dart` | returns `null`, but the old local `_jsonMap` skipped the `.toString()` re-keying step that every other copy has | now uses the more correct shared version (no observable behavior change for real JSON data, since decoded JSON keys are always strings already) |
| `recording_target_sync_service.dart`, `sync_download_service.dart` | throws `FormatException('Expected JSON object, got ${e.runtimeType}')` | same message, now via `castJsonObject` |

This also fully resolves the already-expired #152 (`_asJsonMap` duplication) and #154 as a side effect, since their file lists are subsets of this one.

## Verification

- `flutter analyze` — no issues.
- `flutter test` — full suite green (731 passed, 2 pre-existing skips — 8 new tests added for the helper itself in `test/core/json/json_cast_test.dart`).
- No response-parsing behavior changes: verified via `test/data/api/credits_api_test.dart`, `test/features/library/learning_statistics_test.dart`, `test/features/transcript/transcript_timeline_parse_test.dart`, `test/features/ai/asr_result_test.dart`, `test/features/sync/**`.

Closes #162
