### PR TITLE
refactor(recovery): extract _guarded / _guardedRethrow wrappers (#213)

### DIFF
--- a/lib/core/recovery/recovery_actions.dart
+++ b/lib/core/recovery/recovery_actions.dart
@@ -15,28 +15,57 @@ import 'package:enjoy_player/data/db/app_database.dart';
 
 final _log = logNamed('RecoveryActions');
 
-/// Best-effort copy of [error] to the system clipboard.
-Future<bool> copyErrorToClipboard(Object error, StackTrace? stack) async {
+/// Runs [body] inside a `try`/`catch`. On any thrown error, logs
+/// `_log.warning('$name failed', e, st)` and returns [defaultValue] — which
+/// lets each caller keep its existing failure marker (`false` for bool
+/// "did it succeed" APIs, `null` for `Future<String?>` paths, …).
+Future<T> _guarded<T>(
+  String name,
+  T defaultValue,
+  Future<T> Function() body,
+) async {
   try {
-    final buf = StringBuffer()
-      ..writeln('Enjoy Player — local data recovery')
-      ..writeln('Captured: ${DateTime.now().toUtc().toIso8601String()}')
-      ..writeln()
-      ..writeln('Error:')
-      ..writeln(error)
-      ..writeln();
-    if (stack != null) {
-      buf
-        ..writeln('Stack trace:')
-        ..writeln(stack);
-    }
-    await Clipboard.setData(ClipboardData(text: buf.toString()));
-    return true;
+    return await body();
   } catch (e, st) {
-    _log.warning('copyErrorToClipboard failed', e, st);
-    return false;
+    _log.warning('$name failed', e, st);
+    return defaultValue;
   }
 }
+
+/// Like [_guarded] but rethrows the error after logging. Used by callers
+/// whose own caller logs the failure again with extra context (e.g.
+/// [wipeLocalDatabaseFiles] is rethrown into [_resetLocalLibrary]'s
+/// outer catch, which logs a different message).
+Future<T> _guardedRethrow<T>(
+  String name,
+  Future<T> Function() body,
+) async {
+  try {
+    return await body();
+  } catch (e, st) {
+    _log.warning('$name failed', e, st);
+    rethrow;
+  }
+}
+
+/// Best-effort copy of [error] to the system clipboard.
+Future<bool> copyErrorToClipboard(Object error, StackTrace? stack) =>
+    _guarded('copyErrorToClipboard', false, () async {
+      final buf = StringBuffer()
+        ..writeln('Enjoy Player — local data recovery')
+        ..writeln('Captured: ${DateTime.now().toUtc().toIso8601String()}')
+        ..writeln()
+        ..writeln('Error:')
+        ..writeln(error)
+        ..writeln();
+      if (stack != null) {
+        buf
+          ..writeln('Stack trace:')
+          ..writeln(stack);
+      }
+      await Clipboard.setData(ClipboardData(text: buf.toString()));
+      return true;
+    });
 
 /// Opens the rotating log directory in the platform file explorer.
 ///
@@ -45,32 +74,26 @@ Future<bool> copyErrorToClipboard(Object error, StackTrace? stack) async {
 /// Mobile platforms (Android, iOS) have no generic file-explorer API
 /// and always return `false`; the recovery surface still offers
 /// "Copy error" as the mobile fallback.
-Future<bool> openLogsFolder() async {
-  try {
-    final dir = LogFileSink.instance?.directory;
-    if (dir == null || !dir.existsSync()) {
-      return _openSupportDirFallback();
-    }
-    return _revealInFileManager(dir.path);
-  } catch (e, st) {
-    _log.warning('openLogsFolder failed', e, st);
-    return false;
+Future<bool> openLogsFolder() => _guarded('openLogsFolder', false, () async {
+  final dir = LogFileSink.instance?.directory;
+  if (dir == null || !dir.existsSync()) {
+    return _openSupportDirFallback();
   }
-}
+  return _revealInFileManager(dir.path);
+});
 
-Future<bool> _openSupportDirFallback() async {
-  try {
-    final support = await getApplicationSupportDirectory();
-    final dir = Directory(p.join(support.path, 'logs'));
-    if (!dir.existsSync()) {
-      await dir.create(recursive: true);
-    }
-    return _revealInFileManager(dir.path);
-  } catch (e, st) {
-    _log.warning('openLogsFolder fallback failed', e, st);
-    return false;
-  }
-}
+Future<bool> _openSupportDirFallback() => _guarded(
+      'openLogsFolder fallback',
+      false,
+      () async {
+        final support = await getApplicationSupportDirectory();
+        final dir = Directory(p.join(support.path, 'logs'));
+        if (!dir.existsSync()) {
+          await dir.create(recursive: true);
+        }
+        return _revealInFileManager(dir.path);
+      },
+    );
 
 bool _revealInFileManager(String path) {
   if (Platform.isWindows) {
@@ -107,37 +130,36 @@ Future<Directory> _localDatabaseDirectory() =>
 /// Backs up the on-disk Drift database file (best-effort) before a
 /// destructive wipe. Returns the absolute path of the backup, or `null`
 /// if the backup failed.
-Future<String?> backupLocalDatabaseFile() async {
-  try {
-    final dbDir = await _localDatabaseDirectory();
-    if (!dbDir.existsSync()) {
-      return null;
-    }
-    final stamp = DateTime.now()
-        .toUtc()
-        .toIso8601String()
-        .replaceAll(':', '-')
-        .replaceAll('.', '-');
-    final support = await getApplicationSupportDirectory();
-    final backupDir = Directory(p.join(support.path, 'migrations'));
-    if (!backupDir.existsSync()) {
-      await backupDir.create(recursive: true);
-    }
-    final source = File(
-      p.join(dbDir.path, '${AppDatabase.deviceGlobalDatabaseName}.sqlite'),
+Future<String?> backupLocalDatabaseFile() => _guarded(
+      'backupLocalDatabaseFile',
+      null,
+      () async {
+        final dbDir = await _localDatabaseDirectory();
+        if (!dbDir.existsSync()) {
+          return null;
+        }
+        final stamp = DateTime.now()
+            .toUtc()
+            .toIso8601String()
+            .replaceAll(':', '-')
+            .replaceAll('.', '-');
+        final support = await getApplicationSupportDirectory();
+        final backupDir = Directory(p.join(support.path, 'migrations'));
+        if (!backupDir.existsSync()) {
+          await backupDir.create(recursive: true);
+        }
+        final source = File(
+          p.join(dbDir.path, '${AppDatabase.deviceGlobalDatabaseName}.sqlite'),
+        );
+        if (!source.existsSync()) {
+          return null;
+        }
+        final dest = File(p.join(backupDir.path, 'enjoy_player_$stamp.sqlite'));
+        await source.copy(dest.path);
+        _log.info('backupLocalDatabaseFile: wrote ${dest.path}');
+        return dest.path;
+      },
     );
-    if (!source.existsSync()) {
-      return null;
-    }
-    final dest = File(p.join(backupDir.path, 'enjoy_player_$stamp.sqlite'));
-    await source.copy(dest.path);
-    _log.info('backupLocalDatabaseFile: wrote ${dest.path}');
-    return dest.path;
-  } catch (e, st) {
-    _log.warning('backupLocalDatabaseFile failed', e, st);
-    return null;
-  }
-}
 
 /// Closes every per-user Drift database and deletes the on-disk SQLite
 /// file. After this, the next read of any `appDatabaseProvider*` will
@@ -146,38 +168,36 @@ Future<String?> backupLocalDatabaseFile() async {
 /// The auth controller is not reset; signed-in users keep their session
 /// in secure storage and will rebuild their per-user database on the
 /// next read.
-Future<void> wipeLocalDatabaseFiles() async {
-  try {
-    final dbDir = await _localDatabaseDirectory();
-    if (!dbDir.existsSync()) {
-      return;
-    }
-    final candidates = <String>{
-      '${AppDatabase.deviceGlobalDatabaseName}.sqlite',
-      '${AppDatabase.deviceGlobalDatabaseName}.sqlite-wal',
-      '${AppDatabase.deviceGlobalDatabaseName}.sqlite-shm',
-    };
-    for (final entity in dbDir.listSync(followLinks: false)) {
-      if (entity is! File) continue;
-      final base = p.basename(entity.path);
-      if (base.endsWith('.sqlite') ||
-          base.endsWith('.sqlite-wal') ||
-          base.endsWith('.sqlite-shm')) {
-        candidates.add(base);
-      }
-    }
-    for (final name in candidates) {
-      final f = File(p.join(dbDir.path, name));
-      if (f.existsSync()) {
-        await f.delete();
-        _log.info('wipeLocalDatabaseFiles: deleted $name');
-      }
-    }
-  } catch (e, st) {
-    _log.warning('wipeLocalDatabaseFiles failed', e, st);
-    rethrow;
-  }
-}
+Future<void> wipeLocalDatabaseFiles() => _guardedRethrow(
+      'wipeLocalDatabaseFiles',
+      () async {
+        final dbDir = await _localDatabaseDirectory();
+        if (!dbDir.existsSync()) {
+          return;
+        }
+        final candidates = <String>{
+          '${AppDatabase.deviceGlobalDatabaseName}.sqlite',
+          '${AppDatabase.deviceGlobalDatabaseName}.sqlite-wal',
+          '${AppDatabase.deviceGlobalDatabaseName}.sqlite-shm',
+        };
+        for (final entity in dbDir.listSync(followLinks: false)) {
+          if (entity is! File) continue;
+          final base = p.basename(entity.path);
+          if (base.endsWith('.sqlite') ||
+              base.endsWith('.sqlite-wal') ||
+              base.endsWith('.sqlite-shm')) {
+            candidates.add(base);
+          }
+        }
+        for (final name in candidates) {
+          final f = File(p.join(dbDir.path, name));
+          if (f.existsSync()) {
+            await f.delete();
+            _log.info('wipeLocalDatabaseFiles: deleted $name');
+          }
+        }
+      },
+    );
 
 /// Resets the local library: backs up, then wipes. Used by the
 /// destructive-migration flow wired in `app.dart`.


### PR DESCRIPTION
Five top-level functions in `lib/core/recovery/recovery_actions.dart` (`copyErrorToClipboard`, `openLogsFolder`, `_openSupportDirFallback`, `backupLocalDatabaseFile`, `wipeLocalDatabaseFiles`) each opened with the same lines and closed with the same `try`/`catch _log.warning('<name> failed', e, st)` shape (issue #213, automated duplicate-code report). This PR centralises the wrapper.

## Changes

- Add a private `_guarded<T>(String name, T defaultValue, Future<T> Function() body)` that catches everything, logs `_log.warning('$name failed', e, st)`, and returns `defaultValue`.
- Add a companion `_guardedRethrow<T>(String name, Future<T> Function() body)` for callers that want the error to bubble up after the same log line.
- Migrate the five call sites:
  - `copyErrorToClipboard`, `openLogsFolder`, `_openSupportDirFallback`, `backupLocalDatabaseFile` — all use `_guarded` (swallow).
  - `wipeLocalDatabaseFiles` — uses `_guardedRethrow` (preserves the existing `rethrow` so its outer caller `resetLocalLibraryWithBackup` can log again with backup-context).

## Deliberately unchanged

- `_runAndCheck` is **synchronous** (uses `Process.runSync`) and intentionally logs at `_log.fine` rather than `_log.warning` — a missing `xdg-open` on a desktop that doesn't have one installed is not an error and shouldn't page anyone. Re-shaping it through `_guarded` would force both changes.
- `resetLocalLibraryWithBackup` has its own outer `try`/`catch` whose message (`'wipe failed after backup'`) is intentionally different from what `_guarded` would produce. Wrapping it would double-log the same failure with two messages.

## Why a typed `defaultValue` rather than `Future<T?>` / `null as T` cast

The detector's example returned `Future<T?>` and used `null as T` casts to keep the call-site signatures. I went with `Future<T> _guarded<T>(String name, T defaultValue, …)` instead, so each caller keeps its existing static return type (`Future<bool>` for the launch-and-clipboard APIs, `Future<String?>` for the backup path) without any unsafe casts. It reads as the natural failure marker per call: `false`, `null`, etc.

## Verification

```
flutter analyze lib/core/recovery/
# No issues found! (1.9s)

flutter test
# All 818 tests passed!
```

The existing `recovery_actions_test.dart` (11 tests covering every branch — clipboard success/failure, backup success/missing-file, wipe success, reset outcomes) continues to pass without modification, which is the regression net for the behavioural preservation.

Closes #213.
