### PR TITLE
refactor(ai): extract guardAiCall helper for 7 service wrappers (#203)

### DIFF
--- a/lib/features/ai/application/ai_api_failures.dart
+++ b/lib/features/ai/application/ai_api_failures.dart
@@ -10,3 +10,23 @@ AppFailure mapApiExceptionToAppFailure(ApiException e) {
   }
   return NetworkFailure(e.message, statusCode: e.statusCode);
 }
+
+/// Runs [op] and translates any [ApiException] thrown by the underlying
+/// REST client into the user-facing [AppFailure] hierarchy used by the
+/// AI presentation layer.
+///
+/// Centralising the catch means any future cross-cutting change
+/// (mapping new `ApiException` subclasses, adding telemetry,
+/// propagating context-specific failure codes) happens in one place for
+/// every AI capability (`AsrService.transcribe`, `ChatService.complete`,
+/// `TranslationService.translate`, `ContextualTranslationService.translate`,
+/// `DictionaryService.lookup`, `TtsService.synthesize`, and
+/// `AssessmentService.assess`) instead of in N near-identical try/catch
+/// blocks.
+Future<T> guardAiCall<T>(Future<T> Function() op) async {
+  try {
+    return await op();
+  } on ApiException catch (e) {
+    throw mapApiExceptionToAppFailure(e);
+  }
+}

--- a/lib/features/ai/application/ai_services.dart
+++ b/lib/features/ai/application/ai_services.dart
@@ -1,6 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/features/ai/application/ai_api_failures.dart';
 import 'package:enjoy_player/features/ai/application/ai_capability_providers.dart';
 import 'package:enjoy_player/features/ai/domain/chat_message.dart';
@@ -21,13 +20,9 @@ final class AsrService {
 
   final Ref _ref;
 
-  Future<AsrResult> transcribe(AsrRequest request) async {
-    try {
-      return await _ref.read(asrCapabilityProvider).transcribe(request);
-    } on ApiException catch (e) {
-      throw mapApiExceptionToAppFailure(e);
-    }
-  }
+  Future<AsrResult> transcribe(AsrRequest request) => guardAiCall(
+        () => _ref.read(asrCapabilityProvider).transcribe(request),
+      );
 }
 
 final class ChatService {
@@ -39,19 +34,14 @@ final class ChatService {
     required List<ChatMessage> messages,
     double? temperature,
     int? maxTokens,
-  }) async {
-    try {
-      return await _ref
-          .read(llmCapabilityProvider)
-          .generateChatCompletion(
-            messages: messages,
-            temperature: temperature,
-            maxTokens: maxTokens,
-          );
-    } on ApiException catch (e) {
-      throw mapApiExceptionToAppFailure(e);
-    }
-  }
+  }) =>
+      guardAiCall(
+        () => _ref.read(llmCapabilityProvider).generateChatCompletion(
+              messages: messages,
+              temperature: temperature,
+              maxTokens: maxTokens,
+            ),
+      );
 }
 
 final class TranslationService {
@@ -64,20 +54,15 @@ final class TranslationService {
     required String sourceLanguage,
     required String targetLanguage,
     bool? forceRefresh,
-  }) async {
-    try {
-      return await _ref
-          .read(translationCapabilityProvider)
-          .translate(
-            text: text,
-            sourceLanguage: sourceLanguage,
-            targetLanguage: targetLanguage,
-            forceRefresh: forceRefresh,
-          );
-    } on ApiException catch (e) {
-      throw mapApiExceptionToAppFailure(e);
-    }
-  }
+  }) =>
+      guardAiCall(
+        () => _ref.read(translationCapabilityProvider).translate(
+              text: text,
+              sourceLanguage: sourceLanguage,
+              targetLanguage: targetLanguage,
+              forceRefresh: forceRefresh,
+            ),
+      );
 }
 
 final class ContextualTranslationService {
@@ -90,20 +75,15 @@ final class ContextualTranslationService {
     required String sourceLanguage,
     required String targetLanguage,
     String? context,
-  }) async {
-    try {
-      return await _ref
-          .read(contextualTranslationCapabilityProvider)
-          .translate(
-            text: text,
-            sourceLanguage: sourceLanguage,
-            targetLanguage: targetLanguage,
-            context: context,
-          );
-    } on ApiException catch (e) {
-      throw mapApiExceptionToAppFailure(e);
-    }
-  }
+  }) =>
+      guardAiCall(
+        () => _ref.read(contextualTranslationCapabilityProvider).translate(
+              text: text,
+              sourceLanguage: sourceLanguage,
+              targetLanguage: targetLanguage,
+              context: context,
+            ),
+      );
 }
 
 final class DictionaryService {
@@ -116,20 +96,15 @@ final class DictionaryService {
     required String sourceLanguage,
     required String targetLanguage,
     bool? forceRefresh,
-  }) async {
-    try {
-      return await _ref
-          .read(dictionaryCapabilityProvider)
-          .lookupDictionary(
-            word: word,
-            sourceLanguage: sourceLanguage,
-            targetLanguage: targetLanguage,
-            forceRefresh: forceRefresh,
-          );
-    } on ApiException catch (e) {
-      throw mapApiExceptionToAppFailure(e);
-    }
-  }
+  }) =>
+      guardAiCall(
+        () => _ref.read(dictionaryCapabilityProvider).lookupDictionary(
+              word: word,
+              sourceLanguage: sourceLanguage,
+              targetLanguage: targetLanguage,
+              forceRefresh: forceRefresh,
+            ),
+      );
 }
 
 final class TtsService {
@@ -137,13 +112,9 @@ final class TtsService {
 
   final Ref _ref;
 
-  Future<TtsResult> synthesize(TtsRequest request) async {
-    try {
-      return await _ref.read(ttsCapabilityProvider).synthesize(request);
-    } on ApiException catch (e) {
-      throw mapApiExceptionToAppFailure(e);
-    }
-  }
+  Future<TtsResult> synthesize(TtsRequest request) => guardAiCall(
+        () => _ref.read(ttsCapabilityProvider).synthesize(request),
+      );
 }
 
 final class AssessmentService {
@@ -151,13 +122,9 @@ final class AssessmentService {
 
   final Ref _ref;
 
-  Future<AssessmentResult> assess(AssessmentRequest request) async {
-    try {
-      return await _ref.read(assessmentCapabilityProvider).assess(request);
-    } on ApiException catch (e) {
-      throw mapApiExceptionToAppFailure(e);
-    }
-  }
+  Future<AssessmentResult> assess(AssessmentRequest request) => guardAiCall(
+        () => _ref.read(assessmentCapabilityProvider).assess(request),
+      );
 }
 
 @Riverpod(keepAlive: true)

--- a/test/features/ai/chat_service_test.dart
+++ b/test/features/ai/chat_service_test.dart
@@ -32,6 +32,31 @@ final class _FakeLlm implements LlmCapability {
   }
 }
 
+final class _ThrowingLlm implements LlmCapability {
+  const _ThrowingLlm(this._statusCode);
+  final int _statusCode;
+
+  @override
+  Future<String> generateChatCompletion({
+    required List<ChatMessage> messages,
+    double? temperature,
+    int? maxTokens,
+    Map<String, dynamic>? responseFormat,
+  }) async {
+    throw ApiException(message: 'boom', statusCode: _statusCode);
+  }
+
+  @override
+  Future<String> generateText({
+    String? systemPrompt,
+    required String userPrompt,
+    double? temperature,
+    int? maxTokens,
+  }) async {
+    throw UnimplementedError();
+  }
+}
+
 void main() {
   test('mapApiExceptionToAppFailure maps 402 to CreditsFailure', () {
     final f = mapApiExceptionToAppFailure(
@@ -54,4 +79,27 @@ void main() {
     );
     expect(out, 'echo:ping');
   });
+
+  test(
+    'ChatService.complete translates ApiException via guardAiCall to an '
+    'AppFailure subtree member',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          llmCapabilityProvider.overrideWithValue(const _ThrowingLlm(503)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final chat = container.read(chatServiceProvider);
+      await expectLater(
+        chat.complete(
+          messages: const [
+            ChatMessage(role: ChatMessage.roleUser, content: 'ping'),
+          ],
+        ),
+        throwsA(isA<AppFailure>()),
+      );
+    },
+  );
 }


### PR DESCRIPTION
Seven service classes in `lib/features/ai/application/ai_services.dart` (`AsrService`, `ChatService`, `TranslationService`, `ContextualTranslationService`, `DictionaryService`, `TtsService`, `AssessmentService`) each wrap a single Riverpod capability call in the same `try { … } on ApiException catch (e) { throw mapApiExceptionToAppFailure(e); }` block (issue #203, automated duplicate-code report). This PR centralises that wrapper.

## Changes

- **`lib/features/ai/application/ai_api_failures.dart`** — adds `Future<T> guardAiCall<T>(Future<T> Function() op)` next to the existing `mapApiExceptionToAppFailure`. Same catch shape; one place for any future cross-cutting change (new exception subclasses to map, telemetry, capability-specific failure codes).
- **`lib/features/ai/application/ai_services.dart`** — every method body becomes `guardAiCall(() => _ref.read(<provider>).<method>(<args>))`. The `try` / `on ApiException` / `mapApiExceptionToAppFailure` boilerplate is gone; the only thing each service still contains is the argument list specific to that capability. The class-per-capability shape is preserved, so call-site `ref.read(chatServiceProvider).complete(...)` is unchanged.
- **`test/features/ai/chat_service_test.dart`** — adds a regression test that overrides `llmCapabilityProvider` with a fake that throws `ApiException(503)` and asserts the future completes-with-error as an `AppFailure`. Pins the translation behaviour independent of any one capability's provider.

## Why this matters

A future change like adding `TimeoutException` or `SocketException` to the catch, or threading a capability-specific failure code through `mapApiExceptionToAppFailure`, had to be applied uniformly to all seven try blocks. Easy to miss one. After this change, the cross-cutting concern lives once.

## Verification

```
flutter analyze lib/features/ai/
# No issues found!

flutter test
# All 819 tests passed!
```

Closes #203.
