### PR TITLE
refactor(library,community): reuse formatPracticeDurationMs (#205)

### DIFF
--- a/lib/features/community/presentation/community_activity_card.dart
+++ b/lib/features/community/presentation/community_activity_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/utils/time_format.dart';
 import 'package:enjoy_player/features/community/application/active_users_provider.dart';
 import 'package:enjoy_player/features/community/domain/active_user.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
@@ -23,19 +24,6 @@ const int _kMaxAvatarsCard = 8;
 const int _kMaxAvatarsSummary = 4;
 const double _kSummaryAvatarSize = 28;
 const double _kSummaryAvatarOverlap = 8;
-
-String _formatDurationMs(int ms) {
-  final seconds = ms ~/ 1000;
-  final minutes = seconds ~/ 60;
-  final hours = minutes ~/ 60;
-  if (hours > 0) {
-    return '${hours}h ${minutes % 60}m';
-  }
-  if (minutes > 0) {
-    return '${minutes}m ${seconds % 60}s';
-  }
-  return '${seconds}s';
-}
 
 String _initials(String name) {
   if (name.trim().isEmpty) return 'U';
@@ -137,7 +125,7 @@ class CommunityActivityCard extends ConsumerWidget {
       }
       if (data.recordingsDurationToday != null) {
         parts.add(
-          '${_formatDurationMs(data.recordingsDurationToday!)} ${l10n.homePracticeTime}',
+          '${formatPracticeDurationMs(data.recordingsDurationToday!)} ${l10n.homePracticeTime}',
         );
       }
       return parts.join(', ');
@@ -286,7 +274,7 @@ class _SummaryBody extends StatelessWidget {
               if (data.recordingsDurationToday != null)
                 _InlineMetric(
                   icon: Icons.schedule,
-                  value: _formatDurationMs(data.recordingsDurationToday!),
+                  value: formatPracticeDurationMs(data.recordingsDurationToday!),
                   label: l10n.homePracticeTime,
                   cs: cs,
                   tabular: tabular,
@@ -697,7 +685,7 @@ class _TodayStatsBody extends StatelessWidget {
               Expanded(
                 child: _StatBlock(
                   icon: Icons.schedule,
-                  valueText: _formatDurationMs(data.recordingsDurationToday!),
+                  valueText: formatPracticeDurationMs(data.recordingsDurationToday!),
                   label: l10n.homePracticeTime,
                   compactValue: compactValues,
                 ),

--- a/lib/features/library/presentation/todays_goal_card.dart
+++ b/lib/features/library/presentation/todays_goal_card.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/utils/time_format.dart';
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/library/application/learning_statistics_provider.dart';
@@ -20,19 +21,6 @@ enum TodaysGoalCardVariant {
 
   /// Linear progress + compact copy (mobile insight strip).
   bar,
-}
-
-String _formatDurationMs(int ms) {
-  final seconds = ms ~/ 1000;
-  final minutes = seconds ~/ 60;
-  final hours = minutes ~/ 60;
-  if (hours > 0) {
-    return '${hours}h ${minutes % 60}m';
-  }
-  if (minutes > 0) {
-    return '${minutes}m ${seconds % 60}s';
-  }
-  return '${seconds}s';
 }
 
 int _completedMinutes(int recordingDurationMs) =>
@@ -302,7 +290,7 @@ class TodaysGoalCard extends ConsumerWidget {
         ),
         SizedBox(height: t.space4),
         Text(
-          '${recordingDurationMs > 0 ? _formatDurationMs(recordingDurationMs) : '0m'} ${l10n.homeCompleted}',
+          '${formatPracticeDurationMs(recordingDurationMs)} ${l10n.homeCompleted}',
           textAlign: TextAlign.center,
           style: Theme.of(
             context,
@@ -338,9 +326,7 @@ class TodaysGoalCard extends ConsumerWidget {
   ) {
     final frac = _progressFractionMs(recordingDurationMs, goalMinutes);
     final radius = BorderRadius.circular(t.radiusSm);
-    final durationText = recordingDurationMs > 0
-        ? _formatDurationMs(recordingDurationMs)
-        : '0m';
+    final durationText = formatPracticeDurationMs(recordingDurationMs);
     final tabular = const [FontFeature.tabularFigures()];
 
     return Column(


### PR DESCRIPTION
Replaces two private \_formatDurationMs\ helpers that duplicated the public \ormatPracticeDurationMs\ in \lib/core/utils/time_format.dart\ (issue #205, automated duplicate-code report).

## Changes

- \lib/features/library/presentation/todays_goal_card.dart\
  - Delete the file-local \_formatDurationMs\ (12 lines)
  - Import \ormatPracticeDurationMs\ from \package:enjoy_player/core/utils/time_format.dart\
  - Replace two call sites; drop the now-redundant \ecordingDurationMs > 0 ? … : '0m'\ guards (the canonical helper already maps \ms <= 0\ to \'0m'\)
- \lib/features/community/presentation/community_activity_card.dart\
  - Delete the file-local \_formatDurationMs\ (12 lines)
  - Import \ormatPracticeDurationMs\
  - Replace three call sites

## Verification

\\\
flutter analyze lib/features/library/presentation/todays_goal_card.dart \\
                  lib/features/community/presentation/community_activity_card.dart
# No issues found!

flutter test test/core/utils/time_format_test.dart test/widget_test.dart
# All tests passed!
\\\

## Why this matters

The detector flagged the duplicate at *high* severity because the private copy in \	odays_goal_card.dart\ was missing the \ms <= 0\ guard that the canonical version has — so \