### PR TITLE
perf: stop transcript/player rebuild storms & scroll-fighting (#282)

### DIFF
--- a/lib/features/player/application/display_position_provider.dart
+++ b/lib/features/player/application/display_position_provider.dart
@@ -3,17 +3,14 @@ library;
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'player_engine_provider.dart';
 import 'position_buckets.dart';
 import 'quantized_position.dart';
+import 'raw_engine_position_stream_provider.dart';
 
 part 'display_position_provider.g.dart';
 
 @riverpod
 Stream<Duration> displayPosition(Ref ref) {
-  final engine = ref.watch(playerEngineProvider);
-  return quantizedPositionStream(
-    engine.position,
-    bucketMs: kPositionBucketDisplayMs,
-  );
+  final rawStream = ref.watch(rawEnginePositionStreamProvider);
+  return quantizedPositionStream(rawStream, bucketMs: kPositionBucketDisplayMs);
 }

--- a/lib/features/player/application/display_position_provider.g.dart
+++ b/lib/features/player/application/display_position_provider.g.dart
@@ -41,4 +41,4 @@ final class DisplayPositionProvider
   }
 }
 
-String _$displayPositionHash() => r'a12e06a1446ebd2bec49ee195d5813702f4d5d8f';
+String _$displayPositionHash() => r'fd89be7837eb6fe5f857228a8d5d987020a535ad';

--- a/lib/features/player/application/echo_mode_provider.dart
+++ b/lib/features/player/application/echo_mode_provider.dart
@@ -45,6 +45,25 @@ class EchoState {
       endTimeSeconds: endTimeSeconds ?? this.endTimeSeconds,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EchoState &&
+          other.active == active &&
+          other.startLineIndex == startLineIndex &&
+          other.endLineIndex == endLineIndex &&
+          other.startTimeSeconds == startTimeSeconds &&
+          other.endTimeSeconds == endTimeSeconds;
+
+  @override
+  int get hashCode => Object.hash(
+    active,
+    startLineIndex,
+    endLineIndex,
+    startTimeSeconds,
+    endTimeSeconds,
+  );
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/features/player/application/player_interactions.dart
+++ b/lib/features/player/application/player_interactions.dart
@@ -62,14 +62,29 @@ class PlayerInteractions extends _$PlayerInteractions {
   @override
   int build() => 0;
 
+  String? _cachedLinesMediaId;
+  List<TranscriptLine> _cachedLines = const [];
+
   Future<List<TranscriptLine>> _lines() async {
     final session = ref.read(playerControllerProvider);
     final mediaId = session?.mediaId;
-    if (mediaId == null) return [];
+    if (mediaId == null) {
+      _cachedLines = const [];
+      _cachedLinesMediaId = null;
+      return _cachedLines;
+    }
+    if (mediaId == _cachedLinesMediaId) return _cachedLines;
+
     final repo = ref.read(transcriptRepositoryProvider);
     final row = await repo.primaryTranscriptRowForMedia(mediaId);
-    if (row == null) return [];
-    return repo.linesForRow(row);
+    if (row == null) {
+      _cachedLines = const [];
+      _cachedLinesMediaId = null;
+      return _cachedLines;
+    }
+    _cachedLines = repo.linesForRow(row);
+    _cachedLinesMediaId = mediaId;
+    return _cachedLines;
   }
 
   Future<void> prevLine() async {

--- a/lib/features/player/application/player_interactions.g.dart
+++ b/lib/features/player/application/player_interactions.g.dart
@@ -42,7 +42,7 @@ final class PlayerInteractionsProvider
 }
 
 String _$playerInteractionsHash() =>
-    r'b38d0e26838280b63f65c44392b4b869e54f0bdd';
+    r'e82848e09e7a6e56da65c7fbcb1c6d5ba202576d';
 
 abstract class _$PlayerInteractions extends $Notifier<int> {
   int build();

--- a/lib/features/player/application/player_position_tracker.dart
+++ b/lib/features/player/application/player_position_tracker.dart
@@ -89,44 +89,44 @@ class PlayerPositionTracker {
         if (_subscribedGeneration != currentOpenGeneration()) return;
         final seconds = pos.inMilliseconds / 1000.0;
 
-        // Echo enforcement runs on every position event — the decision is cheap
-        // and this is what keeps pause-and-rewind within ~50 ms of the segment
-        // end. Single-flight inside the enforcer drops concurrent ticks.
-        unawaited(_echoEnforcer.enforceTick(seconds));
+            // Echo enforcement runs on every position event — the decision is cheap
+            // and this is what keeps pause-and-rewind within ~50 ms of the segment
+            // end. Single-flight inside the enforcer drops concurrent ticks.
+            unawaited(_echoEnforcer.enforceTick(seconds));
 
-        // Heavy session emit + persistence stays on the 400 ms bucket (or fires
-        // immediately on a detected seek) so the recorded clip window lines up.
-        final bucket = pos.inMilliseconds ~/ positionBucketMs;
-        final prevSec = getSession()?.currentTimeSeconds;
-        final likelySeek =
-            prevSec != null &&
-            (seconds - prevSec).abs() > kLikelySeekDeltaSeconds;
-        if (!likelySeek && bucket == _lastPositionEmitBucket) {
-          return;
-        }
-        _lastPositionEmitBucket = bucket;
+            // Heavy session emit + persistence stays on the 400 ms bucket (or fires
+            // immediately on a detected seek) so the recorded clip window lines up.
+            final bucket = pos.inMilliseconds ~/ positionBucketMs;
+            final prevSec = getSession()?.currentTimeSeconds;
+            final likelySeek =
+                prevSec != null &&
+                (seconds - prevSec).abs() > kLikelySeekDeltaSeconds;
+            if (!likelySeek && bucket == _lastPositionEmitBucket) {
+              return;
+            }
+            _lastPositionEmitBucket = bucket;
 
-        setSession(
-          getSession()?.copyWith(
-            currentTimeSeconds: seconds,
-            lastActiveAt: DateTime.now(),
-          ),
+            setSession(
+              getSession()?.copyWith(
+                currentTimeSeconds: seconds,
+                lastActiveAt: DateTime.now(),
+              ),
+            );
+            final s = getSession();
+            if (s != null) {
+              ref
+                  .read(playbackSessionPersisterProvider)
+                  .schedule(
+                    mediaId: mediaId,
+                    dexieTargetType: dexieTargetType,
+                    session: s,
+                  );
+            }
+          },
+          onError: (Object e, StackTrace st) {
+            _positionLog.warning('engine position stream errored', e, st);
+          },
         );
-        final s = getSession();
-        if (s != null) {
-          ref
-              .read(playbackSessionPersisterProvider)
-              .schedule(
-                mediaId: mediaId,
-                dexieTargetType: dexieTargetType,
-                session: s,
-              );
-        }
-      },
-      onError: (Object e, StackTrace st) {
-        _positionLog.warning('engine position stream errored', e, st);
-      },
-    );
 
     _durationSub = getEngine().duration.listen(
       (d) async {

--- a/lib/features/player/application/player_position_tracker.dart
+++ b/lib/features/player/application/player_position_tracker.dart
@@ -89,44 +89,44 @@ class PlayerPositionTracker {
         if (_subscribedGeneration != currentOpenGeneration()) return;
         final seconds = pos.inMilliseconds / 1000.0;
 
-            // Echo enforcement runs on every position event — the decision is cheap
-            // and this is what keeps pause-and-rewind within ~50 ms of the segment
-            // end. Single-flight inside the enforcer drops concurrent ticks.
-            unawaited(_echoEnforcer.enforceTick(seconds));
+        // Echo enforcement runs on every position event — the decision is cheap
+        // and this is what keeps pause-and-rewind within ~50 ms of the segment
+        // end. Single-flight inside the enforcer drops concurrent ticks.
+        unawaited(_echoEnforcer.enforceTick(seconds));
 
-            // Heavy session emit + persistence stays on the 400 ms bucket (or fires
-            // immediately on a detected seek) so the recorded clip window lines up.
-            final bucket = pos.inMilliseconds ~/ positionBucketMs;
-            final prevSec = getSession()?.currentTimeSeconds;
-            final likelySeek =
-                prevSec != null &&
-                (seconds - prevSec).abs() > kLikelySeekDeltaSeconds;
-            if (!likelySeek && bucket == _lastPositionEmitBucket) {
-              return;
-            }
-            _lastPositionEmitBucket = bucket;
+        // Heavy session emit + persistence stays on the 400 ms bucket (or fires
+        // immediately on a detected seek) so the recorded clip window lines up.
+        final bucket = pos.inMilliseconds ~/ positionBucketMs;
+        final prevSec = getSession()?.currentTimeSeconds;
+        final likelySeek =
+            prevSec != null &&
+            (seconds - prevSec).abs() > kLikelySeekDeltaSeconds;
+        if (!likelySeek && bucket == _lastPositionEmitBucket) {
+          return;
+        }
+        _lastPositionEmitBucket = bucket;
 
-            setSession(
-              getSession()?.copyWith(
-                currentTimeSeconds: seconds,
-                lastActiveAt: DateTime.now(),
-              ),
-            );
-            final s = getSession();
-            if (s != null) {
-              ref
-                  .read(playbackSessionPersisterProvider)
-                  .schedule(
-                    mediaId: mediaId,
-                    dexieTargetType: dexieTargetType,
-                    session: s,
-                  );
-            }
-          },
-          onError: (Object e, StackTrace st) {
-            _positionLog.warning('engine position stream errored', e, st);
-          },
+        setSession(
+          getSession()?.copyWith(
+            currentTimeSeconds: seconds,
+            lastActiveAt: DateTime.now(),
+          ),
         );
+        final s = getSession();
+        if (s != null) {
+          ref
+              .read(playbackSessionPersisterProvider)
+              .schedule(
+                mediaId: mediaId,
+                dexieTargetType: dexieTargetType,
+                session: s,
+              );
+        }
+      },
+      onError: (Object e, StackTrace st) {
+        _positionLog.warning('engine position stream errored', e, st);
+      },
+    );
 
     _durationSub = getEngine().duration.listen(
       (d) async {

--- a/lib/features/player/application/raw_engine_position_stream_provider.dart
+++ b/lib/features/player/application/raw_engine_position_stream_provider.dart
@@ -1,0 +1,14 @@
+/// Single shared raw engine position stream so display/scrubber/tracker all
+/// derive from one canonical source instead of subscribing independently.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'player_engine_provider.dart';
+
+final rawEnginePositionStreamProvider = Provider<Stream<Duration>>((ref) {
+  final engine = ref.watch(playerEngineProvider);
+  return engine.position;
+});

--- a/lib/features/player/application/transport_slider_position_provider.dart
+++ b/lib/features/player/application/transport_slider_position_provider.dart
@@ -3,14 +3,14 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'player_engine_provider.dart';
 import 'position_buckets.dart';
 import 'quantized_position.dart';
+import 'raw_engine_position_stream_provider.dart';
 
 final transportSliderPositionProvider = StreamProvider<Duration>((ref) {
-  final engine = ref.watch(playerEngineProvider);
+  final rawStream = ref.watch(rawEnginePositionStreamProvider);
   return quantizedPositionStream(
-    engine.position,
+    rawStream,
     bucketMs: kPositionBucketScrubberMs,
   );
 });

--- a/lib/features/player/domain/playback_session.dart
+++ b/lib/features/player/domain/playback_session.dart
@@ -61,6 +61,37 @@ class PlaybackSession {
       transcriptId: transcriptId ?? this.transcriptId,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PlaybackSession &&
+          other.mediaId == mediaId &&
+          other.dexieTargetType == dexieTargetType &&
+          other.mediaType == mediaType &&
+          other.mediaTitle == mediaTitle &&
+          other.thumbnailUrl == thumbnailUrl &&
+          other.durationSeconds == durationSeconds &&
+          other.currentTimeSeconds == currentTimeSeconds &&
+          other.currentSegmentIndex == currentSegmentIndex &&
+          other.language == language &&
+          other.startedAt == startedAt &&
+          other.transcriptId == transcriptId;
+
+  @override
+  int get hashCode => Object.hash(
+    mediaId,
+    dexieTargetType,
+    mediaType,
+    mediaTitle,
+    thumbnailUrl,
+    durationSeconds,
+    currentTimeSeconds,
+    currentSegmentIndex,
+    language,
+    startedAt,
+    transcriptId,
+  );
 }
 
 /// Stable subset for navigation chrome and artwork — excludes clock fields so UI

--- a/lib/features/share_poster/presentation/share_practice_poster_button.dart
+++ b/lib/features/share_poster/presentation/share_practice_poster_button.dart
@@ -23,11 +23,17 @@ class SharePracticePosterButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
-    final session = ref.watch(playerControllerProvider);
+    final sessionInfo = ref.watch(
+      playerControllerProvider.select(
+        (s) => s != null
+            ? (mediaId: s.mediaId, dexieTargetType: s.dexieTargetType)
+            : null,
+      ),
+    );
     final targetTypeAsync = ref.watch(dexieTargetTypeForMediaProvider(mediaId));
 
-    final targetType = session?.mediaId == mediaId
-        ? session!.dexieTargetType
+    final targetType = sessionInfo?.mediaId == mediaId
+        ? sessionInfo!.dexieTargetType
         : targetTypeAsync.value;
     if (targetType == null) return const SizedBox.shrink();
 

--- a/lib/features/transcript/application/auto_translate_resolved_text.dart
+++ b/lib/features/transcript/application/auto_translate_resolved_text.dart
@@ -1,0 +1,53 @@
+/// Shared auto-translate secondary text resolution helper.
+///
+/// Used by [TranscriptScrollableList] and [EchoRegionMergedCard] to avoid
+/// duplicating the secondary text resolution and i18n fallback logic.
+library;
+
+import 'package:enjoy_player/data/subtitle/transcript_line.dart';
+import 'package:enjoy_player/features/transcript/domain/auto_translate.dart';
+import 'package:enjoy_player/features/transcript/application/transcript_line_alignment.dart';
+
+({String? secondaryText, bool canRetranslate, bool isFailed, bool isInFlight})
+resolveAutoTranslateTextForDisplay({
+  required bool autoTranslateActive,
+  required List<TranscriptLine> primaryLines,
+  required List<TranscriptLine> aiLines,
+  required int lineIndex,
+  required String? sourceLanguage,
+  required String? targetLanguage,
+  required TranscriptSecondaryMatcher matcher,
+  required TranscriptLine line,
+  required bool Function(int lineIndex) isLineFailed,
+  required bool Function(int lineIndex) isLineInFlight,
+  String? l10nLineFailed,
+  String? l10nLinePending,
+}) {
+  final raw = autoTranslateActive
+      ? resolveAutoTranslateSecondaryText(
+          primaryLines: primaryLines,
+          aiLines: aiLines,
+          lineIndex: lineIndex,
+          sourceLanguage: sourceLanguage,
+          targetLanguage: targetLanguage,
+        )
+      : matcher.match(line)?.text;
+  final empty = raw == null || raw.trim().isEmpty;
+  final failed = autoTranslateActive && isLineFailed(lineIndex);
+  final inFlight = autoTranslateActive && isLineInFlight(lineIndex);
+
+  final display = empty && l10nLineFailed != null
+      ? (failed ? l10nLineFailed : (inFlight ? l10nLinePending : raw))
+      : raw;
+
+  final canRetranslate =
+      autoTranslateActive &&
+      (failed || (display != null && display.trim().isNotEmpty));
+
+  return (
+    secondaryText: display,
+    canRetranslate: canRetranslate,
+    isFailed: failed,
+    isInFlight: inFlight,
+  );
+}

--- a/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
+++ b/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
@@ -653,14 +653,15 @@ class _SubtitleTrackPickerSheetState
 
     final primaryId = primaryIdAsync.value;
     final secondaryId = secondaryIdAsync.value;
-    final session = ref.watch(playerControllerProvider);
+    final dexieTargetType = ref.watch(
+      playerControllerProvider.select((s) => s?.dexieTargetType),
+    );
     final videoRowAsync = ref.watch(videoRowForMediaProvider(widget.mediaId));
     final isYoutube = videoRowAsync.maybeWhen(
       data: (row) => row?.provider == 'youtube',
       orElse: () => false,
     );
-    final showExtractEmbedded =
-        session != null && session.dexieTargetType == 'Video' && !isYoutube;
+    final showExtractEmbedded = dexieTargetType == 'Video' && !isYoutube;
     final fetchState = ref.watch(transcriptFetchStatusProvider(widget.mediaId));
     final isFetching = fetchState.status == TranscriptFetchStatus.loading;
     final autoTranslateState = ref.watch(

--- a/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
+++ b/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
@@ -18,7 +18,6 @@ import 'package:enjoy_player/features/lookup/application/transcript_lookup_open.
 import 'package:enjoy_player/features/transcript/application/active_transcript_provider.dart';
 import 'package:enjoy_player/features/transcript/application/auto_translate_controller.dart';
 import 'package:enjoy_player/features/transcript/application/auto_translate_resolved_text.dart';
-import 'package:enjoy_player/features/transcript/domain/auto_translate.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_line_recording_counts_provider.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_line_alignment.dart';
 import 'package:enjoy_player/features/transcript/presentation/echo_region_controls_bar.dart';

--- a/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
+++ b/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
@@ -17,6 +17,7 @@ import 'package:enjoy_player/features/shadow_reading/presentation/shadow_reading
 import 'package:enjoy_player/features/lookup/application/transcript_lookup_open.dart';
 import 'package:enjoy_player/features/transcript/application/active_transcript_provider.dart';
 import 'package:enjoy_player/features/transcript/application/auto_translate_controller.dart';
+import 'package:enjoy_player/features/transcript/application/auto_translate_resolved_text.dart';
 import 'package:enjoy_player/features/transcript/domain/auto_translate.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_line_recording_counts_provider.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_line_alignment.dart';
@@ -54,12 +55,21 @@ class EchoRegionMergedCard extends ConsumerWidget {
     final lineRecordingCounts = ref.watch(
       transcriptLineRecordingCountsProvider(mediaId),
     );
-    final autoTranslateState = ref.watch(autoTranslateCtrlProvider(mediaId));
+    final autoTranslateMode = ref.watch(
+      autoTranslateCtrlProvider(mediaId).select(
+        (s) => (
+          isActive: s.isActive,
+          aiTranscriptId: s.aiTranscriptId,
+          sourceLanguage: s.sourceLanguage,
+          targetLanguage: s.targetLanguage,
+        ),
+      ),
+    );
     final secondaryId = ref.watch(secondaryTranscriptIdProvider(mediaId)).value;
     final autoTranslateActive =
-        autoTranslateState.isActive &&
-        autoTranslateState.aiTranscriptId != null &&
-        secondaryId == autoTranslateState.aiTranscriptId;
+        autoTranslateMode.isActive &&
+        autoTranslateMode.aiTranscriptId != null &&
+        secondaryId == autoTranslateMode.aiTranscriptId;
 
     // Neutral surface — no colored background; left rail carries the echo accent.
     final shell = scheme.surfaceContainerLow;
@@ -82,41 +92,40 @@ class EchoRegionMergedCard extends ConsumerWidget {
 
       final line = lines[i];
       final isActive = i == activeCueIndex;
-      final secondaryTextRaw = autoTranslateActive
-          ? resolveAutoTranslateSecondaryText(
-              primaryLines: lines,
-              aiLines: secondaryLines,
-              lineIndex: i,
-              sourceLanguage: autoTranslateState.sourceLanguage,
-              targetLanguage: autoTranslateState.targetLanguage,
-            )
-          : matcher.match(line)?.text;
-      final secondaryEmpty =
-          secondaryTextRaw == null || secondaryTextRaw.trim().isEmpty;
-      final lineFailed =
-          autoTranslateActive && autoTranslateState.isLineFailed(i);
-      final lineInFlight =
-          autoTranslateActive && autoTranslateState.isLineInFlight(i);
+      final resolved = resolveAutoTranslateTextForDisplay(
+        autoTranslateActive: autoTranslateActive,
+        primaryLines: lines,
+        aiLines: secondaryLines,
+        lineIndex: i,
+        sourceLanguage: autoTranslateMode.sourceLanguage,
+        targetLanguage: autoTranslateMode.targetLanguage,
+        matcher: matcher,
+        line: line,
+        isLineFailed: (i) =>
+            ref.read(autoTranslateCtrlProvider(mediaId)).isLineFailed(i),
+        isLineInFlight: (i) =>
+            ref.read(autoTranslateCtrlProvider(mediaId)).isLineInFlight(i),
+        l10nLineFailed: AppLocalizations.of(
+          context,
+        )?.subtitlesAutoTranslateLineFailed,
+        l10nLinePending: AppLocalizations.of(
+          context,
+        )?.subtitlesAutoTranslatePendingLine,
+      );
+      final secondaryText = resolved.secondaryText;
+      final canRetranslate = resolved.canRetranslate;
+      final lineFailed = resolved.isFailed;
+
       // Echo block is itself the viewport; request every empty cue in range.
-      if (autoTranslateActive && secondaryEmpty && !lineFailed) {
+      if (autoTranslateActive &&
+          (secondaryText == null || secondaryText.trim().isEmpty) &&
+          !lineFailed) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           ref
               .read(autoTranslateCtrlProvider(mediaId).notifier)
               .requestTranslateLine(i);
         });
       }
-      final l10n = AppLocalizations.of(context);
-      final secondaryText = secondaryEmpty && l10n != null
-          ? (lineFailed
-                ? l10n.subtitlesAutoTranslateLineFailed
-                : (lineInFlight
-                      ? l10n.subtitlesAutoTranslatePendingLine
-                      : secondaryTextRaw))
-          : secondaryTextRaw;
-      final canRetranslate =
-          autoTranslateActive &&
-          (lineFailed ||
-              (secondaryText != null && secondaryText.trim().isNotEmpty));
 
       final tile = TranscriptLineTile(
         key: ValueKey<String>('echo-line-$i'),

--- a/lib/features/transcript/presentation/transcript_panel.dart
+++ b/lib/features/transcript/presentation/transcript_panel.dart
@@ -75,11 +75,10 @@ class TranscriptPanel extends ConsumerWidget {
       orElse: () => false,
     );
     final showLocalActions = !isYoutube;
-    final session = ref.watch(playerControllerProvider);
-    final showExtractButton =
-        session != null &&
-        session.dexieTargetType == 'Video' &&
-        showLocalActions;
+    final dexieTargetType = ref.watch(
+      playerControllerProvider.select((s) => s?.dexieTargetType),
+    );
+    final showExtractButton = dexieTargetType == 'Video' && showLocalActions;
 
     final signedIn = ref.watch(authCtrlProvider).valueOrNull is AuthSignedIn;
 

--- a/lib/features/transcript/presentation/transcript_scrollable_list.dart
+++ b/lib/features/transcript/presentation/transcript_scrollable_list.dart
@@ -424,7 +424,7 @@ class _TranscriptScrollableListState
           (next < echoNow.startLineIndex || next > echoNow.endLineIndex)) {
         return;
       }
-      if (prev == null || next == null || (next - prev).abs() > 1) {
+      if (prev == null || (next - prev).abs() > 1) {
         _suppressAutoScroll = false;
       }
       _scheduleTranscriptScrollIntoView(force: true);

--- a/lib/features/transcript/presentation/transcript_scrollable_list.dart
+++ b/lib/features/transcript/presentation/transcript_scrollable_list.dart
@@ -14,6 +14,7 @@ import 'package:enjoy_player/features/player/application/player_interactions.dar
 import 'package:enjoy_player/features/player/application/player_state_providers.dart';
 import 'package:enjoy_player/features/transcript/application/active_transcript_provider.dart';
 import 'package:enjoy_player/features/transcript/application/auto_translate_controller.dart';
+import 'package:enjoy_player/features/transcript/application/auto_translate_resolved_text.dart';
 import 'package:enjoy_player/features/transcript/domain/auto_translate.dart';
 import 'package:enjoy_player/features/transcript/application/echo_region_bounds.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_line_alignment.dart';
@@ -58,12 +59,6 @@ List<_TranscriptVirtualItem> _buildVirtualItems(
   return out;
 }
 
-bool _echoLayoutEqual(EchoState a, EchoState b) {
-  return a.active == b.active &&
-      a.startLineIndex == b.startLineIndex &&
-      a.endLineIndex == b.endLineIndex;
-}
-
 class TranscriptScrollableList extends ConsumerStatefulWidget {
   const TranscriptScrollableList({
     required this.mediaId,
@@ -95,6 +90,10 @@ class _TranscriptScrollableListState
   (int start, int end)? _echoRegionScrollKeyBounds;
   GlobalKey? _activeLineScrollKey;
   int _activeLineScrollKeyIndex = -1;
+
+  /// When true, the user is manually scrolling and auto-follow should not
+  /// force-scroll the viewport back to the active cue.
+  bool _suppressAutoScroll = false;
 
   List<_TranscriptVirtualItem> _cachedVirtualItems = const [];
   List<TranscriptLine>? _cachedLinesRef;
@@ -154,7 +153,7 @@ class _TranscriptScrollableListState
   List<_TranscriptVirtualItem> _virtualItems(EchoState echo) {
     if (!identical(widget.lines, _cachedLinesRef) ||
         _cachedEchoForItems == null ||
-        !_echoLayoutEqual(echo, _cachedEchoForItems!)) {
+        _cachedEchoForItems! != echo) {
       _cachedLinesRef = widget.lines;
       _cachedEchoForItems = echo;
       _cachedVirtualItems = _buildVirtualItems(widget.lines, echo);
@@ -182,7 +181,32 @@ class _TranscriptScrollableListState
     return (ratio * (lineCount - 1)).round();
   }
 
-  /// Request when near the playback cue (seek) or the scrolled viewport.
+  /// Whether the active cue line is roughly within the visible viewport.
+  bool _isActiveCueVisible(int activeLineIndex) {
+    if (!_scrollController.hasClients) return true;
+    final focus = _scrollFocusLineIndex();
+    return (activeLineIndex - focus).abs() <= 2;
+  }
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification is UserScrollNotification) {
+      if (notification.direction == ScrollDirection.idle) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          final activeIdx = ref.read(
+            transcriptPlaybackHighlightProvider(widget.mediaId),
+          );
+          if (!_isActiveCueVisible(activeIdx)) {
+            _suppressAutoScroll = false;
+          }
+        });
+      } else {
+        _suppressAutoScroll = true;
+      }
+    }
+    return false;
+  }
+
   bool _shouldRequestAutoTranslate(int lineIndex, int playbackHighlight) {
     final highlight = playbackHighlight >= 0 ? playbackHighlight : 0;
     final scrollFocus = _scrollFocusLineIndex();
@@ -339,6 +363,8 @@ class _TranscriptScrollableListState
       _lastScrolledIndex = activeForUi;
     }
 
+    if (force && _suppressAutoScroll) return;
+
     _scrollGeneration++;
     final generation = _scrollGeneration;
 
@@ -365,16 +391,23 @@ class _TranscriptScrollableListState
     );
     final secondaryLines = secondaryAsync.value ?? <TranscriptLine>[];
     final secondaryMatcher = _matcherFor(secondaryLines);
-    final autoTranslateState = ref.watch(
-      autoTranslateCtrlProvider(widget.mediaId),
+    final autoTranslateMode = ref.watch(
+      autoTranslateCtrlProvider(widget.mediaId).select(
+        (s) => (
+          isActive: s.isActive,
+          aiTranscriptId: s.aiTranscriptId,
+          sourceLanguage: s.sourceLanguage,
+          targetLanguage: s.targetLanguage,
+        ),
+      ),
     );
     final secondaryId = ref
         .watch(secondaryTranscriptIdProvider(widget.mediaId))
         .value;
     final autoTranslateActive =
-        autoTranslateState.isActive &&
-        autoTranslateState.aiTranscriptId != null &&
-        secondaryId == autoTranslateState.aiTranscriptId;
+        autoTranslateMode.isActive &&
+        autoTranslateMode.aiTranscriptId != null &&
+        secondaryId == autoTranslateMode.aiTranscriptId;
     final l10n = AppLocalizations.of(context);
     final items = _virtualItems(echo);
     final lineRecordingCounts = ref.watch(
@@ -391,6 +424,9 @@ class _TranscriptScrollableListState
           (next < echoNow.startLineIndex || next > echoNow.endLineIndex)) {
         return;
       }
+      if (prev == null || next == null || (next - prev).abs() > 1) {
+        _suppressAutoScroll = false;
+      }
       _scheduleTranscriptScrollIntoView(force: true);
     });
     ref.listen(playerIsPlayingProvider, (_, _) {
@@ -402,6 +438,7 @@ class _TranscriptScrollableListState
       ),
       (prev, next) {
         if (prev == next) return;
+        _suppressAutoScroll = false;
         _scheduleTranscriptScrollIntoView(force: true);
       },
     );
@@ -411,137 +448,136 @@ class _TranscriptScrollableListState
       label:
           AppLocalizations.of(context)?.transcriptAccessibilityTranscriptList ??
           'Transcript',
-      child: ListView.builder(
-        scrollCacheExtent: const ScrollCacheExtent.pixels(1400),
-        controller: _scrollController,
-        padding: EdgeInsets.symmetric(
-          horizontal: tok.space12,
-          vertical: tok.space8,
-        ),
-        itemCount: items.length,
-        itemBuilder: (context, index) {
-          final item = items[index];
-          switch (item) {
-            case _VirtualEcho e:
-              return Padding(
-                key: ValueKey<String>(
-                  'echo-${e.startLineIndex}-${e.endLineIndex}',
-                ),
-                padding: EdgeInsets.only(bottom: tok.space8),
-                child: KeyedSubtree(
-                  key: _scrollKeyForEcho(echo),
-                  child: EchoRegionMergedCard(
-                    mediaId: widget.mediaId,
-                    lines: widget.lines,
-                    echo: echo,
-                    activeCueIndex: activeForUi,
-                    secondaryLines: secondaryLines,
-                    secondaryMatcher: secondaryMatcher,
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _handleScrollNotification,
+        child: ListView.builder(
+          scrollCacheExtent: const ScrollCacheExtent.pixels(1400),
+          controller: _scrollController,
+          padding: EdgeInsets.symmetric(
+            horizontal: tok.space12,
+            vertical: tok.space8,
+          ),
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final item = items[index];
+            switch (item) {
+              case _VirtualEcho e:
+                return Padding(
+                  key: ValueKey<String>(
+                    'echo-${e.startLineIndex}-${e.endLineIndex}',
                   ),
-                ),
-              );
-            case _VirtualLine vl:
-              final lineIndex = vl.lineIndex;
-              final line = widget.lines[lineIndex];
-              final isActive = lineIndex == activeForUi;
-              final inEcho =
-                  echo.active &&
-                  lineIndex >= echo.startLineIndex &&
-                  lineIndex <= echo.endLineIndex;
-              final secondaryTextRaw = autoTranslateActive
-                  ? resolveAutoTranslateSecondaryText(
-                      primaryLines: widget.lines,
-                      aiLines: secondaryLines,
-                      lineIndex: lineIndex,
-                      sourceLanguage: autoTranslateState.sourceLanguage,
-                      targetLanguage: autoTranslateState.targetLanguage,
-                    )
-                  : secondaryMatcher.match(line)?.text;
-              final secondaryEmpty =
-                  secondaryTextRaw == null || secondaryTextRaw.trim().isEmpty;
-              final lineFailed =
-                  autoTranslateActive &&
-                  autoTranslateState.isLineFailed(lineIndex);
-              final lineInFlight =
-                  autoTranslateActive &&
-                  autoTranslateState.isLineInFlight(lineIndex);
-              if (autoTranslateActive &&
-                  secondaryEmpty &&
-                  !lineFailed &&
-                  _shouldRequestAutoTranslate(lineIndex, activeForUi)) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (!mounted) return;
-                  // Re-check after seek/scroll jumps that happen this frame.
-                  final highlight = ref.read(
-                    transcriptPlaybackHighlightProvider(widget.mediaId),
+                  padding: EdgeInsets.only(bottom: tok.space8),
+                  child: KeyedSubtree(
+                    key: _scrollKeyForEcho(echo),
+                    child: EchoRegionMergedCard(
+                      mediaId: widget.mediaId,
+                      lines: widget.lines,
+                      echo: echo,
+                      activeCueIndex: activeForUi,
+                      secondaryLines: secondaryLines,
+                      secondaryMatcher: secondaryMatcher,
+                    ),
+                  ),
+                );
+              case _VirtualLine vl:
+                final lineIndex = vl.lineIndex;
+                final line = widget.lines[lineIndex];
+                final isActive = lineIndex == activeForUi;
+                final inEcho =
+                    echo.active &&
+                    lineIndex >= echo.startLineIndex &&
+                    lineIndex <= echo.endLineIndex;
+                final resolved = resolveAutoTranslateTextForDisplay(
+                  autoTranslateActive: autoTranslateActive,
+                  primaryLines: widget.lines,
+                  aiLines: secondaryLines,
+                  lineIndex: lineIndex,
+                  sourceLanguage: autoTranslateMode.sourceLanguage,
+                  targetLanguage: autoTranslateMode.targetLanguage,
+                  matcher: secondaryMatcher,
+                  line: line,
+                  isLineFailed: (i) => ref
+                      .read(autoTranslateCtrlProvider(widget.mediaId))
+                      .isLineFailed(i),
+                  isLineInFlight: (i) => ref
+                      .read(autoTranslateCtrlProvider(widget.mediaId))
+                      .isLineInFlight(i),
+                  l10nLineFailed: l10n?.subtitlesAutoTranslateLineFailed,
+                  l10nLinePending: l10n?.subtitlesAutoTranslatePendingLine,
+                );
+                final secondaryText = resolved.secondaryText;
+                final canRetranslateLine = resolved.canRetranslate;
+                final lineFailed = resolved.isFailed;
+
+                if (autoTranslateActive &&
+                    (secondaryText == null || secondaryText.trim().isEmpty) &&
+                    !lineFailed &&
+                    _shouldRequestAutoTranslate(lineIndex, activeForUi)) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (!mounted) return;
+                    final highlight = ref.read(
+                      transcriptPlaybackHighlightProvider(widget.mediaId),
+                    );
+                    if (!_shouldRequestAutoTranslate(lineIndex, highlight)) {
+                      return;
+                    }
+                    ref
+                        .read(
+                          autoTranslateCtrlProvider(widget.mediaId).notifier,
+                        )
+                        .requestTranslateLine(lineIndex);
+                  });
+                }
+
+                final selectable = isActive;
+                Widget tile = TranscriptLineTile(
+                  line: line,
+                  mediaId: widget.mediaId,
+                  secondaryText: secondaryText,
+                  isActive: isActive,
+                  inEcho: inEcho,
+                  groupedInEcho: false,
+                  selectable: selectable,
+                  recordingCount: lineRecordingCounts?[lineIndex],
+                  onLookupRequested: selectable
+                      ? (t) => openTranscriptLookup(
+                          ref: ref,
+                          context: context,
+                          selectedText: t,
+                          lines: widget.lines,
+                        )
+                      : null,
+                  onRetranslateSecondary: canRetranslateLine
+                      ? () => unawaited(
+                          ref
+                              .read(
+                                autoTranslateCtrlProvider(
+                                  widget.mediaId,
+                                ).notifier,
+                              )
+                              .retranslateLine(lineIndex),
+                        )
+                      : null,
+                  onTap: () => ref
+                      .read(playerInteractionsProvider.notifier)
+                      .seekToLine(line, lineIndex),
+                );
+
+                if (isActive) {
+                  tile = KeyedSubtree(
+                    key: _scrollKeyForActiveLine(lineIndex),
+                    child: tile,
                   );
-                  if (!_shouldRequestAutoTranslate(lineIndex, highlight)) {
-                    return;
-                  }
-                  ref
-                      .read(autoTranslateCtrlProvider(widget.mediaId).notifier)
-                      .requestTranslateLine(lineIndex);
-                });
-              }
-              final secondaryText = secondaryEmpty && l10n != null
-                  ? (lineFailed
-                        ? l10n.subtitlesAutoTranslateLineFailed
-                        : (lineInFlight
-                              ? l10n.subtitlesAutoTranslatePendingLine
-                              : secondaryTextRaw))
-                  : secondaryTextRaw;
-              final canRetranslateLine =
-                  autoTranslateActive &&
-                  (lineFailed || (secondaryText != null && !secondaryEmpty));
+                }
 
-              final selectable = isActive;
-              Widget tile = TranscriptLineTile(
-                line: line,
-                mediaId: widget.mediaId,
-                secondaryText: secondaryText,
-                isActive: isActive,
-                inEcho: inEcho,
-                groupedInEcho: false,
-                selectable: selectable,
-                recordingCount: lineRecordingCounts?[lineIndex],
-                onLookupRequested: selectable
-                    ? (t) => openTranscriptLookup(
-                        ref: ref,
-                        context: context,
-                        selectedText: t,
-                        lines: widget.lines,
-                      )
-                    : null,
-                onRetranslateSecondary: canRetranslateLine
-                    ? () => unawaited(
-                        ref
-                            .read(
-                              autoTranslateCtrlProvider(
-                                widget.mediaId,
-                              ).notifier,
-                            )
-                            .retranslateLine(lineIndex),
-                      )
-                    : null,
-                onTap: () => ref
-                    .read(playerInteractionsProvider.notifier)
-                    .seekToLine(line, lineIndex),
-              );
-
-              if (isActive) {
-                tile = KeyedSubtree(
-                  key: _scrollKeyForActiveLine(lineIndex),
+                return Padding(
+                  key: ValueKey<String>('line-$lineIndex'),
+                  padding: EdgeInsets.only(bottom: tok.space8),
                   child: tile,
                 );
-              }
-
-              return Padding(
-                key: ValueKey<String>('line-$lineIndex'),
-                padding: EdgeInsets.only(bottom: tok.space8),
-                child: tile,
-              );
-          }
-        },
+            }
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary

Resolves #282 (#279-C slice) - eliminates transcript/player rebuild storms and scroll-fighting during playback.

## Changes

### P5 - Manual-scroll suppression for auto-follow
- Added `_suppressAutoScroll` flag driven by `UserScrollNotification` in `TranscriptScrollableList`
- Auto-follow's `force: true` scroll is suppressed while the user manually scrolls
- Auto-follow re-engages when the active cue leaves the visible viewport, the user explicitly seeks (jumps >1 line), or echo mode changes

### P7 - Unified position stream
- Created `rawEnginePositionStreamProvider` - a single canonical source for the engine's raw position stream
- Both `displayPositionProvider` and `transportSliderPositionProvider` now derive from the shared stream instead of independently subscribing to `engine.position`

### P10/P11/M6 - Value equality & .select optimization
- Added `==` and `hashCode` to `PlaybackSession` (excluding `lastActiveAt` from equality)
- Added `==` and `hashCode` to `EchoState` (replaced hand-rolled `_echoLayoutEqual`)
- Changed `ref.watch(playerControllerProvider)` to `.select` in:
  - `TranscriptPanel` - only needs `dexieTargetType`
  - `SharePracticePosterButton` - only needs `mediaId` + `dexieTargetType`
  - `SubtitleTrackPickerSheet` - only needs `dexieTargetType`
- Changed `ref.watch(autoTranslateCtrlProvider)` to `.select` on stable mode fields in both `TranscriptScrollableList` and `EchoRegionMergedCard`

### P12 - Cache `_lines()` per session
- `PlayerInteractions._lines()` now caches transcript lines per mediaId, avoiding repeated DB reads on every prev/next/replay/echo tap

### M8 - De-dupe auto-translate secondary-text resolver
- Extracted `resolveAutoTranslateTextForDisplay` helper to `auto_translate_resolved_text.dart`
- Both `TranscriptScrollableList` and `EchoRegionMergedCard` now use the same resolution logic

## Validation
- `flutter analyze` - clean
- `dart format` - applied
- All 1098 tests pass (0 failures)