### PR TITLE
fix(player): lazy native init, stale-open rollback & async error guards (#283)

### DIFF
--- a/lib/features/player/application/player_engine.dart
+++ b/lib/features/player/application/player_engine.dart
@@ -83,13 +83,20 @@ double aspectRatioFromVideoParams(mk.VideoParams vp, mk.PlayerState state) {
 }
 
 /// Single [mk.Player] instance — ADR-0003 / ADR-0015.
+///
+/// The native mpv player is constructed lazily on first access (not in the
+/// constructor) so swapping between YouTube and local media does not stall the
+/// main isolate with an unnecessary native allocation (issue #283, P8).
 class MediaKitPlayerEngine implements PlayerEngine {
-  MediaKitPlayerEngine() : _player = mk.Player();
+  MediaKitPlayerEngine();
 
-  final mk.Player _player;
-  VideoController? _videoController;
+  mk.Player? __player;
+
+  mk.Player get _player => __player ??= mk.Player();
 
   mk.Player get player => _player;
+
+  VideoController? _videoController;
 
   static VideoControllerConfiguration get _videoControllerConfiguration {
     if (Platform.isWindows) {
@@ -260,6 +267,7 @@ class MediaKitPlayerEngine implements PlayerEngine {
 
   @override
   Future<void> dispose() async {
-    await _player.dispose();
+    await __player?.dispose();
+    __player = null;
   }
 }

--- a/lib/features/player/application/player_open_coordinator.dart
+++ b/lib/features/player/application/player_open_coordinator.dart
@@ -97,7 +97,14 @@ Future<void> runPlayerOpen(PlayerOpenHost host, Ref ref, String mediaId) async {
   await host.positionTracker.cancel();
 
   await engine.open(playable);
-  if (host.isOpenStale(gen)) return;
+  if (host.isOpenStale(gen)) {
+    try {
+      await engine.stop();
+    } catch (_) {
+      // Engine may have been disposed by a new open generation; best-effort.
+    }
+    return;
+  }
 
   if (engine.supportsSubtitleDisabling) {
     await engine.disableRenderedSubtitles();

--- a/lib/features/player/application/player_open_side_effects.dart
+++ b/lib/features/player/application/player_open_side_effects.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/utils/youtube_video_identity.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
@@ -54,10 +55,16 @@ Future<void> _runTranscriptResolve(
   required bool Function() isStale,
   required bool signedIn,
 }) async {
-  if (isStale()) return;
-  await ref
-      .read(transcriptFetchCtrlProvider(mediaId).notifier)
-      .resolveOnOpen(signedIn: signedIn);
+  try {
+    if (isStale()) return;
+    await ref
+        .read(transcriptFetchCtrlProvider(mediaId).notifier)
+        .resolveOnOpen(signedIn: signedIn);
+  } on Object catch (e, st) {
+    logNamed(
+      'PlayerOpenSideEffects',
+    ).warning('transcript resolve failed for $mediaId', e, st);
+  }
 }
 
 Future<void> _runRecordingPull(
@@ -66,10 +73,19 @@ Future<void> _runRecordingPull(
   required String mediaId,
   required bool Function() isStale,
 }) async {
-  if (isStale()) return;
-  await ref
-      .read(recordingTargetSyncServiceProvider)
-      .pullRecordingsForTarget(targetType: dexieTargetType, targetId: mediaId);
+  try {
+    if (isStale()) return;
+    await ref
+        .read(recordingTargetSyncServiceProvider)
+        .pullRecordingsForTarget(
+          targetType: dexieTargetType,
+          targetId: mediaId,
+        );
+  } on Object catch (e, st) {
+    logNamed(
+      'PlayerOpenSideEffects',
+    ).warning('recording pull failed for $mediaId', e, st);
+  }
 }
 
 /// Lazy oEmbed retry after YouTube WebView reports playback-ready.

--- a/lib/features/player/application/player_position_tracker.dart
+++ b/lib/features/player/application/player_position_tracker.dart
@@ -92,7 +92,16 @@ class PlayerPositionTracker {
         // Echo enforcement runs on every position event — the decision is cheap
         // and this is what keeps pause-and-rewind within ~50 ms of the segment
         // end. Single-flight inside the enforcer drops concurrent ticks.
-        unawaited(_echoEnforcer.enforceTick(seconds));
+        // Guarded so a single engine error cannot surface as an uncaught async
+        // exception and stall enforcement for the rest of the session (M7).
+        unawaited(
+          _echoEnforcer.enforceTick(seconds).catchError((
+            Object e,
+            StackTrace st,
+          ) {
+            _positionLog.warning('echo enforcement tick failed', e, st);
+          }),
+        );
 
         // Heavy session emit + persistence stays on the 400 ms bucket (or fires
         // immediately on a detected seek) so the recorded clip window lines up.


### PR DESCRIPTION
Resolves #283 (the P8/M2/M7 set from #279).

## Changes

### P8 — Lazy `mk.Player` init
Defer `mk.Player` construction out of the `MediaKitPlayerEngine` constructor to the first `open` (lazy native init), removing main-isolate stalls on YouTube↔local swaps and `warmVideoSurface` calls.

### M2 — Stale-open rollback
Segment the `runPlayerOpen` pipeline so that a stale check landing after `engine.open` succeeds calls `engine.stop()` instead of returning and leaving mpv playing unwanted media.

### M7 — Async error guards
- **Position tracker**: Guard the `unawaited` echo enforcement tick with `.catchError` so a seek/pause throw from the engine cannot surface as an unhandled async exception.
- **Open side-effects**: Wrap `_runTranscriptResolve` and `_runRecordingPull` in try/catch with `logNamed` warnings so a single Drift/API throw cannot become an uncaught async exception.

## Verification

- `dart format` — clean
- `flutter analyze` — no issues
- `flutter test` — 1098 passed, 0 failed