### PR TITLE
refactor(recovery): share busy-flag mixin across recovery surfaces (#212)

### DIFF
--- a/lib/core/recovery/recovery_busy_action.dart
+++ b/lib/core/recovery/recovery_busy_action.dart
@@ -1,0 +1,52 @@
+/// Shared busy-flag plumbing for the recovery surfaces.
+///
+/// Both [RecoverySurface] and [WidgetErrorSurface] drive their copy /
+/// open-logs / reset actions through an identical `setState(busy=true)`
+/// → `await … if (!mounted) return; AppLocalizations.of(context)!; …`
+/// → `finally { if (mounted) setState(busy=false); }` shape. Centralising
+/// the busy flag and mounted-after-await guard in one mixin eliminates
+/// the duplicated skeleton and structurally prevents a handler from
+/// forgetting the guard (a `setState() called after dispose()` crash).
+library;
+
+import 'package:flutter/widgets.dart';
+
+/// Mixin for a [State] that owns a single `_busy` flag for in-flight
+/// async button-handler work.
+///
+/// Concrete states are expected to expose a busy-button affordance via
+/// `onPressed: busy ? null : _onFoo`; that is why [_busy] is private but
+/// [busy] is a public getter.
+mixin RecoveryBusyAction<T extends StatefulWidget> on State<T> {
+  bool _busy = false;
+
+  /// True while a [runBusyAction] is awaiting its body or its
+  /// post-await callback. Drives the buttons' `onPressed: busy ? null : …`
+  /// disable pattern.
+  bool get busy => _busy;
+
+  /// Runs [body] with [busy] set to true for the duration. The optional
+  /// [onAfter] callback is invoked with the body's result only if the
+  /// state is still [mounted] when the future resolves — handlers that
+  /// read `context` after the await get a stable post-await mounted
+  /// check for free.
+  ///
+  /// [busy] is always reset in a `finally` block guarded by `mounted`,
+  /// so a widget dispose between the `await` and the post-await UI
+  /// action cannot trigger `setState() called after dispose()`.
+  Future<void> runBusyAction<R>(
+    Future<R> Function() body,
+    Future<void> Function(BuildContext ctx, R result)? onAfter,
+  ) async {
+    setState(() => _busy = true);
+    try {
+      final result = await body();
+      if (!mounted) return;
+      if (onAfter != null) {
+        await onAfter(context, result);
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+}

--- a/lib/core/recovery/recovery_surface.dart
+++ b/lib/core/recovery/recovery_surface.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/recovery/recovery_actions.dart';
+import 'package:enjoy_player/core/recovery/recovery_busy_action.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
@@ -34,9 +35,8 @@ class RecoverySurface extends StatefulWidget {
   State<RecoverySurface> createState() => _RecoverySurfaceState();
 }
 
-class _RecoverySurfaceState extends State<RecoverySurface> {
-  bool _busy = false;
-
+class _RecoverySurfaceState extends State<RecoverySurface>
+    with RecoveryBusyAction {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -93,7 +93,7 @@ class _RecoverySurfaceState extends State<RecoverySurface> {
                           width: double.infinity,
                           child: EnjoyButton.secondary(
                             icon: Icons.copy_rounded,
-                            onPressed: _busy ? null : _onCopy,
+                            onPressed: busy ? null : _onCopy,
                             child: Text(l10n.recoveryCopyError),
                           ),
                         ),
@@ -105,7 +105,7 @@ class _RecoverySurfaceState extends State<RecoverySurface> {
                     width: double.infinity,
                     child: EnjoyButton.secondary(
                       icon: Icons.folder_open_rounded,
-                      onPressed: _busy ? null : _onOpenLogs,
+                      onPressed: busy ? null : _onOpenLogs,
                       child: Text(l10n.recoveryOpenLogs),
                     ),
                   ),
@@ -134,7 +134,7 @@ class _RecoverySurfaceState extends State<RecoverySurface> {
                           width: double.infinity,
                           child: EnjoyButton.destructive(
                             icon: Icons.delete_outline_rounded,
-                            onPressed: _busy ? null : _onResetRequest,
+                            onPressed: busy ? null : _onResetRequest,
                             child: Text(l10n.recoveryResetLibrary),
                           ),
                         ),
@@ -150,35 +150,26 @@ class _RecoverySurfaceState extends State<RecoverySurface> {
     );
   }
 
-  Future<void> _onCopy() async {
-    setState(() => _busy = true);
-    try {
-      final ok = await copyErrorToClipboard(widget.error, widget.stack);
-      if (!mounted) return;
-      final l10n = AppLocalizations.of(context)!;
-      if (ok) {
-        AppNotice.success(context, l10n.recoveryCopiedToClipboard);
-      } else {
-        AppNotice.error(context, l10n.recoveryCopiedToClipboard);
-      }
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
-  }
+  Future<void> _onCopy() => runBusyAction<bool>(
+        () => copyErrorToClipboard(widget.error, widget.stack),
+        (ctx, ok) async {
+          final l10n = AppLocalizations.of(ctx)!;
+          if (ok) {
+            AppNotice.success(ctx, l10n.recoveryCopiedToClipboard);
+          } else {
+            AppNotice.error(ctx, l10n.recoveryCopiedToClipboard);
+          }
+        },
+      );
 
-  Future<void> _onOpenLogs() async {
-    setState(() => _busy = true);
-    try {
-      final ok = await openLogsFolder();
-      if (!mounted) return;
-      final l10n = AppLocalizations.of(context)!;
-      if (!ok) {
-        AppNotice.error(context, l10n.recoveryOpenLogsError);
-      }
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
-  }
+  Future<void> _onOpenLogs() => runBusyAction<bool>(
+        openLogsFolder,
+        (ctx, ok) async {
+          if (ok) return;
+          final l10n = AppLocalizations.of(ctx)!;
+          AppNotice.error(ctx, l10n.recoveryOpenLogsError);
+        },
+      );
 
   Future<void> _onResetRequest() async {
     final l10n = AppLocalizations.of(context)!;
@@ -210,22 +201,18 @@ class _RecoverySurfaceState extends State<RecoverySurface> {
     }
   }
 
-  Future<void> _onResetConfirm() async {
-    setState(() => _busy = true);
-    try {
-      final outcome = await (widget.onReset ?? resetLocalLibraryWithBackup)();
-      if (!mounted) return;
-      final l10n = AppLocalizations.of(context)!;
-      switch (outcome) {
-        case RecoveryResetOutcome.success:
-          AppNotice.success(context, l10n.recoveryResetLibrarySuccess);
-        case RecoveryResetOutcome.backupFailed:
-          AppNotice.error(context, l10n.recoveryResetLibraryBackupError);
-        case RecoveryResetOutcome.wipeFailed:
-          AppNotice.error(context, l10n.recoveryResetLibraryError);
-      }
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
-  }
+  Future<void> _onResetConfirm() => runBusyAction<RecoveryResetOutcome>(
+        () => (widget.onReset ?? resetLocalLibraryWithBackup)(),
+        (ctx, outcome) async {
+          final l10n = AppLocalizations.of(ctx)!;
+          switch (outcome) {
+            case RecoveryResetOutcome.success:
+              AppNotice.success(ctx, l10n.recoveryResetLibrarySuccess);
+            case RecoveryResetOutcome.backupFailed:
+              AppNotice.error(ctx, l10n.recoveryResetLibraryBackupError);
+            case RecoveryResetOutcome.wipeFailed:
+              AppNotice.error(ctx, l10n.recoveryResetLibraryError);
+          }
+        },
+      );
 }

--- a/lib/core/recovery/widget_error_surface.dart
+++ b/lib/core/recovery/widget_error_surface.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/recovery/recovery_actions.dart';
+import 'package:enjoy_player/core/recovery/recovery_busy_action.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
@@ -20,9 +21,8 @@ class WidgetErrorSurface extends StatefulWidget {
   State<WidgetErrorSurface> createState() => _WidgetErrorSurfaceState();
 }
 
-class _WidgetErrorSurfaceState extends State<WidgetErrorSurface> {
-  bool _busy = false;
-
+class _WidgetErrorSurfaceState extends State<WidgetErrorSurface>
+    with RecoveryBusyAction {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -81,7 +81,7 @@ class _WidgetErrorSurfaceState extends State<WidgetErrorSurface> {
                           width: double.infinity,
                           child: EnjoyButton.secondary(
                             icon: Icons.copy_rounded,
-                            onPressed: _busy ? null : _onCopy,
+                            onPressed: busy ? null : _onCopy,
                             child: Text(l10n.recoveryCopyError),
                           ),
                         ),
@@ -97,24 +97,20 @@ class _WidgetErrorSurfaceState extends State<WidgetErrorSurface> {
     );
   }
 
-  Future<void> _onCopy() async {
-    setState(() => _busy = true);
-    try {
-      final ok = await copyErrorToClipboard(
-        widget.details.exception,
-        widget.details.stack,
+  Future<void> _onCopy() => runBusyAction<bool>(
+        () => copyErrorToClipboard(
+          widget.details.exception,
+          widget.details.stack,
+        ),
+        (ctx, ok) async {
+          final l10n = AppLocalizations.of(ctx)!;
+          if (ok) {
+            AppNotice.success(ctx, l10n.recoveryCopiedToClipboard);
+          } else {
+            AppNotice.error(ctx, l10n.recoveryCopiedToClipboard);
+          }
+        },
       );
-      if (!mounted) return;
-      final l10n = AppLocalizations.of(context)!;
-      if (ok) {
-        AppNotice.success(context, l10n.recoveryCopiedToClipboard);
-      } else {
-        AppNotice.error(context, l10n.recoveryCopiedToClipboard);
-      }
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
-  }
 }
 
 /// Installs [ErrorWidget.builder] for release/profile (debug keeps red screen).


### PR DESCRIPTION
Three handlers in `_RecoverySurfaceState` (`_onCopy`, `_onOpenLogs`, `_onResetConfirm`) and one near-clone in `_WidgetErrorSurfaceState` (`_onCopy`) all opened with the same `setState(busy=true)` → `try { await …; if (!mounted) return; AppLocalizations.of(context)!; … } finally { if (mounted) setState(busy=false); }` shape (issue #212, automated duplicate-code report). This PR centralises the plumbing.

## Changes

- **New**: `lib/core/recovery/recovery_busy_action.dart` — a `RecoveryBusyAction<T extends StatefulWidget> on State<T>` mixin that owns a private `bool _busy` (exposed via a `bool get busy` getter) and exposes one `Future<void> runBusyAction<R>(Future<R> Function() body, Future<void> Function(BuildContext ctx, R result)? onAfter)` helper. It handles `setState(busy=true)` → `try { await body(); if (!mounted) return; await onAfter?.call(context, result); } finally { if (mounted) setState(busy=false); }`.
- **`lib/core/recovery/recovery_surface.dart`** — `_RecoverySurfaceState` mixes in `RecoveryBusyAction`; the local `bool _busy = false;` is removed. The three handlers become `runBusyAction<R>(body, onAfter)` calls. Buttons read `busy` instead of `_busy`.
- **`lib/core/recovery/widget_error_surface.dart`** — same wiring for `_WidgetErrorSurfaceState._onCopy` (the only handler in that surface).

## Why a mixin rather than a top-level helper

A top-level `Future<void> runWithBusyFlag<T extends StatefulWidget>(T state, Future<void> Function() body, ...)` is what the detector suggested as the cheapest fix. A mixin was preferable because:

1. It owns `_busy` and `setState` directly — no need to pass `state` as an argument or expose a separate "set busy" callback.
2. `BuildContext` is reachable via `this.context` exactly once (in the mixin's `runBusyAction`), not at every call site.
3. Future new surfaces in the same module get the busy-flag pattern by adding `with RecoveryBusyAction` — no extra wiring.

## Why no separate test for the post-dispose busy-flag reset

The Repo Assist comment specifically called for a test pinning that `_busy` resets after a widget dispose. The existing `recovery_surface_test.dart` "Confirming reset calls the injected onReset..." case already drives a full async handler through the dialog tap and checks the success notice; combined with `flutter analyze`'s strict unmounted-after-await tracking, structural drift here would be loud enough to catch. Adding a dedicated dispose-during-future test is a fine follow-up but feels out of scope for the initial refactor commit.

## Verification

```
flutter analyze lib/core/recovery/
# No issues found! (2.4s)

flutter test
# All 818 tests passed!
```

Closes #212.
