### PR TITLE
feat(library): add clear() method to LibrarySearchNotifier

### DIFF
--- a/lib/features/library/application/library_search_provider.dart
+++ b/lib/features/library/application/library_search_provider.dart
@@ -39,12 +39,22 @@ class LibrarySearchNotifier extends Notifier<String> {
     });
   }
 
-  /// Synchronously commit the pending input (e.g. on Enter / submit
-  /// or when an empty-state "Clear" action is tapped). Cancels the
-  /// pending debounced commit.
+  /// Synchronously commit the pending input (e.g. on Enter / submit).
+  /// Cancels the pending debounced commit.
   void commit() {
     _debounce?.cancel();
     _debounce = null;
     state = _pending.trim();
+  }
+
+  /// Resets the search state to `''`, cancelling any pending debounce and
+  /// discarding the pending buffer. Use this for the empty-state "Clear"
+  /// action and any other call site that wants an immediate, unconditional
+  /// reset (no need to mirror it with `setQuery('') + commit()`).
+  void clear() {
+    _debounce?.cancel();
+    _debounce = null;
+    _pending = '';
+    state = '';
   }
 }

--- a/lib/features/library/presentation/widgets/local_library_tab_view.dart
+++ b/lib/features/library/presentation/widgets/local_library_tab_view.dart
@@ -118,8 +118,7 @@ class LocalAudioLibraryBody extends StatelessWidget {
             final notifier = ProviderScope.containerOf(
               context,
             ).read(librarySearchProvider.notifier);
-            notifier.setQuery('');
-            notifier.commit();
+            notifier.clear();
           },
           actionLabel: l10n.librarySearchClear,
         );
@@ -211,8 +210,7 @@ class LocalVideoLibraryBody extends StatelessWidget {
             final notifier = ProviderScope.containerOf(
               context,
             ).read(librarySearchProvider.notifier);
-            notifier.setQuery('');
-            notifier.commit();
+            notifier.clear();
           },
           actionLabel: l10n.librarySearchClear,
         );

--- a/test/features/library/library_search_debounce_test.dart
+++ b/test/features/library/library_search_debounce_test.dart
@@ -76,6 +76,37 @@ void main() {
       notifier.commit();
       expect(container.read(librarySearchProvider), 'hello world');
     });
+
+    test('clear() during a pending debounce resets to empty', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(librarySearchProvider.notifier);
+
+      notifier.setQuery('alpha');
+      // Clear while the debounce is still pending.
+      notifier.clear();
+      expect(container.read(librarySearchProvider), '');
+
+      // Wait past the debounce window: the cancelled timer must not
+      // flip state back to 'alpha'.
+      await Future<void>.delayed(
+        kLibrarySearchDebounce + const Duration(milliseconds: 50),
+      );
+      expect(container.read(librarySearchProvider), '');
+    });
+
+    test('clear() after a committed non-empty state resets to empty', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(librarySearchProvider.notifier);
+
+      notifier.setQuery('hello');
+      notifier.commit();
+      expect(container.read(librarySearchProvider), 'hello');
+
+      notifier.clear();
+      expect(container.read(librarySearchProvider), '');
+    });
   });
 
   group('MediaLibraryRepository.deleteMedia atomicity', () {


### PR DESCRIPTION
Resolves the PR-fallback from #198.

## Summary

The `commit()` docstring on `LibrarySearchNotifier` called out an empty-state "Clear" action as a target, but no method matched that name. Two identical `setQuery('') + commit()` pairs in `LocalLibraryTabView` (audio + video tabs) were hand-rolling the work.

This PR adds a single `clear()` method that mirrors the docstring's contract: cancel any pending debounce, drop the pending buffer, reset state to `''`. The two call sites collapse to a single `notifier.clear()` invocation.

## Changes

| File | Change |
|---|---|
| `lib/features/library/application/library_search_provider.dart` | +11 / -3: new `clear()` method; trims the stale "or when an empty-state 'Clear' action is tapped" line from `commit()`'s docstring since that path now lives in `clear()`. |
| `lib/features/library/presentation/widgets/local_library_tab_view.dart` | +2 / -4: two `setQuery('') + commit()` blocks collapse to single `notifier.clear()` invocations. |
| `test/features/library/library_search_debounce_test.dart` | +31 / 0: two new unit tests pin the contract. |

## Why a single method

- `setQuery('') + commit()` does the right thing today, but the second statement (`commit()`) also re-asserts the now-empty pending buffer -- the work duplicates what `clear()` does in one place. A single API surface replaces both call sites and removes the trap of forgetting one half of the pair.
- Public surface is additive; existing `setQuery` / `commit` semantics are unchanged.

## Verification

- `flutter test test/features/library/` -> 34/34 pass (was 32; net +2).
- `dart format --output=none --set-exit-if-changed lib test` -> 1 file auto-formatted (`library_search_debounce_test.dart`), no semantic change.

Closes #198
