### PR TITLE
refactor(shadow-reading): split panel widgets into presentation/widgets/

### DIFF
--- a/lib/features/shadow_reading/presentation/shadow_reading_panel.dart
+++ b/lib/features/shadow_reading/presentation/shadow_reading_panel.dart
@@ -3,7 +3,6 @@ library;
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:math' as math;
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
@@ -21,20 +20,21 @@ import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
-import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
 import 'package:enjoy_player/features/hotkeys/presentation/hotkey_tooltip_label.dart';
 import 'package:enjoy_player/features/shadow_reading/application/recording_input_device_controller.dart';
 import 'package:enjoy_player/features/shadow_reading/application/shadow_reading_hotkey_bus.dart';
-import 'package:enjoy_player/features/shadow_reading/presentation/recording_assessment_button.dart';
 import 'package:enjoy_player/features/shadow_reading/presentation/recording_assessment_flow.dart';
-import 'package:enjoy_player/features/shadow_reading/presentation/score_level.dart';
 import 'package:enjoy_player/features/sync/application/sync_providers.dart';
 import 'package:enjoy_player/features/sync/domain/sync_types.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 import 'pitch_contour_section.dart';
+import 'widgets/shadow_record_fab.dart';
+import 'widgets/shadow_reading_toolbar_row.dart';
+import 'widgets/shadow_recording_caption.dart';
+import 'widgets/shadow_takes_toolbar_actions.dart';
 
 final _log = logNamed('ShadowReadingPanel');
 
@@ -55,10 +55,6 @@ RecordingRow? _resolvedSelectedRow(
     }
   }
   return list.first;
-}
-
-String _formatSecsOneDecimal(double seconds) {
-  return seconds.toStringAsFixed(1);
 }
 
 class ShadowReadingPanel extends ConsumerStatefulWidget {
@@ -674,7 +670,7 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
                     Center(
                       child: Tooltip(
                         message: ttToggleRecording,
-                        child: _RecordFabWithRing(
+                        child: ShadowRecordFab(
                           recording: true,
                           echoActive: widget.echoActive,
                           ringProgress: ringProgress,
@@ -688,7 +684,7 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
                       ),
                     ),
                     SizedBox(height: tok.space4),
-                    _RecordingCaptionRow(
+                    ShadowRecordingCaptionRow(
                       elapsedSec: elapsedSec,
                       targetSec: targetSec,
                       overTarget: overTarget,
@@ -708,7 +704,7 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _ShadowReadingToolbarRow(
+                  ShadowReadingToolbarRow(
                     tok: tok,
                     scheme: scheme,
                     pitchExpanded: _pitchExpanded,
@@ -717,7 +713,7 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
                     onPitchTap: () =>
                         setState(() => _pitchExpanded = !_pitchExpanded),
                     takesActions: list.isNotEmpty && sel != null
-                        ? _TakesToolbarActions(
+                        ? ShadowTakesToolbarActions(
                             row: sel,
                             list: list,
                             echoActive: widget.echoActive,
@@ -744,7 +740,7 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
                         : null,
                     recordFab: Tooltip(
                       message: recordFabTooltip,
-                      child: _RecordFabWithRing(
+                      child: ShadowRecordFab(
                         recording: false,
                         echoActive: widget.echoActive,
                         ringProgress: 0,
@@ -778,595 +774,6 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
           },
         );
       },
-    );
-  }
-}
-
-// ── Dense toolbar (idle) ──────────────────────────────────────────────────────
-
-class _ShadowReadingToolbarRow extends StatelessWidget {
-  const _ShadowReadingToolbarRow({
-    required this.tok,
-    required this.scheme,
-    required this.pitchExpanded,
-    required this.pitchTooltip,
-    required this.hasMediaPath,
-    required this.onPitchTap,
-    required this.takesActions,
-    required this.recordFab,
-  });
-
-  final EnjoyThemeTokens tok;
-  final ColorScheme scheme;
-  final bool pitchExpanded;
-  final String pitchTooltip;
-  final bool hasMediaPath;
-  final VoidCallback onPitchTap;
-  final Widget? takesActions;
-  final Widget recordFab;
-
-  @override
-  Widget build(BuildContext context) {
-    final pitchIcon = Icon(
-      Icons.show_chart_rounded,
-      size: 22,
-      color: hasMediaPath
-          ? null
-          : scheme.onSurfaceVariant.withValues(alpha: 0.38),
-    );
-
-    final Widget pitchControl = Tooltip(
-      message: pitchTooltip,
-      child: hasMediaPath
-          ? pitchExpanded
-                ? IconButton.filledTonal(
-                    onPressed: onPitchTap,
-                    style: IconButton.styleFrom(
-                      visualDensity: VisualDensity.compact,
-                      minimumSize: const Size(44, 44),
-                    ),
-                    icon: pitchIcon,
-                  )
-                : IconButton(
-                    onPressed: onPitchTap,
-                    style: IconButton.styleFrom(
-                      visualDensity: VisualDensity.compact,
-                      minimumSize: const Size(44, 44),
-                    ),
-                    icon: pitchIcon,
-                  )
-          : IconButton(
-              onPressed: null,
-              style: IconButton.styleFrom(
-                visualDensity: VisualDensity.compact,
-                minimumSize: const Size(44, 44),
-              ),
-              icon: pitchIcon,
-            ),
-    );
-
-    // FAB stays at true horizontal center: overlay it on a Row whose middle
-    // reserves ring width so pitch/takes hug the center without shifting the mic.
-    return Stack(
-      alignment: Alignment.center,
-      clipBehavior: Clip.none,
-      children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Expanded(
-              child: Align(
-                alignment: Alignment.centerRight,
-                child: Padding(
-                  padding: EdgeInsets.only(right: tok.space12),
-                  child: pitchControl,
-                ),
-              ),
-            ),
-            const SizedBox(width: _RecordFabWithRing.ringOuterHitSize),
-            Expanded(
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: Padding(
-                  padding: EdgeInsets.only(left: tok.space12),
-                  child: takesActions ?? const SizedBox.shrink(),
-                ),
-              ),
-            ),
-          ],
-        ),
-        recordFab,
-      ],
-    );
-  }
-}
-
-// ── Countdown ring + FAB ─────────────────────────────────────────────────────
-
-class _CountdownRingPainter extends CustomPainter {
-  _CountdownRingPainter({
-    required this.progress,
-    required this.overTarget,
-    required this.trackColor,
-    required this.fillColor,
-    required this.showProgressArc,
-  });
-
-  final double progress;
-  final bool overTarget;
-  final Color trackColor;
-  final Color fillColor;
-  final bool showProgressArc;
-
-  static const double _strokeWidth = 4;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final center = Offset(size.width / 2, size.height / 2);
-    final radius = size.width / 2 - _strokeWidth / 2;
-
-    final trackPaint = Paint()
-      ..color = trackColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = _strokeWidth
-      ..strokeCap = StrokeCap.round;
-
-    canvas.drawCircle(center, radius, trackPaint);
-
-    if (!showProgressArc) return;
-
-    final arcPaint = Paint()
-      ..color = fillColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = _strokeWidth
-      ..strokeCap = StrokeCap.round;
-
-    final rect = Rect.fromCircle(center: center, radius: radius);
-    if (overTarget) {
-      canvas.drawArc(rect, -math.pi / 2, 2 * math.pi, false, arcPaint);
-    } else {
-      final remaining = (1.0 - progress.clamp(0.0, 1.0));
-      final sweep = 2 * math.pi * remaining;
-      canvas.drawArc(rect, -math.pi / 2, sweep, false, arcPaint);
-    }
-  }
-
-  @override
-  bool shouldRepaint(covariant _CountdownRingPainter oldDelegate) {
-    return oldDelegate.progress != progress ||
-        oldDelegate.overTarget != overTarget ||
-        oldDelegate.trackColor != trackColor ||
-        oldDelegate.fillColor != fillColor ||
-        oldDelegate.showProgressArc != showProgressArc;
-  }
-}
-
-class _RecordFabWithRing extends StatelessWidget {
-  const _RecordFabWithRing({
-    required this.recording,
-    required this.echoActive,
-    required this.ringProgress,
-    required this.overTarget,
-    required this.overPulseHigh,
-    required this.showProgressArc,
-    required this.onTap,
-    required this.scheme,
-    required this.tok,
-  });
-
-  /// Outer hit target / ring diameter; keep in sync with toolbar slot in
-  /// [_ShadowReadingToolbarRow].
-  static const double ringOuterHitSize = 68;
-  static const double _fabInner = 56;
-
-  final bool recording;
-  final bool echoActive;
-  final double ringProgress;
-  final bool overTarget;
-  final bool overPulseHigh;
-  final bool showProgressArc;
-  final VoidCallback onTap;
-  final ColorScheme scheme;
-  final EnjoyThemeTokens tok;
-
-  @override
-  Widget build(BuildContext context) {
-    final scale = overTarget ? (overPulseHigh ? 1.04 : 1.0) : 1.0;
-    final trackAlpha = showProgressArc ? 0.38 : 0.18;
-    final iconSize = _fabInner <= 56 ? 24.0 : 28.0;
-
-    return AnimatedScale(
-      scale: scale,
-      duration: const Duration(milliseconds: 280),
-      curve: Curves.easeOutCubic,
-      child: SizedBox(
-        width: ringOuterHitSize,
-        height: ringOuterHitSize,
-        child: Stack(
-          alignment: Alignment.center,
-          clipBehavior: Clip.none,
-          children: [
-            CustomPaint(
-              size: const Size(ringOuterHitSize, ringOuterHitSize),
-              painter: _CountdownRingPainter(
-                progress: ringProgress,
-                overTarget: overTarget,
-                trackColor: scheme.outlineVariant.withValues(alpha: trackAlpha),
-                fillColor: overTarget ? scheme.error : scheme.primary,
-                showProgressArc: showProgressArc,
-              ),
-            ),
-            Material(
-              color: Colors.transparent,
-              child: InkWell(
-                customBorder: const CircleBorder(),
-                onTap: echoActive ? onTap : null,
-                child: AnimatedContainer(
-                  duration: tok.motionFast,
-                  width: _fabInner,
-                  height: _fabInner,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: recording ? tok.echoActive : scheme.primary,
-                    boxShadow: [
-                      BoxShadow(
-                        color: (recording ? tok.echoActive : scheme.primary)
-                            .withValues(alpha: 0.35),
-                        blurRadius: recording ? 22 : 12,
-                        spreadRadius: recording ? 2 : 0,
-                        offset: const Offset(0, 4),
-                      ),
-                    ],
-                  ),
-                  child: Icon(
-                    recording ? Icons.stop_rounded : Icons.mic_rounded,
-                    color: recording ? Colors.white : scheme.onPrimary,
-                    size: iconSize,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _RecordingCaptionRow extends StatelessWidget {
-  const _RecordingCaptionRow({
-    required this.elapsedSec,
-    required this.targetSec,
-    required this.overTarget,
-    required this.overBySec,
-    required this.l10n,
-    required this.tt,
-    required this.scheme,
-    required this.tok,
-  });
-
-  final double elapsedSec;
-  final double targetSec;
-  final bool overTarget;
-  final double overBySec;
-  final AppLocalizations l10n;
-  final TextTheme tt;
-  final ColorScheme scheme;
-  final EnjoyThemeTokens tok;
-
-  @override
-  Widget build(BuildContext context) {
-    if (targetSec > 0) {
-      return Semantics(
-        label:
-            '${_formatSecsOneDecimal(elapsedSec)} seconds elapsed of '
-            '${_formatSecsOneDecimal(targetSec)} seconds target',
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: tok.space8),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                '${_formatSecsOneDecimal(elapsedSec)} s / '
-                '${_formatSecsOneDecimal(targetSec)} s',
-                style: tt.labelMedium?.copyWith(
-                  fontFeatures: const [FontFeature.tabularFigures()],
-                ),
-              ),
-              if (overTarget) ...[
-                SizedBox(width: tok.space8),
-                Icon(Icons.circle, size: 8, color: scheme.error),
-                SizedBox(width: tok.space4),
-                Flexible(
-                  child: Text(
-                    l10n.shadowRecordingOverTarget(
-                      _formatSecsOneDecimal(overBySec),
-                    ),
-                    style: tt.labelSmall?.copyWith(color: scheme.error),
-                    maxLines: 2,
-                    textAlign: TextAlign.center,
-                  ),
-                ),
-              ],
-            ],
-          ),
-        ),
-      );
-    }
-
-    return Center(
-      child: Text(
-        '${_formatSecsOneDecimal(elapsedSec)} s',
-        style: tt.labelMedium?.copyWith(
-          fontFeatures: const [FontFeature.tabularFigures()],
-        ),
-      ),
-    );
-  }
-}
-
-const _kDeleteTakeToken = '__shadow_delete_current_take__';
-const _kReassessTakeToken = '__shadow_reassess_current_take__';
-
-Future<void> _confirmDeleteCurrentTake({
-  required BuildContext context,
-  required ColorScheme scheme,
-  required AppLocalizations l10n,
-  required String takeSummary,
-  required VoidCallback onConfirmed,
-}) async {
-  if (!context.mounted) return;
-  final cancelLabel = MaterialLocalizations.of(context).cancelButtonLabel;
-  final confirmed = await showEnjoyAlertDialog<bool>(
-    context: context,
-    title: Text(l10n.shadowRecordingDeleteConfirmTitle),
-    content: Text(l10n.shadowRecordingDeleteConfirmMessage(takeSummary)),
-    actionsBuilder: (ctx) => [
-      TextButton(
-        onPressed: () => Navigator.of(ctx).pop(false),
-        child: Text(cancelLabel),
-      ),
-      FilledButton(
-        style: FilledButton.styleFrom(
-          foregroundColor: scheme.onError,
-          backgroundColor: scheme.error,
-        ),
-        onPressed: () => Navigator.of(ctx).pop(true),
-        child: Text(l10n.shadowRecordingDelete),
-      ),
-    ],
-  );
-  if (confirmed == true && context.mounted) {
-    onConfirmed();
-  }
-}
-
-class _TakesToolbarActions extends ConsumerWidget {
-  const _TakesToolbarActions({
-    required this.row,
-    required this.list,
-    required this.echoActive,
-    required this.scheme,
-    required this.tok,
-    required this.l10n,
-    required this.onPlayOrPause,
-    required this.onDeleteCurrent,
-    required this.onChooseTake,
-  });
-
-  final RecordingRow row;
-  final List<RecordingRow> list;
-  final bool echoActive;
-  final ColorScheme scheme;
-  final EnjoyThemeTokens tok;
-  final AppLocalizations l10n;
-  final VoidCallback onPlayOrPause;
-  final VoidCallback onDeleteCurrent;
-  final Future<void> Function(String id) onChooseTake;
-
-  int _takeNumber(RecordingRow r) {
-    final i = list.indexWhere((e) => e.id == r.id);
-    if (i < 0) return list.length;
-    return list.length - i;
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final preview = ref.watch(recordingPreviewPlayerProvider);
-    final lp = row.localPath;
-    final canPlay = echoActive && lp != null && lp.isNotEmpty;
-
-    final takeSummary =
-        '${l10n.shadowRecordingTake} ${_takeNumber(row)} · '
-        '${(row.duration / 1000).toStringAsFixed(1)} s';
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        lp != null && lp.isNotEmpty
-            ? StreamBuilder<bool>(
-                stream: preview.playing,
-                initialData: false,
-                builder: (context, playSnap) {
-                  final abs = File(lp).absolute.path;
-                  final playingThis =
-                      (playSnap.data ?? false) && preview.loadedPath == abs;
-                  return IconButton(
-                    style: IconButton.styleFrom(
-                      visualDensity: VisualDensity.compact,
-                      minimumSize: const Size(44, 44),
-                    ),
-                    tooltip: takeSummary,
-                    icon: Icon(
-                      playingThis
-                          ? Icons.pause_rounded
-                          : Icons.play_arrow_rounded,
-                    ),
-                    onPressed: canPlay ? onPlayOrPause : null,
-                  );
-                },
-              )
-            : IconButton(
-                style: IconButton.styleFrom(
-                  visualDensity: VisualDensity.compact,
-                  minimumSize: const Size(44, 44),
-                ),
-                tooltip: takeSummary,
-                icon: const Icon(Icons.play_arrow_rounded),
-                onPressed: null,
-              ),
-        RecordingAssessmentButton(row: row, echoActive: echoActive),
-        PopupMenuButton<String>(
-          tooltip: l10n.shadowRecordingChooseTake,
-          onSelected: (value) {
-            if (!echoActive) return;
-            if (value == _kDeleteTakeToken) {
-              unawaited(
-                _confirmDeleteCurrentTake(
-                  context: context,
-                  scheme: scheme,
-                  l10n: l10n,
-                  takeSummary: takeSummary,
-                  onConfirmed: onDeleteCurrent,
-                ),
-              );
-              return;
-            }
-            if (value == _kReassessTakeToken) {
-              unawaited(
-                triggerRecordingAssessment(
-                  context: context,
-                  ref: ref,
-                  l10n: l10n,
-                  row: row,
-                  forceRun: true,
-                ),
-              );
-              return;
-            }
-            unawaited(onChooseTake(value));
-          },
-          itemBuilder: (context) {
-            return [
-              for (var i = 0; i < list.length; i++)
-                PopupMenuItem<String>(
-                  value: list[i].id,
-                  child: Builder(
-                    builder: (ctx) {
-                      final r = list[i];
-                      final score = pronunciationScoreFromRecording(r);
-                      return Row(
-                        children: [
-                          SizedBox(
-                            width: 28,
-                            child: r.id == row.id
-                                ? Icon(
-                                    Icons.check,
-                                    size: 20,
-                                    color: scheme.primary,
-                                  )
-                                : const SizedBox.shrink(),
-                          ),
-                          Expanded(
-                            child: Text(
-                              '${l10n.shadowRecordingTake} ${list.length - i} · '
-                              '${(r.duration / 1000).toStringAsFixed(1)} s',
-                            ),
-                          ),
-                          if (score != null)
-                            Padding(
-                              padding: const EdgeInsets.only(left: 8),
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(
-                                  color: assessmentScoreBackground(
-                                    scheme,
-                                    assessmentScoreLevel(score),
-                                  ),
-                                  borderRadius: BorderRadius.circular(999),
-                                ),
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 8,
-                                    vertical: 2,
-                                  ),
-                                  child: Text(
-                                    '$score',
-                                    style: TextStyle(
-                                      fontSize: 12,
-                                      fontWeight: FontWeight.w700,
-                                      color: assessmentScoreColor(
-                                        scheme,
-                                        assessmentScoreLevel(score),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                        ],
-                      );
-                    },
-                  ),
-                ),
-              PopupMenuItem<String>(
-                value: _kReassessTakeToken,
-                enabled:
-                    echoActive &&
-                    row.assessmentJson != null &&
-                    row.assessmentJson!.trim().isNotEmpty,
-                child: Row(
-                  children: [
-                    SizedBox(
-                      width: 28,
-                      child: Icon(
-                        Icons.refresh_rounded,
-                        size: 20,
-                        color: scheme.primary,
-                      ),
-                    ),
-                    Expanded(child: Text(l10n.assessmentReassess)),
-                  ],
-                ),
-              ),
-              const PopupMenuDivider(),
-              PopupMenuItem<String>(
-                value: _kDeleteTakeToken,
-                enabled: echoActive,
-                child: Builder(
-                  builder: (ctx) {
-                    final baseStyle = DefaultTextStyle.of(ctx).style;
-                    final color = echoActive
-                        ? scheme.error
-                        : scheme.onSurface.withValues(alpha: 0.38);
-                    return Row(
-                      children: [
-                        SizedBox(
-                          width: 28,
-                          child: Icon(
-                            Icons.delete_outline_rounded,
-                            size: 20,
-                            color: color,
-                          ),
-                        ),
-                        Expanded(
-                          child: Text(
-                            l10n.shadowRecordingDelete,
-                            style: baseStyle.copyWith(color: color),
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                ),
-              ),
-            ];
-          },
-          child: Padding(
-            padding: EdgeInsets.all(tok.space4),
-            child: Icon(Icons.more_vert, color: scheme.onSurfaceVariant),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/shadow_reading/presentation/widgets/shadow_reading_toolbar_row.dart
+++ b/lib/features/shadow_reading/presentation/widgets/shadow_reading_toolbar_row.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+
+import 'shadow_record_fab.dart';
+
+/// Idle shadow-reading toolbar: pitch toggle (left) · record FAB (center) ·
+/// takes actions slot (right). The FAB is overlaid on a Row whose middle
+/// reserves [ShadowRecordFab.ringOuterHitSize] so pitch/takes hug the center
+/// without shifting the mic off true horizontal center.
+///
+/// Extracted from `shadow_reading_panel.dart` — see issue #180.
+class ShadowReadingToolbarRow extends StatelessWidget {
+  const ShadowReadingToolbarRow({
+    required this.tok,
+    required this.scheme,
+    required this.pitchExpanded,
+    required this.pitchTooltip,
+    required this.hasMediaPath,
+    required this.onPitchTap,
+    required this.takesActions,
+    required this.recordFab,
+    super.key,
+  });
+
+  final EnjoyThemeTokens tok;
+  final ColorScheme scheme;
+  final bool pitchExpanded;
+  final String pitchTooltip;
+  final bool hasMediaPath;
+  final VoidCallback onPitchTap;
+  final Widget? takesActions;
+  final Widget recordFab;
+
+  @override
+  Widget build(BuildContext context) {
+    final pitchIcon = Icon(
+      Icons.show_chart_rounded,
+      size: 22,
+      color: hasMediaPath
+          ? null
+          : scheme.onSurfaceVariant.withValues(alpha: 0.38),
+    );
+
+    final Widget pitchControl = Tooltip(
+      message: pitchTooltip,
+      child: hasMediaPath
+          ? pitchExpanded
+                ? IconButton.filledTonal(
+                    onPressed: onPitchTap,
+                    style: IconButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      minimumSize: const Size(44, 44),
+                    ),
+                    icon: pitchIcon,
+                  )
+                : IconButton(
+                    onPressed: onPitchTap,
+                    style: IconButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      minimumSize: const Size(44, 44),
+                    ),
+                    icon: pitchIcon,
+                  )
+          : IconButton(
+              onPressed: null,
+              style: IconButton.styleFrom(
+                visualDensity: VisualDensity.compact,
+                minimumSize: const Size(44, 44),
+              ),
+              icon: pitchIcon,
+            ),
+    );
+
+    // FAB stays at true horizontal center: overlay it on a Row whose middle
+    // reserves ring width so pitch/takes hug the center without shifting the
+    // mic.
+    return Stack(
+      alignment: Alignment.center,
+      clipBehavior: Clip.none,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Padding(
+                  padding: EdgeInsets.only(right: tok.space12),
+                  child: pitchControl,
+                ),
+              ),
+            ),
+            const SizedBox(width: ShadowRecordFab.ringOuterHitSize),
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Padding(
+                  padding: EdgeInsets.only(left: tok.space12),
+                  child: takesActions ?? const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ],
+        ),
+        recordFab,
+      ],
+    );
+  }
+}

--- a/lib/features/shadow_reading/presentation/widgets/shadow_record_fab.dart
+++ b/lib/features/shadow_reading/presentation/widgets/shadow_record_fab.dart
@@ -1,0 +1,160 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+
+/// Record FAB with a circular countdown ring + over-target pulse animation.
+///
+/// Extracted from `shadow_reading_panel.dart` — see issue #180.
+class ShadowRecordFab extends StatelessWidget {
+  const ShadowRecordFab({
+    required this.recording,
+    required this.echoActive,
+    required this.ringProgress,
+    required this.overTarget,
+    required this.overPulseHigh,
+    required this.showProgressArc,
+    required this.onTap,
+    required this.scheme,
+    required this.tok,
+    super.key,
+  });
+
+  /// Outer hit target / ring diameter; keep in sync with the toolbar slot in
+  /// [ShadowReadingToolbarRow].
+  static const double ringOuterHitSize = 68;
+  static const double _fabInner = 56;
+
+  final bool recording;
+  final bool echoActive;
+  final double ringProgress;
+  final bool overTarget;
+  final bool overPulseHigh;
+  final bool showProgressArc;
+  final VoidCallback onTap;
+  final ColorScheme scheme;
+  final EnjoyThemeTokens tok;
+
+  @override
+  Widget build(BuildContext context) {
+    final scale = overTarget ? (overPulseHigh ? 1.04 : 1.0) : 1.0;
+    final trackAlpha = showProgressArc ? 0.38 : 0.18;
+    final iconSize = _fabInner <= 56 ? 24.0 : 28.0;
+
+    return AnimatedScale(
+      scale: scale,
+      duration: const Duration(milliseconds: 280),
+      curve: Curves.easeOutCubic,
+      child: SizedBox(
+        width: ringOuterHitSize,
+        height: ringOuterHitSize,
+        child: Stack(
+          alignment: Alignment.center,
+          clipBehavior: Clip.none,
+          children: [
+            CustomPaint(
+              size: const Size(ringOuterHitSize, ringOuterHitSize),
+              painter: ShadowRecordRingPainter(
+                progress: ringProgress,
+                overTarget: overTarget,
+                trackColor: scheme.outlineVariant.withValues(alpha: trackAlpha),
+                fillColor: overTarget ? scheme.error : scheme.primary,
+                showProgressArc: showProgressArc,
+              ),
+            ),
+            Material(
+              color: Colors.transparent,
+              child: InkWell(
+                customBorder: const CircleBorder(),
+                onTap: echoActive ? onTap : null,
+                child: AnimatedContainer(
+                  duration: tok.motionFast,
+                  width: _fabInner,
+                  height: _fabInner,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: recording ? tok.echoActive : scheme.primary,
+                    boxShadow: [
+                      BoxShadow(
+                        color: (recording ? tok.echoActive : scheme.primary)
+                            .withValues(alpha: 0.35),
+                        blurRadius: recording ? 22 : 12,
+                        spreadRadius: recording ? 2 : 0,
+                        offset: const Offset(0, 4),
+                      ),
+                    ],
+                  ),
+                  child: Icon(
+                    recording ? Icons.stop_rounded : Icons.mic_rounded,
+                    color: recording ? Colors.white : scheme.onPrimary,
+                    size: iconSize,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Circular countdown progress ring + over-target full-arc indicator.
+class ShadowRecordRingPainter extends CustomPainter {
+  ShadowRecordRingPainter({
+    required this.progress,
+    required this.overTarget,
+    required this.trackColor,
+    required this.fillColor,
+    required this.showProgressArc,
+  });
+
+  final double progress;
+  final bool overTarget;
+  final Color trackColor;
+  final Color fillColor;
+  final bool showProgressArc;
+
+  static const double _strokeWidth = 4;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2 - _strokeWidth / 2;
+
+    final trackPaint = Paint()
+      ..color = trackColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawCircle(center, radius, trackPaint);
+
+    if (!showProgressArc) return;
+
+    final arcPaint = Paint()
+      ..color = fillColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    final rect = Rect.fromCircle(center: center, radius: radius);
+    if (overTarget) {
+      canvas.drawArc(rect, -math.pi / 2, 2 * math.pi, false, arcPaint);
+    } else {
+      final remaining = (1.0 - progress.clamp(0.0, 1.0));
+      final sweep = 2 * math.pi * remaining;
+      canvas.drawArc(rect, -math.pi / 2, sweep, false, arcPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant ShadowRecordRingPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.overTarget != overTarget ||
+        oldDelegate.trackColor != trackColor ||
+        oldDelegate.fillColor != fillColor ||
+        oldDelegate.showProgressArc != showProgressArc;
+  }
+}

--- a/lib/features/shadow_reading/presentation/widgets/shadow_recording_caption.dart
+++ b/lib/features/shadow_reading/presentation/widgets/shadow_recording_caption.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+
+String _formatSecsOneDecimal(double seconds) {
+  return seconds.toStringAsFixed(1);
+}
+
+/// Live recording caption `0.0 s / 1.2 s` (+ over-target error badge) with
+/// `Semantics`.
+///
+/// Extracted from `shadow_reading_panel.dart` — see issue #180.
+class ShadowRecordingCaptionRow extends StatelessWidget {
+  const ShadowRecordingCaptionRow({
+    required this.elapsedSec,
+    required this.targetSec,
+    required this.overTarget,
+    required this.overBySec,
+    required this.l10n,
+    required this.tt,
+    required this.scheme,
+    required this.tok,
+    super.key,
+  });
+
+  final double elapsedSec;
+  final double targetSec;
+  final bool overTarget;
+  final double overBySec;
+  final AppLocalizations l10n;
+  final TextTheme tt;
+  final ColorScheme scheme;
+  final EnjoyThemeTokens tok;
+
+  @override
+  Widget build(BuildContext context) {
+    if (targetSec > 0) {
+      return Semantics(
+        label:
+            '${_formatSecsOneDecimal(elapsedSec)} seconds elapsed of '
+            '${_formatSecsOneDecimal(targetSec)} seconds target',
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: tok.space8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '${_formatSecsOneDecimal(elapsedSec)} s / '
+                '${_formatSecsOneDecimal(targetSec)} s',
+                style: tt.labelMedium?.copyWith(
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+              if (overTarget) ...[
+                SizedBox(width: tok.space8),
+                Icon(Icons.circle, size: 8, color: scheme.error),
+                SizedBox(width: tok.space4),
+                Flexible(
+                  child: Text(
+                    l10n.shadowRecordingOverTarget(
+                      _formatSecsOneDecimal(overBySec),
+                    ),
+                    style: tt.labelSmall?.copyWith(color: scheme.error),
+                    maxLines: 2,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Center(
+      child: Text(
+        '${_formatSecsOneDecimal(elapsedSec)} s',
+        style: tt.labelMedium?.copyWith(
+          fontFeatures: const [FontFeature.tabularFigures()],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/shadow_reading/presentation/widgets/shadow_takes_toolbar_actions.dart
+++ b/lib/features/shadow_reading/presentation/widgets/shadow_takes_toolbar_actions.dart
@@ -1,0 +1,285 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:enjoy_player/core/audio/recording_preview_player_provider.dart';
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/features/shadow_reading/presentation/recording_assessment_button.dart';
+import 'package:enjoy_player/features/shadow_reading/presentation/recording_assessment_flow.dart';
+import 'package:enjoy_player/features/shadow_reading/presentation/score_level.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+
+/// `PopupMenuButton` value tokens for the takes menu — kept library-private.
+const kShadowDeleteTakeToken = '__shadow_delete_current_take__';
+const kShadowReassessTakeToken = '__shadow_reassess_current_take__';
+
+/// Shared alert-dialog helper confirming deletion of the current take.
+Future<void> confirmShadowDeleteTake({
+  required BuildContext context,
+  required ColorScheme scheme,
+  required AppLocalizations l10n,
+  required String takeSummary,
+  required VoidCallback onConfirmed,
+}) async {
+  if (!context.mounted) return;
+  final cancelLabel = MaterialLocalizations.of(context).cancelButtonLabel;
+  final confirmed = await showEnjoyAlertDialog<bool>(
+    context: context,
+    title: Text(l10n.shadowRecordingDeleteConfirmTitle),
+    content: Text(l10n.shadowRecordingDeleteConfirmMessage(takeSummary)),
+    actionsBuilder: (ctx) => [
+      TextButton(
+        onPressed: () => Navigator.of(ctx).pop(false),
+        child: Text(cancelLabel),
+      ),
+      FilledButton(
+        style: FilledButton.styleFrom(
+          foregroundColor: scheme.onError,
+          backgroundColor: scheme.error,
+        ),
+        onPressed: () => Navigator.of(ctx).pop(true),
+        child: Text(l10n.shadowRecordingDelete),
+      ),
+    ],
+  );
+  if (confirmed == true && context.mounted) {
+    onConfirmed();
+  }
+}
+
+/// Takes toolbar: play/pause + assess + popup menu (take list, reassess,
+/// delete). Extracted from `shadow_reading_panel.dart` — see issue #180.
+class ShadowTakesToolbarActions extends ConsumerWidget {
+  const ShadowTakesToolbarActions({
+    required this.row,
+    required this.list,
+    required this.echoActive,
+    required this.scheme,
+    required this.tok,
+    required this.l10n,
+    required this.onPlayOrPause,
+    required this.onDeleteCurrent,
+    required this.onChooseTake,
+    super.key,
+  });
+
+  final RecordingRow row;
+  final List<RecordingRow> list;
+  final bool echoActive;
+  final ColorScheme scheme;
+  final EnjoyThemeTokens tok;
+  final AppLocalizations l10n;
+  final VoidCallback onPlayOrPause;
+  final VoidCallback onDeleteCurrent;
+  final Future<void> Function(String id) onChooseTake;
+
+  int _takeNumber(RecordingRow r) {
+    final i = list.indexWhere((e) => e.id == r.id);
+    if (i < 0) return list.length;
+    return list.length - i;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final preview = ref.watch(recordingPreviewPlayerProvider);
+    final lp = row.localPath;
+    final canPlay = echoActive && lp != null && lp.isNotEmpty;
+
+    final takeSummary =
+        '${l10n.shadowRecordingTake} ${_takeNumber(row)} · '
+        '${(row.duration / 1000).toStringAsFixed(1)} s';
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        lp != null && lp.isNotEmpty
+            ? StreamBuilder<bool>(
+                stream: preview.playing,
+                initialData: false,
+                builder: (context, playSnap) {
+                  final abs = File(lp).absolute.path;
+                  final playingThis =
+                      (playSnap.data ?? false) && preview.loadedPath == abs;
+                  return IconButton(
+                    style: IconButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      minimumSize: const Size(44, 44),
+                    ),
+                    tooltip: takeSummary,
+                    icon: Icon(
+                      playingThis
+                          ? Icons.pause_rounded
+                          : Icons.play_arrow_rounded,
+                    ),
+                    onPressed: canPlay ? onPlayOrPause : null,
+                  );
+                },
+              )
+            : IconButton(
+                style: IconButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  minimumSize: const Size(44, 44),
+                ),
+                tooltip: takeSummary,
+                icon: const Icon(Icons.play_arrow_rounded),
+                onPressed: null,
+              ),
+        RecordingAssessmentButton(row: row, echoActive: echoActive),
+        PopupMenuButton<String>(
+          tooltip: l10n.shadowRecordingChooseTake,
+          onSelected: (value) {
+            if (!echoActive) return;
+            if (value == kShadowDeleteTakeToken) {
+              unawaited(
+                confirmShadowDeleteTake(
+                  context: context,
+                  scheme: scheme,
+                  l10n: l10n,
+                  takeSummary: takeSummary,
+                  onConfirmed: onDeleteCurrent,
+                ),
+              );
+              return;
+            }
+            if (value == kShadowReassessTakeToken) {
+              unawaited(
+                triggerRecordingAssessment(
+                  context: context,
+                  ref: ref,
+                  l10n: l10n,
+                  row: row,
+                  forceRun: true,
+                ),
+              );
+              return;
+            }
+            unawaited(onChooseTake(value));
+          },
+          itemBuilder: (context) {
+            return [
+              for (var i = 0; i < list.length; i++)
+                PopupMenuItem<String>(
+                  value: list[i].id,
+                  child: Builder(
+                    builder: (ctx) {
+                      final r = list[i];
+                      final score = pronunciationScoreFromRecording(r);
+                      return Row(
+                        children: [
+                          SizedBox(
+                            width: 28,
+                            child: r.id == row.id
+                                ? Icon(
+                                    Icons.check,
+                                    size: 20,
+                                    color: scheme.primary,
+                                  )
+                                : const SizedBox.shrink(),
+                          ),
+                          Expanded(
+                            child: Text(
+                              '${l10n.shadowRecordingTake} ${list.length - i} · '
+                              '${(r.duration / 1000).toStringAsFixed(1)} s',
+                            ),
+                          ),
+                          if (score != null)
+                            Padding(
+                              padding: const EdgeInsets.only(left: 8),
+                              child: DecoratedBox(
+                                decoration: BoxDecoration(
+                                  color: assessmentScoreBackground(
+                                    scheme,
+                                    assessmentScoreLevel(score),
+                                  ),
+                                  borderRadius: BorderRadius.circular(999),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 2,
+                                  ),
+                                  child: Text(
+                                    '$score',
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w700,
+                                      color: assessmentScoreColor(
+                                        scheme,
+                                        assessmentScoreLevel(score),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              PopupMenuItem<String>(
+                value: kShadowReassessTakeToken,
+                enabled:
+                    echoActive &&
+                    row.assessmentJson != null &&
+                    row.assessmentJson!.trim().isNotEmpty,
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 28,
+                      child: Icon(
+                        Icons.refresh_rounded,
+                        size: 20,
+                        color: scheme.primary,
+                      ),
+                    ),
+                    Expanded(child: Text(l10n.assessmentReassess)),
+                  ],
+                ),
+              ),
+              const PopupMenuDivider(),
+              PopupMenuItem<String>(
+                value: kShadowDeleteTakeToken,
+                enabled: echoActive,
+                child: Builder(
+                  builder: (ctx) {
+                    final baseStyle = DefaultTextStyle.of(ctx).style;
+                    final color = echoActive
+                        ? scheme.error
+                        : scheme.onSurface.withValues(alpha: 0.38);
+                    return Row(
+                      children: [
+                        SizedBox(
+                          width: 28,
+                          child: Icon(
+                            Icons.delete_outline_rounded,
+                            size: 20,
+                            color: color,
+                          ),
+                        ),
+                        Expanded(
+                          child: Text(
+                            l10n.shadowRecordingDelete,
+                            style: baseStyle.copyWith(color: color),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ];
+          },
+          child: Padding(
+            padding: EdgeInsets.all(tok.space4),
+            child: Icon(Icons.more_vert, color: scheme.onSurfaceVariant),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Resolves #180 (partial).

## Summary

`shadow_reading_panel.dart` had grown to **1372 lines**, mixing the recording-lifecycle `State` with four private widgets and a `CustomPainter`. This PR extracts the four self-contained UI pieces into `presentation/widgets/`, matching the layout already used by 8 other features (auth, hotkeys, library, player, settings, …). The shadow-reading feature was the only outlier without a `widgets/` subdir.

This is a **mechanical, behavior-preserving** move — only the leading `_` was dropped on the renamed classes. No logic changed. The public `ShadowReadingPanel` API is untouched (verified: the only external consumer is `transcript_echo_region_merged_card.dart`).

## New files

| File | Lines | Contents |
|---|---|---|
| `widgets/shadow_record_fab.dart` | 160 | `ShadowRecordFab` (was `_RecordFabWithRing`) + `ShadowRecordRingPainter` (was `_CountdownRingPainter`) |
| `widgets/shadow_reading_toolbar_row.dart` | 110 | `ShadowReadingToolbarRow` (was `_ShadowReadingToolbarRow`) |
| `widgets/shadow_recording_caption.dart` | 85 | `ShadowRecordingCaptionRow` (was `_RecordingCaptionRow`) |
| `widgets/shadow_takes_toolbar_actions.dart` | 285 | `ShadowTakesToolbarActions` (was `_TakesToolbarActions`) + `confirmShadowDeleteTake` + popup-menu value tokens |

The pure helper `_formatSecsOneDecimal` moved into `shadow_recording_caption.dart` (its only consumer). `_resolvedSelectedRow`, `_shortSaveError`, `_buildShadowRecordConfig`, `_log` stay in the panel — they belong to the recording state that remains.

**Panel: 1372 → 779 lines** (−43%).

## Why the controller extraction (split 1) is deferred

Issue #180 also proposed extracting a `ShadowReadingRecordingController` `Notifier` into `application/`. **I rejected that part as out of scope for this PR** because it would be a redesign, not a refactor:

- The recording state is bound to per-instance widget params (`mediaId`, `targetType`, `startSec`/`endSec`, `referenceText`, `echoActive`) that change via `didUpdateWidget`. A Riverpod `Notifier` has no natural home for these — it would need a family provider keyed by region or a hand-wired callback bridge.
- The methods call `setState`, `if (mounted)`, `AppNotice.error(context, …)`, `AppLocalizations.of(context)!`, `triggerRecordingAssessment(context: …)`, and own a `Ticker` via `createTicker` (which requires a `TickerProvider`). A standalone `Notifier` cannot own a `Ticker`, and rerouting all the `BuildContext`-dependent notices through an event channel changes the architecture.
- Recording is a user-visible hot path (mic permission, WAV persistence, hotkeys). Per the constitution, behavior changes here need new tests + perf evidence. Without a second consumer or a concrete testability requirement, the risk/reward isn't justified today.

Happy to revisit when a second consumer appears or isolated controller tests become a requirement.

## Acceptance criteria (vs. issue)

- [x] Four new widget files under `presentation/widgets/`, each ≤ 285 lines.
- [x] Public `ShadowReadingPanel` API unchanged.
- [x] All imports correct; `flutter analyze` + `flutter test` + `dart format --set-exit-if-changed` clean.
- [~] Panel reduced (1372 → 779), **not under 300** — controller intentionally retained; rationale above.
- [~] No `application/shadow_reading_recording_controller.dart` — split 1 rejected as out-of-scope redesign; rationale above.

## Verification

```
flutter analyze                                                      # No issues found
flutter test                                                         # All tests passed (731)
dart format --output=none --set-exit-if-changed lib/features/shadow_reading  # 0 changed
```

No codegen needed (no `@riverpod` / schema changes).