### PR TITLE
fix(api): use buildQuery for timezone param in stats/user APIs

### DIFF
--- a/lib/data/api/services/stats_api.dart
+++ b/lib/data/api/services/stats_api.dart
@@ -1,6 +1,7 @@
 /// `/api/v1/mine/stats` (today/week/month learning statistics).
 library;
 
+import 'package:enjoy_player/data/api/query_params.dart';
 import 'package:enjoy_player/data/api/rest_api.dart';
 
 class StatsApi extends RestApi {
@@ -9,9 +10,9 @@ class StatsApi extends RestApi {
   static const _path = '/api/v1/mine/stats';
 
   Future<Map<String, dynamic>> learningStatistics({String? timezone}) {
-    final q = timezone == null || timezone.isEmpty
-        ? null
-        : <String, String>{'timezone': timezone};
-    return client.getJson(_path, queryParameters: q);
+    return client.getJson(
+      _path,
+      queryParameters: buildQuery({'timezone': timezone}),
+    );
   }
 }

--- a/lib/data/api/services/user_api.dart
+++ b/lib/data/api/services/user_api.dart
@@ -1,6 +1,7 @@
 /// `/api/v1/users/active` (active learners + optional community today stats).
 library;
 
+import 'package:enjoy_player/data/api/query_params.dart';
 import 'package:enjoy_player/data/api/rest_api.dart';
 
 class UserApi extends RestApi {
@@ -9,9 +10,9 @@ class UserApi extends RestApi {
   static const _path = '/api/v1/users/active';
 
   Future<Map<String, dynamic>> activeUsers({String? timezone}) {
-    final q = timezone == null || timezone.isEmpty
-        ? null
-        : <String, String>{'timezone': timezone};
-    return client.getJson(_path, queryParameters: q);
+    return client.getJson(
+      _path,
+      queryParameters: buildQuery({'timezone': timezone}),
+    );
   }
 }


### PR DESCRIPTION
## Summary

Resolves #267.

StatsApi.learningStatistics and UserApi.activeUsers re-implemented the exact null/empty-string guard that uildQuery (lib/data/api/query_params.dart) already provides — the same anti-pattern the helper's docstring calls out. Every other multi-param service (udio, 	ranscript, ecording, ideo, credits) already routes through uildQuery; these two were missed.

This switches both call sites to uildQuery({'timezone': timezone}).

## Why

- **Consistency**: restores the single, established query-building convention across all *Api services.
- **Behavior-preserving**: uildQuery drops 
ull, drops empty strings, and returns 
ull when the resulting map is empty — a 1:1 match for the removed inline ternary.
- **Future-proofing**: any improvement to uildQuery (encoding, trimming) now applies here automatically.

## Verification

- \dart analyze\ on changed files + \query_params.dart\ — no issues.
- \dart format\ — clean.
- \lutter test --no-pub test/data/api/query_params_test.dart\ — 6/6 pass (confirms \uildQuery\ null/empty semantics).
- \lutter test --no-pub test/features/library/home_screen_test.dart\ — passes (this widget consumes both \learningStatisticsProvider\ and \ctiveUsersProvider\).

> Note: the repo's \lutter\ tooling on this machine re-runs dependency resolution on every \lutter analyze\/\lutter test\ invocation, so CI's full \alidate_ci_gates.sh\ should be the source of truth for the complete gate run.

## Scope

Only the two files cited in #267. Issues #266 and #268 (from the same automated duplicate-code run) were reviewed separately and **closed as not planned** — see comments on each issue for rationale.