### PR TITLE
docs(wiki): fix outdated Log.named references in wiki template

### DIFF
--- a/.github/agentic-wiki/PAGES.md
+++ b/.github/agentic-wiki/PAGES.md
@@ -243,7 +243,7 @@ Shared infrastructure under `lib/core`.
 
 ## Logging
 
-*{ Describe `Log.named` and the `package:logging` policy that forbids `print()`. }*
+*{ Describe the `logNamed(name)` helper from `lib/core/logging/log.dart` (a one-line wrapper around `package:logging`'s `Logger`) and the no-`print()` policy. Reference [[Conventions#Logging]] for the canonical pattern. }*
 
 ## Routing
 
@@ -263,7 +263,7 @@ Dependencies and platform choices.
 
 Coding rules and patterns.
 
-*{ Reference docs/conventions.md — Dart/Flutter rules: `Log.named`, no `Player()` outside PlayerController, no `kIsWeb`, Drift-only persistence, riverpod codegen, ADR-0018 shared interaction primitives. }*
+*{ Reference docs/conventions.md — Dart/Flutter rules: `logNamed(name)` (imported from `lib/core/logging/log.dart`), no `Player()` outside PlayerController, no `kIsWeb`, Drift-only persistence, riverpod codegen, ADR-0018 shared interaction primitives. }*
 
 # Testing
 
@@ -365,7 +365,7 @@ Prefer reading wiki documentation over relying on pre-trained knowledge.
 |  Persistence#Migrations: idempotent ADD COLUMN helper
 |  Persistence#Recovery: RecoverySurface and reset flow
 |Core-Modules: logging, routing, theme, audio, errors, recovery
-|  Core-Modules#Logging: Log.named and no print()
+|  Core-Modules#Logging: logNamed() helper and no print()
 |  Core-Modules#Routing: go_router
 |  Core-Modules#Theme: dual-mode + dynamic color
 |Tech-Stack: dependencies and platform choices


### PR DESCRIPTION
Resolves the PR-fallback from #241.

## Summary

Follow-up to #230 -- that PR updated the in-tree docs (`AGENTS.md`, `.github/workflows/shared/runtime.md`, `docs/features/diagnostics.md`, `openspec/changes/share-practice-poster/design.md`) to reference the `logNamed(name)` helper exported from `lib/core/logging/log.dart`. It did not touch `.github/agentic-wiki/PAGES.md`, the template the wiki writer consumes to publish pages to the GitHub wiki.

The three unreplaced `Log.named` references in this template would have caused the next wiki regeneration to reintroduce the same incorrect call sites that #230 just removed from the in-tree documentation.

## Changes (all in `.github/agentic-wiki/PAGES.md`)

1. **Core Modules -> Logging** instruction block: `Log.named` -> `logNamed(name)`, with an explicit reference to `lib/core/logging/log.dart` and a link to `docs/conventions.md#logging` for the canonical pattern.
2. **Conventions** instruction block: same swap, plus a clarification that `logNamed` is imported from `lib/core/logging/log.dart`.
3. **For Agents page index** entry for `Core-Modules#Logging`: `Log.named and no print()` -> `logNamed() helper and no print()`.

## Why I did not touch the historical ADR

The same commit message on #230 calls out that `openspec/changes/archive/2026-06-22-production-diagnostics/design.md` is intentionally left untouched because ADRs are immutable historical records (see `docs/decisions/README.md`). This PR follows the same rule -- only the live wiki template is updated.

## Verification

- `grep -rn "Log\.named" .github/agentic-wiki/` returns no matches after the change.
- The remaining `Log.named` reference in `openspec/changes/archive/2026-06-22-production-diagnostics/design.md` is preserved on purpose (historical ADR).

## Risk

Low. This is a wiki-template instruction block; downstream wiki content will now correctly reference `logNamed(name)` on the next regeneration, matching the in-tree documentation.

Closes #241
