### PR TITLE
docs(changelog): note Windows deep-link single-instance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows deep links**: PKCE sign-in callbacks no longer spawn a stray second window. The installer-registered `enjoyplayer://` protocol previously launched a fresh `enjoy_player.exe` per click; that process had no in-memory PKCE state, so the original window was stuck waiting and a second window was left open. `windows/runner/main.cpp` now detects an already-running instance via `FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"Enjoy Player")`, forwards the URI to it through `app_links`'s `SendAppLink` (`WM_COPYDATA`), restores/foregrounds that window, and exits. See [docs/features/auth.md](docs/features/auth.md#deep-links-pkce-callback).
+
 ## [0.3.0] - 2026-07-01
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds an `[Unreleased]` -> **Fixed** entry to `CHANGELOG.md` for the Windows deep-link single-instance forwarding fix (commit `fa0251f`).

## Why

The implementation landed in `fa0251f` with a design note in `docs/features/auth.md#deep-links-pkce-callback`, but the change was never mirrored in the user-facing changelog.

Resolves #167.
