### PR TITLE
fix(ci): raise agentic-wiki-writer repo-memory max-patch-size

### DIFF
--- a/.github/workflows/agentic-wiki-writer.lock.yml
+++ b/.github/workflows/agentic-wiki-writer.lock.yml
@@ -309,7 +309,7 @@ jobs:
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
           GH_AW_MEMORY_BRANCH_NAME: 'memory/agentic-wiki'
-          GH_AW_MEMORY_CONSTRAINTS: "\n\n**Constraints:**\n- **Max File Size**: 1048576 bytes (1.00 MB) per file\n- **Max File Count**: 50 files per commit\n- **Max Patch Size**: 10240 bytes (10 KB) total per push (max: 1024 KB)\n"
+          GH_AW_MEMORY_CONSTRAINTS: "\n\n**Constraints:**\n- **Max File Size**: 1048576 bytes (1.00 MB) per file\n- **Max File Count**: 50 files per commit\n- **Max Patch Size**: 51200 bytes (50 KB) total per push (max: 1024 KB)\n"
           GH_AW_MEMORY_DESCRIPTION: ' Source file mappings, content hashes, and file summaries for incremental wiki regeneration'
           GH_AW_MEMORY_DIR: '/tmp/gh-aw/repo-memory/default/'
           GH_AW_MEMORY_TARGET_REPO: ' of the current repository'
@@ -1701,7 +1701,7 @@ jobs:
           BRANCH_NAME: memory/agentic-wiki
           MAX_FILE_SIZE: 1048576
           MAX_FILE_COUNT: 50
-          MAX_PATCH_SIZE: 10240
+          MAX_PATCH_SIZE: 51200
           ALLOWED_EXTENSIONS: '[".json",".md"]'
         with:
           script: |

--- a/.github/workflows/agentic-wiki-writer.md
+++ b/.github/workflows/agentic-wiki-writer.md
@@ -139,6 +139,7 @@ tools:
     description: Source file mappings, content hashes, and file summaries for incremental wiki regeneration
     max-file-count: 50
     max-file-size: 1048576
+    max-patch-size: 51200
 ---
 # Wiki Generator
 


### PR DESCRIPTION
## Summary

The [Agentic Wiki Writer](https://github.com/baizhiheizi/enjoy_player/actions/runs/28510891563) workflow run failed with a **repo-memory patch size exceeded** error: the `default` memory push exceeded the default 10 KB (`max-patch-size: 10240`) limit.

## Change

- `.github/workflows/agentic-wiki-writer.md` — adds `max-patch-size: 51200` (50 KB, 5x the default) to the `repo-memory` front matter, per the workflow's own suggested remediation.
- `.github/workflows/agentic-wiki-writer.lock.yml` — mirrors the same value at the two generated call sites (`GH_AW_MEMORY_CONSTRAINTS` env string and the `push_repo_memory` job's `MAX_PATCH_SIZE` env var).

## Note for maintainer

I compiled this by hand (`gh aw compile` did not complete in this sandbox — likely a network restriction fetching workflow engine metadata) by mirroring the exact two `MAX_PATCH_SIZE` / `Max Patch Size` occurrences the compiler produces elsewhere in this file. Please run `gh aw compile agentic-wiki-writer` locally (or let the next `gh-aw` update pass regenerate it) to confirm the lock file is byte-for-byte what the compiler would produce — the frontmatter hash embedded in the lock file's metadata comment will still reflect the pre-change frontmatter until it's recompiled, though this doesn't affect the workflow's runtime behavior.

Resolves #168.
