### PR TITLE
docs(landing): document Coming soon disabled state for store buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Landing page store buttons**: iOS TestFlight and Android Play beta cards now stay visible when their URLs are unset in `landing/config.js`, rendering a disabled "Coming soon" button (`btn--disabled`, `aria-disabled="true"`) instead of dropping the cards or shipping a broken link. See [docs/packaging.md](docs/packaging.md#updating-store-links) and [ADR-0024](docs/decisions/0024-download-landing-page.md).
+
 ## [0.3.1] - 2026-07-03
 
 ### Added

--- a/docs/decisions/0024-download-landing-page.md
+++ b/docs/decisions/0024-download-landing-page.md
@@ -20,7 +20,7 @@ The app explicitly forbids Flutter web (ADR-0005), so the landing page must be a
 
 4. **Static fallback links** — When JS is disabled or the manifest is unreachable, all platform buttons fall back to the GitHub releases/latest page, so no action is ever missing.
 
-5. **Store/TestFlight links in `config.js`** — iOS (TestFlight) and Android Play beta have stable URLs that do not come from `latest.json`. They live in `landing/config.js` (the single file to update for link maintenance), applied by JS on load.
+5. **Store/TestFlight links in `config.js`** — iOS (TestFlight) and Android Play beta have stable URLs that do not come from `latest.json`. They live in `landing/config.js` (the single file to update for link maintenance), applied by JS on load. URLs are validated by origin (`https://testflight.apple.com/join/...` / `https://play.google.com/...`); anything else — including `null` — renders the matching card with a disabled **Coming soon** button (`btn--disabled`, `aria-disabled="true"`) instead of dropping the card or exposing a broken link.
 
 6. **OS detection with progressive enhancement** — `navigator.userAgentData` / `userAgent` / `platform` heuristics; iPadOS is disambiguated from macOS via `navigator.maxTouchPoints > 1`. The detected platform's card is reordered to the front and highlighted with a gradient border. All four platform cards always render.
 
@@ -30,6 +30,7 @@ The app explicitly forbids Flutter web (ADR-0005), so the landing page must be a
 
 - `landing/` must not contain a `web/` subdirectory or any Flutter web artefacts.
 - The TestFlight invite URL and Play beta URL in `landing/config.js` must be updated manually when they change (invite expiry, new TestFlight group, etc.).
+- When either URL is `null` or fails origin validation, the corresponding store card stays visible with a disabled **Coming soon** button — visitors see the platform exists, but cannot click through to a missing invite.
 - A new version of the app automatically surfaces on the landing page on the next page load, because the manifest proxy reflects the live `latest.json`.
 - Wrangler and the deploy workflow have no impact on the Flutter app build pipeline.
 - Two CI secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) must be set in the repository before the deploy workflow can run.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -492,6 +492,8 @@ npx wrangler pages deploy .
 
 When the TestFlight invite URL changes or the Play beta URL changes, edit [`landing/config.js`](../landing/config.js) and push to `main`. The deploy workflow picks it up automatically.
 
+`testFlightUrl` and `playBetaUrl` accept only `https://testflight.apple.com/join/...` and `https://play.google.com/...` respectively — anything else (including `null` or empty string) disables the matching store button. When disabled, the card stays visible with a **Coming soon** label, `btn--disabled` styling, and `aria-disabled="true"`, so users can still see the platform exists without being sent to a broken link. Direct-download buttons (Windows, macOS, Android APK) are never disabled by this — they always come from `dl.enjoy.bot/player/latest.json`.
+
 ### Custom domain
 
 `get.enjoy.bot` must have a CNAME record pointing to `enjoy-player-landing.pages.dev` in Cloudflare DNS. Until the custom domain is attached, the `enjoy-player-landing.pages.dev` URL works for verification.


### PR DESCRIPTION
Resolves #192.

Closes a documentation gap surfaced by `755cafd` (fix(landing): disable Play Store and TestFlight until store releases). That commit keeps the iOS TestFlight and Android Play beta cards visible with a disabled **Coming soon** button when `testFlightUrl` / `playBetaUrl` are unset in `landing/config.js`, but the operator-facing docs (`ADR-0024`, `docs/packaging.md`) still described store links as "the URL from `config.js`, applied by JS on load" without explaining the disabled fallback.

## Changes

- **`CHANGELOG.md`** — adds an `[Unreleased]` entry describing the disabled-button behavior, with cross-links to the operator docs.
- **`docs/decisions/0024-download-landing-page.md`** — expands ADR §5 to document the origin validation (`testflight.apple.com` / `play.google.com`) and the disabled-button fallback, and adds a matching bullet under Consequences.
- **`docs/packaging.md`** — expands "Updating store links" with what `null` / invalid URLs do and clarifies that direct-download buttons (Windows / macOS / Android APK) are unaffected (they always come from `dl.enjoy.bot/player/latest.json`).

## Testing

- No code changes; markdown lint not enforced in this repo.
- Manual: re-read all three files end-to-end after the edit; cross-links to `landing/config.js`, `ADR-0024`, and `docs/packaging.md#updating-store-links` resolve.

Patch generated by the `update-docs` agentic workflow (run 28635008055); pushed manually because the bot lacks push permission on protected files (`CHANGELOG.md`).
