### PR TITLE
docs(changelog): document local-database-recovery fix in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Local database recovery**: detection + reset flow were both leaving users stuck. `recovery_actions.dart` now reads the `.sqlite` files from `getApplicationDocumentsDirectory()` — the directory `drift_flutter` actually writes into (the previous path was `ApplicationSupport/databases/`, which nothing populated), and `isUnrecoverableDatabaseError` now also matches `SqliteException`, `no such column`, `duplicate column name`, and `disk image malformed` (prior regex typo missed the `ite`). A successful reset invalidates `guestAppDatabaseProvider` / `appDatabaseProvider` / `appPreferencesCtrlProvider` via the new `performRecoveryReset` + `recoveryResetResultProvider` so the app reloads in place instead of forcing a manual relaunch, and `_fallbackLocalizationsDelegates` keeps `RecoverySurface` rendering before the router-backed `MaterialApp.router` resolves a locale. `RecoverySurface.onReset` is now injectable for tests. See [docs/features/local-database-recovery.md](docs/features/local-database-recovery.md).
+
 ## [0.3.1] - 2026-07-03
 
 ### Added


### PR DESCRIPTION
Resolves #207.

Captures the local-database-recovery fix (commit `8f7d301`) in the CHANGELOG's `[Unreleased]` section so the next release notes carry the change.

## What the original commit did (already merged on `main`)

- Corrected `backupLocalDatabaseFile` / `wipeLocalDatabaseFiles` to read from `getApplicationDocumentsDirectory()` — the directory `drift_flutter` actually writes `.sqlite` files into (the previous path was `ApplicationSupport/databases/`, which nothing populated).
- Broadened `isUnrecoverableDatabaseError` to match `SqliteException` (regex typo fix), `no such column`, `duplicate column name`, and `disk image malformed`.
- Extracted `performRecoveryReset` + `recoveryResetResultProvider` so a successful reset invalidates `guestAppDatabaseProvider` / `appDatabaseProvider` / `appPreferencesCtrlProvider` and the app reloads in place instead of forcing a manual relaunch.
- Added `_fallbackLocalizationsDelegates` so `RecoverySurface` renders before the router-backed `MaterialApp.router` resolves a locale.
- Made `RecoverySurface.onReset` injectable for tests.
- Added a downgrade-safe migration regression test and an end-to-end `app_recovery_flow_test.dart`.
- Updated `recoveryResetLibrarySuccess` copy (en/zh/zh-CN) to reflect the in-place reload.

## What this PR adds

- A single `[Unreleased] / Fixed` entry in `CHANGELOG.md` summarizing the user-visible behavior change and linking to `docs/features/local-database-recovery.md`.

The per-feature documentation was already created in the same commit (`docs/features/local-database-recovery.md`) and was verified to accurately describe the implementation.

Patch generated by the `update-docs` agentic workflow (run 28783605621); pushed manually because the bot lacks push permission on protected files (`CHANGELOG.md`).
