### PR TITLE
docs(ai): document guardAiCall error-translation helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Maintainers and agents should keep these files **accurate** when behavior or arc
 | [features/auth.md](features/auth.md) | Product + dev | Sign-in, profile, API base URL, or settings sync behavior changes |
 | [features/credits-usage.md](features/credits-usage.md) | Product + dev | Credits usage audit (Worker `/credits/usages`) behavior changes |
 | [features/subscription.md](features/subscription.md) | Product + dev | Pro subscription status, desktop checkout, or mobile purchase deferral changes |
-| [features/ai.md](features/ai.md) | Product + dev | AI worker capabilities, playground, or provider matrix behavior changes |
+| [features/ai.md](features/ai.md) | Product + dev | AI worker capabilities, playground, provider matrix, or `ApiException → AppFailure` translation (`guardAiCall`) behavior changes |
 | [features/sync.md](features/sync.md) | Product + dev | Cloud metadata sync (library + recordings + queue) behavior changes |
 | [features/library.md](features/library.md) | Product + dev | Home / Library media UI, thumbnails, cold-start perf notes |
 | [features/cloud.md](features/cloud.md) | Product + dev | Remote media index (add-to-library) behavior changes |

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -63,6 +63,28 @@ Keys are **masked** in storage and the field shows a saved-key preview chip (e.g
 
 [`ai_capability_providers.dart`](../../lib/features/ai/application/ai_capability_providers.dart) resolves `Enjoy*Capability` vs `Byok*Capability` from `aiModalityConfigsProvider`. Feature code should use `*ServiceProvider`, not vendor HTTP in widgets.
 
+### Error translation (`guardAiCall`)
+
+Every `*Service` in [`ai_services.dart`](../../lib/features/ai/application/ai_services.dart) (`AsrService`, `ChatService`, `TranslationService`, `ContextualTranslationService`, `DictionaryService`, `TtsService`, `AssessmentService`) wraps its single Riverpod capability call in [`guardAiCall<T>()`](../../lib/features/ai/application/ai_api_failures.dart):
+
+```dart
+Future<AsrResult> transcribe(AsrRequest request) => guardAiCall(
+      () => _ref.read(asrCapabilityProvider).transcribe(request),
+    );
+```
+
+`guardAiCall` runs the body and translates any [`ApiException`](../../lib/data/api/api_exception.dart) thrown by the underlying REST client into the user-facing [`AppFailure`](../../lib/core/errors/app_failure.dart) hierarchy used by the AI presentation layer, via [`mapApiExceptionToAppFailure`](../../lib/features/ai/application/ai_api_failures.dart):
+
+| `ApiException` | `AppFailure` |
+|----------------|--------------|
+| `statusCode == 401` (`isUnauthorized`) | `AuthFailure(code: AuthFailureCode.sessionRevoked)` |
+| `statusCode == 402` | `CreditsFailure` |
+| Any other | `NetworkFailure(statusCode: e.statusCode)` |
+
+Centralising the catch means any future cross-cutting change (new `ApiException` subclasses, telemetry, context-specific failure codes) happens in one place for every AI capability instead of in N near-identical `try`/`catch` blocks. The `*ServiceProvider` access pattern at every call site is unchanged — only the service body shape differs.
+
+Missing BYOK credentials are surfaced **before** the capability runs, by the `ByokNotConfigured*Capability` wrappers and [`ByokNotConfiguredFailure`](../../lib/features/ai/domain/byok_not_configured_failure.dart) — see [BYOK provider § Persistence and security](#persistence-and-security) above. The translation table above only applies to errors thrown by the resolved capability itself.
+
 ### Debug UI
 
 **Settings → Developer → AI playground** shows the active provider label per modality and exercises ASR, chat, translation, dictionary, and assessment.
@@ -90,4 +112,4 @@ Feature screens should depend on `*ServiceProvider` types in `application/`, not
 
 ## Verification
 
-Automated: `flutter test test/features/ai/` and `packages/azure_speech/test/`. Manual BYOK scenarios: [`specs/003-byok-ai/quickstart.md`](../../specs/003-byok-ai/quickstart.md).
+Automated: `flutter test test/features/ai/` and `packages/azure_speech/test/`. `test/features/ai/chat_service_test.dart` pins the `guardAiCall` translation by overriding `llmCapabilityProvider` with a stub that throws `ApiException 503` and asserting the future completes-with-error as an `AppFailure`. Manual BYOK scenarios: [`specs/003-byok-ai/quickstart.md`](../../specs/003-byok-ai/quickstart.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,6 +29,7 @@ CI uploads `coverage/lcov.info` to [Codecov](https://codecov.io) and fails when 
 | Subtitle parsers | `test/data/subtitle/subtitle_parser_test.dart` |
 | Sync queue + retry backoff | `test/features/sync/sync_queue_repository_test.dart`, `test/features/sync/sync_engine_test.dart` |
 | Azure WAV normalization | `test/features/ai/azure_assessment_wav_normalizer_test.dart` |
+| AI service `ApiException → AppFailure` translation | `test/features/ai/chat_service_test.dart` |
 | Echo PCM extraction guards | `test/features/shadow_reading/echo_segment_pcm_extractor_test.dart` |
 | Sliver key index helper | `test/core/utils/sliver_key_index_test.dart` |
 | App smoke (EnjoyApp) | `test/widget_test.dart` |


### PR DESCRIPTION
Resolves #235.

Documentation-only follow-up to #228 / commit `434ef3d` (refactor(ai): extract `guardAiCall` helper for 7 service wrappers).

The refactor introduced a single `ApiException → AppFailure` translation point in `lib/features/ai/application/ai_api_failures.dart` and a new test file at `test/features/ai/chat_service_test.dart`, but the `docs/` tree never described the helper, the failure-translation table, or listed the new test.

## Changes

- **`docs/features/ai.md`** — new **Error translation (`guardAiCall`)** subsection under the capability-routing area. Names the seven services that share the wrapper, shows the canonical service-body shape, and gives the `ApiException → AppFailure` translation table (401 → `AuthFailure(sessionRevoked)`, 402 → `CreditsFailure`, else → `NetworkFailure`). Cross-links to `ByokNotConfiguredFailure` for pre-capability errors. Verification paragraph now names `test/features/ai/chat_service_test.dart`.
- **`docs/testing.md`** — Add a row for the new test file in the Layout table.
- **`docs/README.md`** — Extend the `ai.md` "Update when" trigger to cover the new `guardAiCall` translation behavior.

## Verification

- `dart format --output=none --set-exit-if-changed` on the changed files (clean).
- `git diff --stat`: 3 files changed, 25 insertions, 2 deletions.
- Manual cross-check: every code-path / file linked from the new section exists in the tree at the cited commit.

Patch generated by the `update-docs` agentic workflow (run 28863270576); pushed manually because the bot lacks push permission on protected files (`README.md`).
