### PR TITLE
docs(theme): document artwork palette LRU (path, size, mtime) cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `findSliverIndexByPrefixedId<T>` in `lib/core/utils/sliver_key_index.dart` — shared `findChildIndexCallback` lookup for sliver grids/lists keyed by a `"$prefix${id}"` `ValueKey<String>`.
+- `ArtworkPalette` now has value-equality on its four `Color` fields so `Map<ArtworkPalette, ...>` use sites and `==` checks behave like data classes. `@visibleForTesting` cache seams on `lib/core/theme/dynamic_color/artwork_palette.dart`: `debugResetArtworkPaletteCache`, `debugArtworkPaletteCacheSize`, `debugArtworkPaletteCacheContainsPath`, `debugLookupArtworkPalette`, `debugPutArtworkPalette`. 12 tests in `test/core/theme/artwork_palette_test.dart` cover the new invalidation contract.
 
 ### Changed
 
 - Home recents grid, discover merged feed grid, and channel feed grid use stable per-row `ValueKey`s + `findChildIndexCallback` so a Drift re-emit or RSS refresh no longer rebuilds every visible tile.
+- **Artwork palette LRU cache key**: switched from thumbnail path alone to `(path, size, mtime)`. The in-process LRU in `extractArtworkPalette` re-`stat`s the file on every lookup and evicts any prior entry for the same path whose `(size, mtime)` no longer matches the live stat. LRU cap stays at 32 entries. ADR-0007 updated to describe the new key shape and invalidation contract.
 
 ### Fixed
 
 - Documented the `POST /youtube/transcripts` polling contract (request body, attempt/delay budget, `forceRefresh` semantics, and outcome handling) — no behavior change, closes a docs gap between `YoutubeTranscriptsApi` and `docs/features/transcript.md`.
+- **Artwork palette stale-cache leak**: re-thumbnailing or rewriting the local artwork file in place used to return the cached palette for the previous bytes because the LRU key was the path string only. Keyed by `(path, size, mtime)` so a regenerate-then-reopen cycle extracts a fresh palette.
 - **Windows deep links**: PKCE sign-in callbacks no longer spawn a stray second window. The installer-registered `enjoyplayer://` protocol previously launched a fresh `enjoy_player.exe` per click; that process had no in-memory PKCE state, so the original window was stuck waiting and a second window was left open. `windows/runner/main.cpp` now detects an already-running instance via `FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"Enjoy Player")`, forwards the URI to it through `app_links`'s `SendAppLink` (`WM_COPYDATA`), restores/foregrounds that window, and exits. See [docs/features/auth.md](docs/features/auth.md#deep-links-pkce-callback).
 
 ## [0.3.0] - 2026-07-01

--- a/docs/decisions/0007-dynamic-color-from-artwork.md
+++ b/docs/decisions/0007-dynamic-color-from-artwork.md
@@ -9,7 +9,7 @@ The "Cinematic Editorial" design direction requires the player chrome, transport
 
 ## Decision
 
-Use `package:palette_generator` to extract a dominant swatch and a vibrant accent from the local thumbnail file on demand. Results are cached in memory keyed by a hash of the thumbnail path so repeated extractions are free. The palette is exposed as an `@riverpod` provider `artworkPaletteProvider(mediaId)` that returns a nullable `ArtworkPalette` record.
+Use `package:palette_generator` to extract a dominant swatch and a vibrant accent from the local thumbnail file on demand. Results are cached in memory in an **LRU-bounded in-process cache** (cap = 32) keyed by `(path, size, mtime)` so repeated extractions are free *and* a re-thumbnailed or re-encoded artwork file invalidates the cached palette instead of masking the stale result. Lookup walks the LRU order list, evicts any entry for the same path whose `(size, mtime)` no longer matches the file's stat, and returns the matching live entry when one exists. The palette is exposed as `@riverpod` providers: `currentArtworkPaletteProvider` (active player) and `artworkPaletteProvider(path)` (arbitrary path). Both return a nullable `ArtworkPalette`, which has value-equality on its four `Color` fields.
 
 Consumers apply the palette as an overlay/tint (never as a hard surface replacement) so that the app remains coherent when no artwork is available (falls back to theme primary).
 
@@ -19,3 +19,4 @@ Consumers apply the palette as an overlay/tint (never as a hard surface replacem
 - Extraction runs on an `Isolate` via the package — does not block the UI thread.
 - Discontinued package notice accepted (no maintained alternative with equivalent API in 2026; can be replaced with custom FFI extraction later).
 - Dynamic color only applies to player surfaces; library/home/settings always use the static brand amber.
+- LRU cache invalidates on `(size, mtime)` change, not on path alone — re-thumbnailing or rewriting the file in place is enough to force a fresh extraction. `@visibleForTesting` seams (`debugResetArtworkPaletteCache`, `debugArtworkPaletteCacheSize`, `debugArtworkPaletteCacheContainsPath`, `debugLookupArtworkPalette`, `debugPutArtworkPalette`) expose the cache for tests; production code must not call them.

--- a/docs/features/app-ui.md
+++ b/docs/features/app-ui.md
@@ -99,8 +99,8 @@ Focus ring: 2px (custom nav / sidebars)
 ## Dynamic color module
 
 `lib/core/theme/dynamic_color/`
-- `artwork_palette.dart` — LRU-cached extraction via `palette_generator`
-- `dynamic_color_provider.dart` — Riverpod providers: `currentArtworkPaletteProvider`, `artworkPaletteProvider(path)`
+- `artwork_palette.dart` — `extractArtworkPalette(path)` extracts an `ArtworkPalette { dominant, accent, onAccent, vibrant }` from a local thumbnail via `palette_generator`. Results are held in a process-wide **LRU cache** (cap = 32) keyed by `(path, size, mtime)`; lookups re-`stat` the file and evict any prior entry for the same path whose `(size, mtime)` no longer matches the live stat, so re-thumbnailing or rewriting the file in place correctly invalidates the cache. `ArtworkPalette` has value-equality on its four `Color` fields. `@visibleForTesting` seams (`debugResetArtworkPaletteCache`, `debugArtworkPaletteCacheSize`, `debugArtworkPaletteCacheContainsPath`, `debugLookupArtworkPalette`, `debugPutArtworkPalette`) are the only supported access path for tests.
+- `dynamic_color_provider.dart` — Riverpod providers: `currentArtworkPaletteProvider` (active player, watches `playerControllerProvider`'s `thumbnailUrl`), `artworkPaletteProvider(path)` (per-path family).
 
 See ADR-0007 for rationale.
 

--- a/docs/features/library.md
+++ b/docs/features/library.md
@@ -25,6 +25,8 @@
 
 **Fix:** Home and Library grid tiles use **`generativeAccentForSeed`** for hover / border tint only — no per-tile `palette_generator`. **Artwork-derived palettes** remain for the **active player** (e.g. `currentArtworkPaletteProvider` on transport / hero artwork), where a single extraction is acceptable.
 
+**Stale-cache note (artwork palette LRU):** `extractArtworkPalette` caches by `(path, size, mtime)` and re-`stat`s on every lookup, so a re-thumbnailed artwork file (e.g. after `VideoPosterCaptureService` overwrites `media_thumbs/<key>.jpg`) invalidates the prior palette automatically — see [ADR-0007](../decisions/0007-dynamic-color-from-artwork.md) and `test/core/theme/artwork_palette_test.dart`.
+
 **Also in tree (supporting, not the freeze root cause):** `driftRuntimeOptions.dontWarnAboutMultipleDatabases` in `lib/main.dart` (device-global + per-user DBs are intentional), and `app_database_provider.dart` caches one `AppDatabase` per session name with `onDispose` cleanup — avoids duplicate instances and Drift’s multi-open warning spam.
 
 **Regression checks:** Use Flutter DevTools **CPU profiler** (UI thread) if similar freezes reappear; avoid reintroducing per-item `PaletteGenerator` in large scrollables without an isolate or precomputed palette.


### PR DESCRIPTION
Resolves #191.

ADR-0007 and `docs/features/app-ui.md` described the in-process artwork palette cache as "keyed by a hash of the thumbnail path" / "LRU-cached extraction via `palette_generator`". Since #188 the key is `(path, size, mtime)`, the LRU evicts prior entries whose `(size, mtime)` no longer matches the live stat, and `ArtworkPalette` has value equality. This PR brings the docs in line with the implementation so the next reader doesn't get surprised by a stale palette after a re-thumbnail.

## Changes

- **`docs/decisions/0007-dynamic-color-from-artwork.md`** — replace the path-only / "hash of the path" wording with the actual key shape `(path, size, mtime)`, document the LRU cap (32), the eviction walk, and the `@visibleForTesting` seams. Note both providers (`currentArtworkPaletteProvider`, `artworkPaletteProvider(path)`) and the value-equality on `ArtworkPalette`.
- **`docs/features/app-ui.md`** — expand the `lib/core/theme/dynamic_color/` bullet so the cache contract and test seams are discoverable from the design-system doc without re-reading the ADR.
- **`docs/features/library.md`** — add a stale-cache note linking the LRU invalidation to `VideoPosterCaptureService` so the rationale for re-extracting after a poster capture is in one place.
- **`CHANGELOG.md`** (`Unreleased`) — Added (value equality, `@visibleForTesting` seams, 12 tests in `test/core/theme/artwork_palette_test.dart`), Changed (cache key shape, LRU cap), Fixed (stale palette leak on re-thumbnailed artwork).

## Verification

- Docs-only diff; no production code or test changes — `flutter analyze` and `flutter test` should be unaffected. CI does not lint markdown.
- Cross-checked against `lib/core/theme/dynamic_color/artwork_palette.dart` (after #188): `_kCacheMax = 32`, `_lookupFresh` walks `_cacheOrder` and evicts by `(path, size, mtime)`, `ArtworkPalette` overrides `==` and `hashCode`.

Patch generated by the `update-docs` agentic workflow (run 28627555092); pushed manually because the bot lacks push permission on protected files (`CHANGELOG.md`). Resolved a minor merge conflict in `docs/features/library.md` where the patch's "guest + per-user DBs" wording was superseded by "device-global + per-user DBs" in commit `35a2a57`.
