### PR TITLE
docs(changelog): document Dicebear avatar SVG→PNG rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Avatars** — Dicebear SVG URLs returned by the Enjoy API (e.g. `https://api.dicebear.com/.../svg?seed=…`) are now rewritten to their PNG counterpart (`…/png?seed=…`) before being handed to Flutter's raster image widgets. The shared helper lives at [`lib/core/utils/avatar_url.dart`](lib/core/utils/avatar_url.dart) (`rasterAvatarUrl`) and is invoked at every decode site — `ActiveUser`, `UserProfile`, `SidebarAccountChip`, `ProfileContent`, `AccountHeroSection`, and the community activity card — so unsigned `NetworkImage` / `CachedNetworkImageProvider` decoders no longer fail with "Image provider cannot decode image" on SVG payloads. Documented alongside `CommunityActivityCard` in [docs/features/community.md](docs/features/community.md#home-signed-in); no behavior change for PNG-originated avatars. Closes a long-standing gap surfaced when the first SVG payloads shipped from the cloud profile endpoint.
+
 ## [0.3.1] - 2026-07-03
 
 ### Added


### PR DESCRIPTION
Resolves #216.

Adds an `[Unreleased]` entry to `CHANGELOG.md` mirroring the recent Dicebear avatar fix so the changelog accurately reflects the current `main` behavior.

The fix shipped in `55ba5fd` introduced a shared `rasterAvatarUrl` helper (`lib/core/utils/avatar_url.dart`) that rewrites Dicebear `.../svg?seed=...` URLs to `.../png?seed=...` before handing them to Flutter's raster image widgets — applied at every decode site (`ActiveUser`, `UserProfile`, `SidebarAccountChip`, `ProfileContent`, `AccountHeroSection`, community activity card). Without an entry, the changelog would still read as if 0.3.1 were the latest release.

## Changes

- `CHANGELOG.md`: add `### Fixed` entry under `## [Unreleased]` describing the SVG → PNG rewrite, the helper location, every call site, and the cross-link to `docs/features/community.md` (the existing doc that already explains the rationale).

## Verification

- `git diff --stat` confirms only `CHANGELOG.md` was touched (`+4 -0`).
- No code, no migration, no docs structure change.

Patch generated by the `update-docs` agentic workflow (run 28837422126); pushed manually because the bot lacks push permission on protected files (`CHANGELOG.md`). The remote branch was force-pushed to replace a stale bot-pushed version that contained only the code fix (already merged as `55ba5fd`) without the docs entry.
