### PR TITLE
chore(editor): add .editorconfig matching project conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Markdown hard-wrapping style varies by contributor and renderer.
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.ps1]
+# PowerShell community convention.
+indent_size = 4
+
+[*.bat]
+# Windows cmd interpreter requires CRLF.
+indent_size = 4
+end_of_line = crlf
+
+# Generated files -- owned by `dart run build_runner build` and
+# `flutter gen-l10n`, not by humans. Don't let a stray editor "fix"
+# drift into a regenerated file.
+[*.{g,freezed,config,gen,mocks,pb}.dart]
+trim_trailing_whitespace = false
+
+[lib/l10n/**]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Resolves the PR-fallback from #218.

## Summary

Add a project `.editorconfig` codifying the formatting rules the codebase already follows by hand: UTF-8, LF, 2-space indent, final newline, trimmed trailing whitespace. These match `dart format` defaults and the `flutter_lints` ruleset already enabled in `analysis_options.yaml`.

EditorConfig is the de-facto cross-editor standard (VS Code, Android Studio, IntelliJ, Vim, Emacs all support it natively or via plugin). With one in tree, future contributors stop accidentally introducing Windows line endings, tabs in YAML, or trailing whitespace in files that aren't auto-formatted by `dart format` and aren't gated by CI (YAML, Markdown, JSON, shell scripts, assorted config).

## File

`.editorconfig` (34 lines, new):

- `root = true` so it applies to the entire tree (no inheritance surprises from parent directories).
- `[*]` block sets the universal defaults: UTF-8, LF, 2-space indent, final newline, trim trailing whitespace.
- `[*.md]` opts out of `trim_trailing_whitespace = false` because Markdown hard-wrapping style varies by contributor and renderer; some contributors deliberately leave two-space line breaks.
- `[Makefile]` switches to tabs (required by GNU Make).
- `[*.ps1]` uses 4-space indent (PowerShell community convention).
- `[*.bat]` uses 4-space indent + CRLF (Windows cmd interpreter requirement). The repo currently has `android/gradlew.bat` and `packages/ffmpeg_kit_flutter_new/android/gradlew.bat` -- both are Gradle wrapper scripts that ship with their own line endings, so the override mainly affects future hand-authored `.bat` files.
- Generated-file blocks (`*.{g,freezed,config,gen,mocks,pb}.dart`, `lib/l10n/**`) opt out of trailing-whitespace trimming -- these are owned by `dart run build_runner build` and `flutter gen-l10n`, and we shouldn't let a stray editor "fix" drift into a regenerated file.

## Why not `dart format`

`dart format` already runs in CI for `lib/`, `test/`, and `packages/*/lib`+`test/`. But it only covers Dart. The codebase has YAML (`*.yaml`, `*.yml`), Markdown (`*.md`), JSON, shell scripts (`*.sh`, `*.ps1`), and assorted config files that aren't auto-formatted -- currently, drift in those is human-review-only. An `.editorconfig` gives every contributor a consistent baseline across all of those without adding CI runtime.

## Trade-offs

- **First-commit learning curve**: contributors using editors without EditorConfig support (e.g. bare `nano`) won't get any of the rules; CI still won't catch `*.yaml` trailing whitespace. That's fine -- it's an opt-in tooling improvement, not a hard gate. If we later want a hard gate, a 5-line `pre-commit` hook or a CI step running `editorconfig-checker` would close that loop.
- **Excludes `*.md` from trim-trailing-whitespace**: protects Markdown hard-wrapping but means docs can still accumulate trailing whitespace. Acceptable trade-off since Markdown rendering is whitespace-insensitive.
- **Generated-file exceptions**: if `dart format` or `build_runner` ever emits trailing whitespace in their generated output (none observed), editors will preserve it. Worth checking next time those generators are bumped.

## Verification

- `dart format`: not applicable (no Dart files touched).
- `flutter analyze`: not applicable (no Dart files touched; the analyzer does not read `.editorconfig`).
- `flutter test`: not applicable (no Dart files touched; no test runtime impact).
- File-level sanity: 34 lines, valid INI, opens cleanly in EditorConfig-aware tooling.

Closes #218
