### PR TITLE
[cleanup] Split TranscriptLineTile, name constants, fix mounted guard & dead scan (#279-E)

### DIFF
--- a/lib/features/player/application/player_engine.dart
+++ b/lib/features/player/application/player_engine.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart' as mk;
 import 'package:media_kit_video/media_kit_video.dart';
 
+import 'package:enjoy_player/features/player/application/player_engine_constants.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 
 /// Contract implemented by [MediaKitPlayerEngine] / [YouTubePlayerEngine]; fakes in tests.
@@ -93,14 +94,17 @@ class MediaKitPlayerEngine implements PlayerEngine {
 
   static VideoControllerConfiguration get _videoControllerConfiguration {
     if (Platform.isWindows) {
-      return const VideoControllerConfiguration(width: 1920, height: 1080);
+      return const VideoControllerConfiguration(
+        width: kVideoControllerWidth,
+        height: kVideoControllerHeight,
+      );
     }
     if (Platform.isMacOS) {
       // Bind libmpv video output before decode; prefer software GL texture path
       // on recent macOS where deprecated OpenGL HW textures can stay black.
       return const VideoControllerConfiguration(
-        width: 1920,
-        height: 1080,
+        width: kVideoControllerWidth,
+        height: kVideoControllerHeight,
         hwdec: 'auto-safe',
         enableHardwareAcceleration: false,
       );
@@ -159,7 +163,7 @@ class MediaKitPlayerEngine implements PlayerEngine {
   @override
   Stream<double> get videoAspectRatioStream => _player.stream.videoParams
       .map((vp) => aspectRatioFromVideoParams(vp, _player.state))
-      .distinct((a, b) => (a - b).abs() < 0.0001);
+      .distinct((a, b) => (a - b).abs() < kAspectRatioEpsilon);
 
   @override
   Widget buildVideoStage({
@@ -233,7 +237,7 @@ class MediaKitPlayerEngine implements PlayerEngine {
 
   @override
   Future<void> setVolumeNormalized(double volume) =>
-      _player.setVolume(volume.clamp(0, 1) * 100);
+      _player.setVolume(volume.clamp(0, 1) * kVolumeScale);
 
   @override
   Future<void> playOrPause() => _player.playOrPause();

--- a/lib/features/player/application/player_engine_constants.dart
+++ b/lib/features/player/application/player_engine_constants.dart
@@ -1,0 +1,16 @@
+/// Tuning constants for [MediaKitPlayerEngine] video controller dimensions,
+/// aspect-ratio dedup epsilon, and normalised-volume mapping.
+library;
+
+/// Default width for the [media_kit] [VideoController] on non-mobile platforms.
+const int kVideoControllerWidth = 1920;
+
+/// Default height for the [media_kit] [VideoController] on non-mobile platforms.
+const int kVideoControllerHeight = 1080;
+
+/// Two aspect ratios within this epsilon are considered equal (dedup guard for
+/// the [MediaKitPlayerEngine.videoAspectRatioStream]).
+const double kAspectRatioEpsilon = 0.0001;
+
+/// Scale factor mapping a 0.0–1.0 normalised volume to `media_kit` volume units.
+const double kVolumeScale = 100;

--- a/lib/features/transcript/application/transcript_cue_selection.dart
+++ b/lib/features/transcript/application/transcript_cue_selection.dart
@@ -26,15 +26,7 @@ int transcriptActiveIndex(List<TranscriptLine> lines, double t) {
     }
   }
 
-  if (rightmost >= 0 && t < lines[rightmost].endSeconds) {
-    return rightmost;
-  }
-
-  // Gap after last matched start, or before first cue: fall back to last cue with start <= t.
-  for (var i = lines.length - 1; i >= 0; i--) {
-    if (t >= lines[i].startSeconds) return i;
-  }
-  return -1;
+  return rightmost;
 }
 
 /// When echo mode is on, only cues inside `[startLineIndex, endLineIndex]` may show

--- a/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
+++ b/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
@@ -120,6 +120,7 @@ class EchoRegionMergedCard extends ConsumerWidget {
           (secondaryText == null || secondaryText.trim().isEmpty) &&
           !lineFailed) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!ref.context.mounted) return;
           ref
               .read(autoTranslateCtrlProvider(mediaId).notifier)
               .requestTranslateLine(i);

--- a/lib/features/transcript/presentation/transcript_line_selection_toolbar.dart
+++ b/lib/features/transcript/presentation/transcript_line_selection_toolbar.dart
@@ -1,0 +1,224 @@
+/// Selection-aware [SelectableText.rich] with custom Look Up / Copy toolbar
+/// for desktop mouse-drag selections. Extracted from [TranscriptLineTile].
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:enjoy_player/core/interaction/haptics.dart';
+import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/features/hotkeys/application/hotkey_focus_policy.dart';
+import 'package:enjoy_player/features/transcript/presentation/transcript_text_selection_scope.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+
+class TranscriptSelectableRichText extends StatefulWidget {
+  const TranscriptSelectableRichText({
+    required this.span,
+    this.onTap,
+    this.onLookupRequested,
+    super.key,
+  });
+
+  final TextSpan span;
+  final VoidCallback? onTap;
+  final ValueChanged<String>? onLookupRequested;
+
+  @override
+  State<TranscriptSelectableRichText> createState() =>
+      _TranscriptSelectableRichTextState();
+}
+
+class _TranscriptSelectableRichTextState
+    extends State<TranscriptSelectableRichText> {
+  Timer? _selectionToolbarTimer;
+
+  static const _toolbarDebounce = Duration(milliseconds: 200);
+
+  @override
+  void dispose() {
+    _selectionToolbarTimer?.cancel();
+    super.dispose();
+  }
+
+  static EditableTextState? _findEditableTextState(BuildContext context) {
+    EditableTextState? found;
+    void visit(Element element) {
+      if (found != null) return;
+      if (element is StatefulElement && element.state is EditableTextState) {
+        found = element.state as EditableTextState;
+        return;
+      }
+      element.visitChildren(visit);
+    }
+
+    final element = context as Element?;
+    if (element == null) return null;
+    visit(element);
+    return found;
+  }
+
+  void _onSelectionChanged(
+    BuildContext selectableSubtreeContext,
+    TextSelection selection,
+    SelectionChangedCause? cause,
+  ) {
+    _selectionToolbarTimer?.cancel();
+    _selectionToolbarTimer = null;
+
+    if (cause == SelectionChangedCause.keyboard) return;
+    if (!selection.isValid || selection.isCollapsed) return;
+
+    if (cause == SelectionChangedCause.drag) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (!selectableSubtreeContext.mounted) return;
+        final editable = _findEditableTextState(selectableSubtreeContext);
+        if (editable == null || !editable.mounted) return;
+        editable.hideToolbar();
+      });
+    }
+
+    _selectionToolbarTimer = Timer(_toolbarDebounce, () {
+      _selectionToolbarTimer = null;
+      if (!mounted) return;
+      if (!selectableSubtreeContext.mounted) return;
+      final editable = _findEditableTextState(selectableSubtreeContext);
+      if (editable == null || !editable.mounted) return;
+      final sel = editable.textEditingValue.selection;
+      if (!sel.isValid || sel.isCollapsed) return;
+      editable.showToolbar();
+    });
+  }
+
+  static String? _rawSelectedSlice(String plain, TextSelection selection) {
+    if (!selection.isValid || selection.isCollapsed) return null;
+    final max = plain.length;
+    final start = selection.start.clamp(0, max);
+    final end = selection.end.clamp(0, max);
+    if (end <= start) return null;
+    return plain.substring(start, end);
+  }
+
+  static String? _lookupSlice(String plain, TextSelection selection) {
+    final raw = _rawSelectedSlice(plain, selection);
+    if (raw == null) return null;
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty || trimmed.length > 100) return null;
+    return trimmed;
+  }
+
+  List<ContextMenuButtonItem> _toolbarItems({
+    required BuildContext menuContext,
+    required EditableTextState editableTextState,
+    required AppLocalizations l10n,
+  }) {
+    final value = editableTextState.textEditingValue;
+    final plain = value.text;
+    final selection = value.selection;
+    final items = <ContextMenuButtonItem>[];
+
+    final lookupText = widget.onLookupRequested == null
+        ? null
+        : _lookupSlice(plain, selection);
+    if (lookupText != null) {
+      items.add(
+        ContextMenuButtonItem(
+          label: l10n.lookupSheetTitle,
+          onPressed: () {
+            Haptics.selection(menuContext);
+            editableTextState.hideToolbar();
+            releasePrimaryFocusForGlobalHotkeys();
+            widget.onLookupRequested!(lookupText);
+          },
+        ),
+      );
+    }
+
+    if (editableTextState.copyEnabled) {
+      items.add(
+        ContextMenuButtonItem(
+          type: ContextMenuButtonType.copy,
+          label: l10n.lookupCopy,
+          onPressed: () async {
+            Haptics.selection(menuContext);
+            final raw = _rawSelectedSlice(
+              plain,
+              editableTextState.textEditingValue.selection,
+            );
+            if (raw != null && raw.isNotEmpty) {
+              await Clipboard.setData(ClipboardData(text: raw));
+            } else {
+              editableTextState.copySelection(SelectionChangedCause.toolbar);
+            }
+            editableTextState.hideToolbar();
+            if (menuContext.mounted) {
+              AppNotice.success(menuContext, l10n.lookupCopySuccess);
+            }
+          },
+        ),
+      );
+    }
+
+    if (editableTextState.selectAllEnabled) {
+      items.add(
+        ContextMenuButtonItem(
+          type: ContextMenuButtonType.selectAll,
+          onPressed: () {
+            Haptics.selection(menuContext);
+            editableTextState.selectAll(SelectionChangedCause.toolbar);
+          },
+        ),
+      );
+    }
+
+    return items;
+  }
+
+  Widget _toolbarBuilder(
+    BuildContext menuContext,
+    EditableTextState editableTextState,
+  ) {
+    final l10n = AppLocalizations.of(menuContext);
+    if (l10n == null) {
+      return AdaptiveTextSelectionToolbar.editableText(
+        editableTextState: editableTextState,
+      );
+    }
+    final items = _toolbarItems(
+      menuContext: menuContext,
+      editableTextState: editableTextState,
+      l10n: l10n,
+    );
+    if (items.isEmpty) {
+      return AdaptiveTextSelectionToolbar.editableText(
+        editableTextState: editableTextState,
+      );
+    }
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: items,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (selectableSubtreeContext) {
+        return TranscriptTextSelectionScope(
+          child: SelectableText.rich(
+            widget.span,
+            onTap: widget.onTap,
+            contextMenuBuilder: (menuContext, editableTextState) {
+              return _toolbarBuilder(menuContext, editableTextState);
+            },
+            onSelectionChanged: (selection, cause) {
+              _onSelectionChanged(selectableSubtreeContext, selection, cause);
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/transcript/presentation/transcript_line_tile.dart
+++ b/lib/features/transcript/presentation/transcript_line_tile.dart
@@ -1,27 +1,22 @@
 /// Single transcript cue row with timestamp, markup, and tap target.
 library;
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/interaction/enjoy_tappable.dart';
 import 'package:enjoy_player/core/interaction/haptics.dart';
-import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/typography.dart';
 import 'package:enjoy_player/data/subtitle/transcript_line.dart';
-import 'package:enjoy_player/features/hotkeys/application/hotkey_focus_policy.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_blur_mode_provider.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_cue_reveal_provider.dart';
 import 'package:enjoy_player/features/transcript/application/tap_reveal_hold_provider.dart';
 import 'package:enjoy_player/features/transcript/domain/transcript_blur.dart';
 import 'package:enjoy_player/features/transcript/presentation/transcript_blur_text.dart';
 import 'package:enjoy_player/features/transcript/presentation/transcript_line_recording_badge.dart';
+import 'package:enjoy_player/features/transcript/presentation/transcript_line_selection_toolbar.dart';
 import 'package:enjoy_player/features/transcript/presentation/transcript_markup.dart';
-import 'package:enjoy_player/features/transcript/presentation/transcript_text_selection_scope.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 class TranscriptLineTile extends ConsumerStatefulWidget {
@@ -71,34 +66,10 @@ class TranscriptLineTile extends ConsumerStatefulWidget {
 
 class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
   bool _hover = false;
-  Timer? _selectionToolbarTimer;
-
-  static const _toolbarDebounce = Duration(milliseconds: 200);
 
   @override
   void dispose() {
-    _selectionToolbarTimer?.cancel();
     super.dispose();
-  }
-
-  /// [SelectableText]'s [EditableText] is internal; locate it to open the
-  /// selection toolbar on desktop mouse drag (Flutter otherwise only auto-shows
-  /// the toolbar for touch/stylus or double-tap+drag).
-  static EditableTextState? _findEditableTextState(BuildContext context) {
-    EditableTextState? found;
-    void visit(Element element) {
-      if (found != null) return;
-      if (element is StatefulElement && element.state is EditableTextState) {
-        found = element.state as EditableTextState;
-        return;
-      }
-      element.visitChildren(visit);
-    }
-
-    final element = context as Element?;
-    if (element == null) return null;
-    visit(element);
-    return found;
   }
 
   void _handleTap(BuildContext context) {
@@ -125,177 +96,6 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
           cueId: cueIdFor(widget.line),
           holdSeconds: kTapRevealHoldSeconds,
         );
-  }
-
-  void _onSelectableSelectionChanged(
-    BuildContext selectableSubtreeContext,
-    TextSelection selection,
-    SelectionChangedCause? cause,
-  ) {
-    _selectionToolbarTimer?.cancel();
-    _selectionToolbarTimer = null;
-
-    if (!widget.selectable) return;
-    // Match [SelectableText] handle visibility: keyboard-driven selection does
-    // not surface the floating toolbar by default.
-    if (cause == SelectionChangedCause.keyboard) return;
-    if (!selection.isValid || selection.isCollapsed) return;
-
-    if (cause == SelectionChangedCause.drag) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        if (!selectableSubtreeContext.mounted) return;
-        final editable = _findEditableTextState(selectableSubtreeContext);
-        if (editable == null || !editable.mounted) return;
-        editable.hideToolbar();
-      });
-    }
-
-    _selectionToolbarTimer = Timer(_toolbarDebounce, () {
-      _selectionToolbarTimer = null;
-      if (!mounted) return;
-      if (!selectableSubtreeContext.mounted) return;
-      final editable = _findEditableTextState(selectableSubtreeContext);
-      if (editable == null || !editable.mounted) return;
-      final sel = editable.textEditingValue.selection;
-      if (!sel.isValid || sel.isCollapsed) return;
-      editable.showToolbar();
-    });
-  }
-
-  /// Raw substring for the current [selection] (no trim), or `null` if invalid.
-  static String? _rawSelectedSlice(String plain, TextSelection selection) {
-    if (!selection.isValid || selection.isCollapsed) return null;
-    final max = plain.length;
-    final start = selection.start.clamp(0, max);
-    final end = selection.end.clamp(0, max);
-    if (end <= start) return null;
-    return plain.substring(start, end);
-  }
-
-  /// Trimmed slice suitable for lookup, max 100 characters, or `null`.
-  static String? _lookupSlice(String plain, TextSelection selection) {
-    final raw = _rawSelectedSlice(plain, selection);
-    if (raw == null) return null;
-    final trimmed = raw.trim();
-    if (trimmed.isEmpty || trimmed.length > 100) return null;
-    return trimmed;
-  }
-
-  List<ContextMenuButtonItem> _selectionToolbarItems({
-    required BuildContext menuContext,
-    required EditableTextState editableTextState,
-    required AppLocalizations l10n,
-  }) {
-    final value = editableTextState.textEditingValue;
-    final plain = value.text;
-    final selection = value.selection;
-    final items = <ContextMenuButtonItem>[];
-
-    final lookupText = widget.onLookupRequested == null
-        ? null
-        : _lookupSlice(plain, selection);
-    if (lookupText != null) {
-      items.add(
-        ContextMenuButtonItem(
-          label: l10n.lookupSheetTitle,
-          onPressed: () {
-            Haptics.selection(menuContext);
-            editableTextState.hideToolbar();
-            releasePrimaryFocusForGlobalHotkeys();
-            widget.onLookupRequested!(lookupText);
-          },
-        ),
-      );
-    }
-
-    if (editableTextState.copyEnabled) {
-      items.add(
-        ContextMenuButtonItem(
-          type: ContextMenuButtonType.copy,
-          label: l10n.lookupCopy,
-          onPressed: () async {
-            Haptics.selection(menuContext);
-            final raw = _rawSelectedSlice(
-              plain,
-              editableTextState.textEditingValue.selection,
-            );
-            if (raw != null && raw.isNotEmpty) {
-              await Clipboard.setData(ClipboardData(text: raw));
-            } else {
-              editableTextState.copySelection(SelectionChangedCause.toolbar);
-            }
-            editableTextState.hideToolbar();
-            if (menuContext.mounted) {
-              AppNotice.success(menuContext, l10n.lookupCopySuccess);
-            }
-          },
-        ),
-      );
-    }
-
-    if (editableTextState.selectAllEnabled) {
-      items.add(
-        ContextMenuButtonItem(
-          type: ContextMenuButtonType.selectAll,
-          onPressed: () {
-            Haptics.selection(menuContext);
-            editableTextState.selectAll(SelectionChangedCause.toolbar);
-          },
-        ),
-      );
-    }
-
-    return items;
-  }
-
-  Widget _selectionToolbar(
-    BuildContext menuContext,
-    EditableTextState editableTextState,
-  ) {
-    final l10n = AppLocalizations.of(menuContext);
-    if (l10n == null) {
-      return AdaptiveTextSelectionToolbar.editableText(
-        editableTextState: editableTextState,
-      );
-    }
-    final items = _selectionToolbarItems(
-      menuContext: menuContext,
-      editableTextState: editableTextState,
-      l10n: l10n,
-    );
-    if (items.isEmpty) {
-      return AdaptiveTextSelectionToolbar.editableText(
-        editableTextState: editableTextState,
-      );
-    }
-    return AdaptiveTextSelectionToolbar.buttonItems(
-      anchors: editableTextState.contextMenuAnchors,
-      buttonItems: items,
-    );
-  }
-
-  Widget _richSelectable({required TextSpan span, VoidCallback? onTap}) {
-    return Builder(
-      builder: (selectableSubtreeContext) {
-        return TranscriptTextSelectionScope(
-          child: SelectableText.rich(
-            span,
-            onTap: onTap,
-            contextMenuBuilder: (menuContext, editableTextState) {
-              return _selectionToolbar(menuContext, editableTextState);
-            },
-            onSelectionChanged: (selection, cause) {
-              _onSelectableSelectionChanged(
-                selectableSubtreeContext,
-                selection,
-                cause,
-              );
-            },
-          ),
-        );
-      },
-    );
   }
 
   String _snippet(String plain) {
@@ -375,7 +175,7 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
     }
 
     final primaryWidget = widget.selectable
-        ? _richSelectable(
+        ? TranscriptSelectableRichText(
             span: transcriptMarkupToTextSpan(
               widget.line.text,
               baseBody,
@@ -383,6 +183,7 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
               emphasize: widget.isActive,
             ),
             onTap: _revealHoldOnly,
+            onLookupRequested: widget.onLookupRequested,
           )
         : Text.rich(
             transcriptMarkupToTextSpan(
@@ -396,7 +197,7 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
     Widget? secondaryWidget;
     if (widget.secondaryText != null) {
       secondaryWidget = widget.selectable
-          ? _richSelectable(
+          ? TranscriptSelectableRichText(
               span: transcriptMarkupToTextSpan(
                 widget.secondaryText!,
                 typography.secondaryStyle,
@@ -404,6 +205,7 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
                 emphasize: false,
               ),
               onTap: _revealHoldOnly,
+              onLookupRequested: widget.onLookupRequested,
             )
           : Text.rich(
               transcriptMarkupToTextSpan(

--- a/lib/features/transcript/presentation/transcript_scrollable_list.dart
+++ b/lib/features/transcript/presentation/transcript_scrollable_list.dart
@@ -26,6 +26,15 @@ import 'package:enjoy_player/features/transcript/presentation/transcript_echo_re
 import 'package:enjoy_player/features/transcript/presentation/transcript_line_tile.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
+/// Viewport alignment used by [Scrollable.ensureVisible] and the bootstrap
+/// jump estimate so the active cue sits roughly 42 % from the top of the list.
+const double kTranscriptScrollAlignment = 0.42;
+
+/// Fraction of the viewport height subtracted from the jump estimate to avoid
+/// overshoot when the active cue is bootstrapped via raw line index (single-line
+/// tile height) rather than the actual widget height.
+const double kTranscriptScrollEstimateFactor = 0.85;
+
 sealed class _TranscriptVirtualItem {
   const _TranscriptVirtualItem();
 }
@@ -227,7 +236,8 @@ class _TranscriptScrollableListState
     final pos = _scrollController.position;
     final ratio = lineIndex / lineCount;
     final estimated = ratio * pos.maxScrollExtent;
-    final alignmentAdjust = alignment * pos.viewportDimension * 0.85;
+    final alignmentAdjust =
+        alignment * pos.viewportDimension * kTranscriptScrollEstimateFactor;
     _scrollController.jumpTo(
       (estimated - alignmentAdjust).clamp(0.0, pos.maxScrollExtent),
     );
@@ -307,7 +317,7 @@ class _TranscriptScrollableListState
     if (ctx != null) {
       _ensureVisible(
         ctx,
-        alignment: 0.42,
+        alignment: kTranscriptScrollAlignment,
         duration: tok.motionStandard,
         curve: Curves.easeOutCubic,
         generation: generation,
@@ -315,7 +325,7 @@ class _TranscriptScrollableListState
       return;
     }
 
-    _jumpToLineIndexEstimate(active, alignment: 0.42);
+    _jumpToLineIndexEstimate(active, alignment: kTranscriptScrollAlignment);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || generation != _scrollGeneration) return;
@@ -323,7 +333,7 @@ class _TranscriptScrollableListState
       if (ctx2 == null) return;
       _ensureVisible(
         ctx2,
-        alignment: 0.42,
+        alignment: kTranscriptScrollAlignment,
         duration: tok.motionStandard,
         curve: Curves.easeOutCubic,
         generation: generation,

--- a/test/features/transcript/transcript_cue_selection_test.dart
+++ b/test/features/transcript/transcript_cue_selection_test.dart
@@ -23,6 +23,16 @@ void main() {
       expect(transcriptActiveIndex(lines, 1.5), 0);
     });
 
+    test('returns last cue when t is in a non-empty gap between cues', () {
+      final lines = [
+        cue(0, 1000),
+        cue(1000, 1000),
+        cue(3000, 1000),
+        cue(4000, 1000),
+      ];
+      expect(transcriptActiveIndex(lines, 2.5), 1);
+    });
+
     test('returns -1 when t is before first cue', () {
       final lines = [cue(1000, 500)];
       expect(transcriptActiveIndex(lines, 0.5), -1);


### PR DESCRIPTION
Closes #284.

## Summary

Part of #279. Lower-risk cleanup covering four findings:

### M9b — Magic number extraction
- Created `player_engine_constants.dart` (`kVideoControllerWidth`, `kVideoControllerHeight`, `kAspectRatioEpsilon`, `kVolumeScale`)
- Added `kTranscriptScrollAlignment` (0.42) and `kTranscriptScrollEstimateFactor` (0.85) to `transcript_scrollable_list.dart`
- `playback_session_persister.dart` already had `kPlaybackSessionDebounceMs` — no action needed

### M10 — Missing mounted guard
- Added `if (!ref.context.mounted) return;` to the post-frame callback in `transcript_echo_region_merged_card.dart` matching the existing `_deferEchoResize` pattern

### M11 — Split TranscriptLineTile
- Extracted desktop selection-toolbar logic (~190 lines) into new `TranscriptSelectableRichText` widget in `transcript_line_selection_toolbar.dart`
- `transcript_line_tile.dart` reduced from 558 → 360 lines

### P14 — Dead linear scan
- Removed dead O(n) backward linear scan after binary search in `transcript_cue_selection.dart` (always returned `rightmost`)
- Added gap-case test (t between two cue ranges with a non-empty gap)

## Verification
- `dart analyze`: no issues
- `dart format`: clean