### PR TITLE
docs(auth): record Google OAuth config status (iOS done, macOS still pending)

### DIFF
--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -64,6 +64,18 @@ OAuth client IDs are **public identifiers**, not secrets — they are safe to em
 4. **Flip `kGoogleNativeSignInConfiguredOnApple` to `true`** in [`google_auth_config.dart`](../../lib/features/auth/domain/google_auth_config.dart) in the same change as steps 2–3. Until both Info.plist files *and* this flag are updated together, `nativeGoogleSignInSupported` keeps the "Continue with Google" button hidden on iOS/macOS by design: `google_sign_in`'s iOS/macOS implementation reads `GIDClientID` straight from Info.plist and calling `GIDSignIn.signIn()` while it's still the placeholder throws an **uncaught, uncatchable native `NSInvalidArgumentException`** ("Your app is missing support for the following URL schemes: com.googleusercontent.apps...") that kills the whole app process — Dart `try`/`catch` cannot intercept it because the exception fires inside Google's native SDK before control returns to the Flutter engine. `GoogleSignInService.signInForIdToken()` also throws a `StateError` early as defense-in-depth for any call site that bypasses the UI gating.
 5. Rebuild the app on each platform and confirm `signInForIdToken()` returns a non-null token, then that `POST /api/v1/auth/google` succeeds.
 
+### Configuration status (as of last doc audit)
+
+The five steps above must land **together**. The current checkout is partially complete — keep this table honest as the missing piece lands:
+
+| Step | State | Notes |
+|------|-------|-------|
+| 2 — iOS `Info.plist` `GIDClientID` + reversed `CFBundleURLSchemes` | ✅ Configured (`93185289922-ostq1e99j92mq3l5dokeb904rgetkcvu`) | Expect matching `google.ios_client_id` in enjoy_web Rails credentials. |
+| 3 — macOS `Info.plist` `GIDClientID` + reversed `CFBundleURLSchemes` | ❌ Still `REPLACE_WITH_MACOS_OAUTH_CLIENT_ID` | First Google sign-in on macOS will crash (see flag caveat below). |
+| 4 — `kGoogleNativeSignInConfiguredOnApple = true` | ⚠️ Flipped, but **premature for macOS** | The button is shown on macOS today; macOS Info.plist must be filled in (step 3) in the same change that flipped this flag, or revert this flag until step 3 lands. |
+
+Until step 3 lands, do **not** ship a macOS build with `kGoogleNativeSignInConfiguredOnApple = true` to external testers — the gate's purpose is to keep the placeholder from triggering an uncatchable native crash. If macOS must ship before the OAuth client exists, revert the flag; the button hides itself again.
+
 ## Apple Sign-In setup (manual, one-time)
 
 Apple Sign-In fails **on the device** with `com.apple.AuthenticationServices.AuthorizationError error 1000` when the app binary is not signed with the Sign in with Apple entitlement — this happens inside `SignInWithApple.getAppleIDCredential()` **before** `POST /api/v1/auth/apple`, so backend credentials cannot fix it.


### PR DESCRIPTION
Resolves #215.

Records the partial state of the Google OAuth setup after `b7d3890 config google auth` landed.

## What changed in `b7d3890`

- **iOS** (`ios/Runner/Info.plist`): real `GIDClientID` (`93185289922-ostq1e99j92mq3l5dokeb904rgetkcvu`) + matching reversed `CFBundleURLSchemes` entry — **step 2 done**.
- **macOS** (`macos/Runner/Info.plist`): still `REPLACE_WITH_MACOS_OAUTH_CLIENT_ID` — **step 3 not done**.
- `kGoogleNativeSignInConfiguredOnApple` flipped to `true` in `lib/features/auth/domain/google_auth_config.dart` — **step 4 done, but premature for macOS**.

The five steps in `docs/features/auth.md#google-oauth-client-setup-manual-one-time` are explicit that steps 2, 3, and 4 must land together. With the flag flipped and macOS still on the placeholder, the "Continue with Google" button now appears on macOS, and the first sign-in click will crash via the uncatchable native `NSInvalidArgumentException` that the gate was specifically introduced to prevent.

## Doc changes in this PR

- **`docs/features/auth.md`**: new **Configuration status (as of last doc audit)** subsection under Google OAuth setup with a per-step state table making the partial state obvious, plus explicit guidance not to ship a macOS build externally until step 3 lands (or to revert the flag if it must ship before then).
- **`CHANGELOG.md`**: `[Unreleased] > Changed` entry recording the iOS config change and the macOS caveat.

## Out of scope

- No code changes. Reverting the flag or filling in the macOS `Info.plist` are code-level decisions and should ship in a separate PR owned by the team member with Google Cloud Console access.

Patch generated by the `update-docs` agentic workflow (run 28836553791); pushed manually because the bot lacks push permission on protected files (`CHANGELOG.md`). Resolved a merge conflict in `docs/features/auth.md` where the patch's insertion point predated the `## Apple Sign-In setup` section added in `4020250`; ordered the new "Configuration status" subsection immediately after the Google OAuth steps (where it belongs) and kept the Apple Sign-In section intact below it.
