### PR TITLE
refactor(app): extract _baseMaterialApp factory + loading-branch regression test (#211)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -91,29 +91,88 @@ class _EnjoyAppState extends ConsumerState<EnjoyApp> {
     GlobalCupertinoLocalizations.delegate,
   ];
 
-  MaterialApp _loadingMaterialApp(ThemeData theme) {
+  /// Centralized MaterialApp/MaterialApp.router construction for every
+  /// branch of [build].
+  ///
+  /// The loading, error, and router branches all configure the same
+  /// fallback localization delegates, supported locales, scaffold
+  /// messenger key, and theme; only `home` (loading/error) vs
+  /// `routerConfig + locale` (router) differs. Routing all three through
+  /// this single factory makes the missing-delegates bug fixed in 8f7d301
+  /// [RecoverySurface] crashing on `AppLocalizations.of(context)` in the
+  /// loading/error fallbacks structurally impossible to reintroduce.
+  ///
+  /// Pass `router: null` to build a plain `MaterialApp` with [home];
+  /// pass a [GoRouter] to build a `MaterialApp.router` with the supplied
+  /// [prefs] as the locale source.
+  Widget _baseMaterialApp({
+    required ThemeData theme,
+    required Widget home,
+    GoRouter? router,
+    AppPreferencesState? prefs,
+  }) {
+    if (router != null) {
+      return MaterialApp.router(
+        scaffoldMessengerKey: appScaffoldMessengerKey,
+        onGenerateTitle: (ctx) => AppLocalizations.of(ctx)!.appTitle,
+        theme: theme,
+        locale: prefs?.locale,
+        localizationsDelegates: _fallbackLocalizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: router,
+        builder: _shellBuilder,
+      );
+    }
     return MaterialApp(
       scaffoldMessengerKey: appScaffoldMessengerKey,
       theme: theme,
       localizationsDelegates: _fallbackLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
+      home: home,
+    );
+  }
+
+  /// Wraps the router-configured app in its system-chrome overlay,
+  /// deep-link listener, update prompt, and (on desktop) hotkey listener.
+  /// Only the router variant needs a `builder`; the loading + error
+  /// fallbacks render their `home` directly.
+  Widget _shellBuilder(BuildContext context, Widget? child) {
+    const overlayStyle = SystemUiOverlayStyle(
+      statusBarColor: Colors.transparent,
+      statusBarIconBrightness: Brightness.light,
+      systemNavigationBarColor: Color(0xFF09090B),
+      systemNavigationBarIconBrightness: Brightness.light,
+      systemNavigationBarContrastEnforced: false,
+    );
+    final viewport = ConstrainedAppViewport(
+      child: AnnotatedRegion<SystemUiOverlayStyle>(
+        value: overlayStyle,
+        child: child ?? const SizedBox.shrink(),
+      ),
+    );
+    final hosted = AuthDeepLinkListener(
+      child: UpdatePromptHost(child: viewport),
+    );
+    return isDesktop ? AppHotkeysKeyboardListener(child: hosted) : hosted;
+  }
+
+  Widget _loadingBranch(ThemeData theme) {
+    return _baseMaterialApp(
+      theme: theme,
       home: const ConstrainedAppViewport(
         child: Scaffold(body: Center(child: SkeletonAppBootstrap())),
       ),
     );
   }
 
-  MaterialApp _errorMaterialApp(
+  Widget _errorBranch(
     ThemeData theme,
     Object error,
     StackTrace? stack,
   ) {
     final isDb = isUnrecoverableDatabaseError(error);
-    return MaterialApp(
-      scaffoldMessengerKey: appScaffoldMessengerKey,
+    return _baseMaterialApp(
       theme: theme,
-      localizationsDelegates: _fallbackLocalizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
       home: isDb
           ? RecoverySurface(
               error: error,
@@ -129,38 +188,16 @@ class _EnjoyAppState extends ConsumerState<EnjoyApp> {
     );
   }
 
-  Widget _routerApp({
+  Widget _routerBranch({
     required GoRouter router,
     required ThemeData theme,
     required AppPreferencesState prefs,
   }) {
-    return MaterialApp.router(
-      scaffoldMessengerKey: appScaffoldMessengerKey,
-      onGenerateTitle: (ctx) => AppLocalizations.of(ctx)!.appTitle,
+    return _baseMaterialApp(
       theme: theme,
-      locale: prefs.locale,
-      localizationsDelegates: _fallbackLocalizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      routerConfig: router,
-      builder: (context, child) {
-        const overlayStyle = SystemUiOverlayStyle(
-          statusBarColor: Colors.transparent,
-          statusBarIconBrightness: Brightness.light,
-          systemNavigationBarColor: Color(0xFF09090B),
-          systemNavigationBarIconBrightness: Brightness.light,
-          systemNavigationBarContrastEnforced: false,
-        );
-        final viewport = ConstrainedAppViewport(
-          child: AnnotatedRegion<SystemUiOverlayStyle>(
-            value: overlayStyle,
-            child: child ?? const SizedBox.shrink(),
-          ),
-        );
-        final hosted = AuthDeepLinkListener(
-          child: UpdatePromptHost(child: viewport),
-        );
-        return isDesktop ? AppHotkeysKeyboardListener(child: hosted) : hosted;
-      },
+      home: const SizedBox.shrink(),
+      router: router,
+      prefs: prefs,
     );
   }
 
@@ -186,14 +223,14 @@ class _EnjoyAppState extends ConsumerState<EnjoyApp> {
     final effective = live ?? _lastResolvedPrefs;
 
     if (prefsAsync.hasError && effective == null) {
-      return _errorMaterialApp(theme, prefsAsync.error!, prefsAsync.stackTrace);
+      return _errorBranch(theme, prefsAsync.error!, prefsAsync.stackTrace);
     }
 
     if (prefsAsync.isLoading && effective == null) {
-      return _loadingMaterialApp(theme);
+      return _loadingBranch(theme);
     }
 
-    return _routerApp(
+    return _routerBranch(
       router: router,
       theme: theme,
       prefs: effective ?? AppPreferencesState.initial,

--- a/test/app_loading_branch_test.dart
+++ b/test/app_loading_branch_test.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:enjoy_player/app.dart';
+import 'package:enjoy_player/core/application/app_preferences_provider.dart';
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/auth/application/auth_controller.dart';
+import 'package:enjoy_player/features/auth/domain/auth_state.dart';
+import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
+import 'package:enjoy_player/features/update/application/update_controller.dart';
+import 'package:enjoy_player/features/update/domain/update_types.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'support/fake_player_engine.dart';
+import 'support/test_path_provider.dart';
+
+ThemeData _testTheme() {
+  final scheme = ColorScheme.fromSeed(
+    seedColor: const Color(0xFF7B61FF),
+    brightness: Brightness.dark,
+  );
+  return ThemeData(
+    colorScheme: scheme,
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    extensions: [EnjoyThemeTokens.build(scheme)],
+  );
+}
+
+class _SignedOutAuthCtrl extends AuthCtrl {
+  @override
+  Future<AuthState> build() async => const AuthSignedOut();
+}
+
+/// Builds successfully but the returned [Future] never resolves, so
+/// `appPreferencesCtrlProvider` stays in `AsyncLoading` for the whole
+/// test — exactly what the loading branch of [EnjoyApp] is supposed to
+/// handle.
+class _NeverCompletingPrefsCtrl extends AppPreferencesCtrl {
+  @override
+  Future<AppPreferencesState> build() async {
+    return Completer<AppPreferencesState>().future;
+  }
+}
+
+class _NoopUpdateCtrl extends UpdateCtrl {
+  @override
+  UpdateCheckResult? build() => null;
+
+  @override
+  Future<void> bootstrap() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'EnjoyApp loading branch renders the skeleton with a localized context '
+    'instead of crashing on a missing AppLocalizations delegate',
+    (tester) async {
+      // Regression coverage: the loading branch of [_EnjoyAppState]
+      // (formerly `_loadingMaterialApp`, now `_loadingBranch`) used to
+      // omit `localizationsDelegates`, so any widget further down the
+      // tree that did `AppLocalizations.of(context)!` would null-check
+      // crash before the first frame ever painted. The bug surfaced in
+      // production as a blank/white screen during cold start while
+      // preferences were still resolving; the fix in 8f7d301 introduced
+      // `_fallbackLocalizationsDelegates` so the loading branch shares the
+      // delegate bundle with the router branch.
+      //
+      // This test pins that the structural fix has not regressed. The
+      // companion error-branch coverage lives in `app_recovery_flow_test`.
+      FlutterSecureStorage.setMockInitialValues({});
+      PackageInfo.setMockInitialValues(
+        appName: 'Enjoy Player',
+        packageName: 'com.enjoy.player.test',
+        version: '0.3.1',
+        buildNumber: '2',
+        buildSignature: 'test',
+      );
+
+      final root = Directory.systemTemp.createTempSync(
+        'enjoy_app_loading_branch',
+      );
+      PathProviderPlatform.instance = TestPathProvider(root.path);
+
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      final fakeEngine = FakePlayerEngine();
+
+      tester.view.physicalSize = const Size(1200, 1800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            deviceGlobalAppDatabaseProvider.overrideWithValue(db),
+            appDatabaseProvider.overrideWithValue(db),
+            authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new),
+            appPreferencesCtrlProvider.overrideWith(
+              _NeverCompletingPrefsCtrl.new,
+            ),
+            updateCtrlProvider.overrideWith(_NoopUpdateCtrl.new),
+            playerEngineTestDoubleProvider.overrideWithValue(fakeEngine),
+          ],
+          child: const EnjoyApp(themeBuilder: _testTheme),
+        ),
+      );
+
+      // Pump for a few frames; the AsyncValue stays loading forever, so
+      // the test isn't pumping for completion. The point is that no
+      // exception ever reaches the test framework and the MaterialApp +
+      // localizations context render.
+      for (var i = 0; i < 4; i++) {
+        await tester.pump();
+      }
+
+      expect(find.byType(MaterialApp), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await fakeEngine.dispose();
+      await db.close();
+      if (root.existsSync()) root.deleteSync(recursive: true);
+    },
+  );
+}


### PR DESCRIPTION
The loading, error, and router branches of `_EnjoyAppState.build()` all configure the same `localizationsDelegates`, `supportedLocales`, `scaffoldMessengerKey`, and `theme` arguments on a `MaterialApp` (issue #211, automated duplicate-code report). This PR routes all three through a single `_baseMaterialApp()` helper.

## Changes

### `lib/app.dart`

- New `Widget _baseMaterialApp({required ThemeData theme, required Widget home, GoRouter? router, AppPreferencesState? prefs})` on `_EnjoyAppState`:
  - When `router != null`, returns `MaterialApp.router` with the shared delegates, theme, messenger key, and `prefs?.locale`, plus a `builder: _shellBuilder`.
  - When `router == null`, returns a plain `MaterialApp` with the same delegates/theme/messenger key and the supplied `home`.
- New `Widget _shellBuilder(BuildContext, Widget?)` extracted from the inline lambda in the old `_routerApp` — it owns only the system-chrome `AnnotatedRegion`, `AuthDeepLinkListener`, `UpdatePromptHost`, and `AppHotkeysKeyboardListener` chain, all of which are router-only.
- The three old per-branch constructors (`_loadingMaterialApp`, `_errorMaterialApp`, `_routerApp`) become three small branch helpers (`_loadingBranch`, `_errorBranch`, `_routerBranch`) that each just decide their `home` / `routerConfig` and delegate to `_baseMaterialApp`.

### `test/app_loading_branch_test.dart` (new)

A regression test that drives the loading branch by overriding `appPreferencesCtrlProvider` with a `_NeverCompletingPrefsCtrl` whose `build()` returns a `Future` that never resolves. It pumps four frames, then asserts `find.byType(MaterialApp)` finds one widget and `tester.takeException()` is null.

This pins the very bug that motivated `_fallbackLocalizationsDelegates` (commit 8f7d301) — the loading + error branches used to forget `localizationsDelegates`, and `AppLocalizations.of(context)!` inside `RecoverySurface` null-check crashed before the first frame ever painted. The companion error-branch coverage already lives in `app_recovery_flow_test.dart`; this new file closes the loading branch gap.

## Why this matters

Before this change, any future contributor adding a fifth locale-related delegate (or any other shared config) to one branch could miss the other two. After this change, all three configurations live behind one factory signature — the same kind of "delegates bundle update in N places" hazard that originally motivated `_fallbackLocalizationsDelegates` is now eliminated at the call-site level instead of patched up at the constant level.

## Verification

```
flutter analyze lib/app.dart test/app_loading_branch_test.dart
# No issues found!

flutter test
# All 819 tests passed!  (818 before this PR + the new loading-branch test)
```

Closes #211.
