### PR TITLE
docs(auth): record custom-scheme-only PKCE callback

### DIFF
--- a/docs/decisions/0034-custom-scheme-only-pkce-callback.md
+++ b/docs/decisions/0034-custom-scheme-only-pkce-callback.md
@@ -1,0 +1,30 @@
+# ADR-0034: Custom-scheme-only PKCE callback
+
+## Status
+
+Accepted — supersedes [ADR-0027](0027-native-auth-v2.md) §Decision 2 only
+
+## Context
+
+[ADR-0027](0027-native-auth-v2.md) §Decision 2 specified two possible PKCE redirect URIs: a universal/app link (`https://enjoy.bot/app/auth/callback`) or the Windows-only custom scheme (`enjoyplayer://auth/callback`). In practice, hosting the universal/app link required `apple-app-site-association` and Android `assetlinks.json` on the backend, plus the corresponding intent filter / associated-domain entitlement work on every mobile platform — none of which materialized before the native-auth-v2 rollout.
+
+`auth_pkce_redirect_uri()` was refactored to always return `enjoyplayer://auth/callback` regardless of `TargetPlatform`, and the Android universal-link intent filter was removed from `AndroidManifest.xml`. This is a real behavioral divergence from ADR-0027, not just an implementation detail — a future maintainer reading ADR-0027 would reasonably expect a live universal/app-link path that no longer exists in the client.
+
+Separately, the same change introduced `kGoogleWebClientId` (`google_auth_config.dart`) as the canonical home for the Google **Web application** OAuth client ID, passed as `serverClientId` on Android per-platform ID-token verification. This constant is a public OAuth client identifier, not a secret.
+
+## Decision
+
+1. **Single redirect URI, every platform:** `authPkceRedirectUri()` returns `enjoyplayer://auth/callback` for Android, iOS, macOS, and Windows. There is no universal/app-link alternative.
+2. **Per-platform scheme registration** (no backend-hosted association files required):
+   - **Android** — `VIEW` intent filter for the `enjoyplayer` scheme in `AndroidManifest.xml` (the universal-link intent filter is removed).
+   - **iOS / macOS** — `CFBundleURLSchemes` entry for `enjoyplayer` in `Info.plist`.
+   - **Windows** — Inno Setup installer registers the `enjoyplayer://` protocol handler at install time.
+3. **`kGoogleWebClientId` is first-class:** the Google Web application OAuth client ID lives in `lib/features/auth/domain/google_auth_config.dart` as a named public constant, rather than being inlined at each call site. It is passed as `serverClientId` on Android so the returned ID token's audience matches what `NativeAuth::GoogleIdTokenVerifier` already accepts by default.
+4. **Everything else in ADR-0027 stands.** The native SDK exchanges (`/api/v1/auth/google`, `/api/v1/auth/apple`, `/api/v1/auth/otp/*`), the `/api/v1/auth/token` PKCE exchange endpoint, refresh-token rotation, the platform matrix, account linking, and the `start_auth`/WebView deprecation are unaffected by this ADR.
+
+## Consequences
+
+- No backend work needed to host `apple-app-site-association` or `assetlinks.json` — one fewer moving part for the mobile deep-link story.
+- Windows requires the single-instance forwarding workaround documented in [`docs/features/auth.md`](../features/auth.md#deep-links-pkce-callback) (`SendAppLinkToInstance`) since the OS always launches a fresh process for a registered custom-scheme URL; a universal/app link would not have needed this on iOS/macOS, but Windows never supported universal links anyway.
+- `enjoy_web`'s `config/native_auth_clients.yml` only needs to whitelist the one custom-scheme redirect URI.
+- If a future universal/app-link requirement re-emerges (e.g. an OS deprecates custom URL schemes), it will need its own ADR rather than reviving this superseded decision.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -57,3 +57,4 @@ Trade-offs, follow-up work, risks.
 | [0031](0031-login-only-access.md) | Login-only application access — auth gate, welcome sign-in hub, guest migration removed |
 | [0032](0032-platform-scoped-subscription-purchase.md) | Platform-scoped Pro purchase — desktop external checkout; mobile IAP deferred |
 | [0033](0033-byok-ai-provider-settings.md) | BYOK AI provider settings — per-modality Enjoy vs BYOK, secure secrets, direct vendor HTTP |
+| [0034](0034-custom-scheme-only-pkce-callback.md) | Custom-scheme-only PKCE callback — drops universal/app links (partial supersession of 0027) |

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -52,6 +52,8 @@ This is the only redirect URI whitelisted in enjoy_web's `config/native_auth_cli
 
 ## Google OAuth client setup (manual, one-time)
 
+OAuth client IDs are **public identifiers**, not secrets — they are safe to embed in client code the same way they already ship in `google-services.json` / `GoogleService-Info.plist`. The Web application client ID lives as a named constant, `kGoogleWebClientId` in [`google_auth_config.dart`](../../lib/features/auth/domain/google_auth_config.dart), rather than being inlined at each call site. Rotating any of these client IDs does not affect the `enjoyplayer://auth/callback` redirect URI (see [Deep links](#deep-links-pkce-callback)) — the scheme is stable and only needs to change if the app's URL scheme itself changes.
+
 `GoogleSignInService` and `ios/Runner/Info.plist` / `macos/Runner/Info.plist` currently ship with `REPLACE_WITH_*` placeholders. Someone with access to the Google Cloud project backing `google.client_id` in enjoy_web's Rails credentials must:
 
 1. **Android** — no new OAuth client needed. `GoogleSignInService` already passes the existing **Web application** client ID (`kGoogleWebClientId` in [`google_auth_config.dart`](../../lib/features/auth/domain/google_auth_config.dart)) as `serverClientId`; enjoy_web's `NativeAuth::GoogleIdTokenVerifier` already accepts it for `platform=android` (falls back to `google.client_id` when `google.android_client_id` is unset). You only need to register the app's **SHA-1 fingerprints** (debug + release keystores, `keytool -list -v -keystore <path>`) against package `ai.enjoy.player` in Google Cloud Console → Credentials, or Google Sign-In will reject the app at runtime.
@@ -81,5 +83,6 @@ The PKCE callback stream is owned by the auth controller and is now properly **c
 - [ADR-0006](../decisions/0006-auth-and-profile-sync.md)
 - [ADR-0012](../decisions/0012-per-user-sqlite-isolation.md)
 - [ADR-0016](../decisions/0016-enjoy-account-webview-sign-in.md) — superseded for Enjoy account delivery
-- [ADR-0027](../decisions/0027-native-auth-v2.md)
+- [ADR-0027](../decisions/0027-native-auth-v2.md) — §Decision 2 (redirect URI) superseded by ADR-0034
 - [ADR-0031](../decisions/0031-login-only-access.md)
+- [ADR-0034](../decisions/0034-custom-scheme-only-pkce-callback.md) — custom-scheme-only PKCE callback, drops the universal/app-link alternative


### PR DESCRIPTION
## Summary

`auth_pkce_redirect_uri()` was refactored (commit `079a93d`) to always return the custom-scheme redirect URI for every platform, but [ADR-0027](docs/decisions/0027-native-auth-v2.md) §Decision 2 still describes a universal/app-link alternative that was never built. Since ADRs are immutable after merge, this records the current behavior as a new ADR that supersedes ADR-0027 §Decision 2 only.

## Changes

- **`docs/decisions/0034-custom-scheme-only-pkce-callback.md`** (new ADR) — records the single-redirect-URI decision, drops universal/app links, documents per-platform scheme registration, and makes `kGoogleWebClientId` first-class. Scope is limited to superseding ADR-0027 §Decision 2; all other points of ADR-0027 stay in force.
- **`docs/decisions/README.md`** — index entry for ADR-0034.
- **`docs/features/auth.md`** — links ADR-0034 from "Related ADRs", and expands the Google OAuth client setup section to note client IDs are public identifiers (not secrets), point to `kGoogleWebClientId`, and clarify the `enjoyplayer://` scheme is stable across OAuth client rotation.

Resolves #164.
