### PR TITLE
refactor(ai): dedupe BYOK speech guards, HTTP helpers, and LLM JSON extraction

### DIFF
--- a/lib/core/json/json_from_llm.dart
+++ b/lib/core/json/json_from_llm.dart
@@ -1,0 +1,45 @@
+/// JSON-object extraction for LLM responses.
+///
+/// LLMs prompted to "reply with JSON" frequently wrap their answer in a
+/// ```json fenced code block, sometimes with a leading language tag, sometimes
+/// not. The exact fence shape drifts between providers (and between
+/// individual model runs), so callers historically reinvented the same
+/// "strip fences, fall back to the outermost `{…}` braces" recipe.
+///
+/// [extractJsonObject] centralizes that recipe so any LLM-backed capability
+/// can pull a JSON object out of a fenced / unfenced / partially-fenced
+/// response without re-implementing fence-stripping.
+library;
+
+/// Returns the JSON-object substring of [raw].
+///
+/// Strategy:
+/// 1. If the trimmed response starts with `{`, it is returned verbatim.
+/// 2. Otherwise the first ``` fence (with its optional language tag) is
+///    stripped and the content between the opening and closing fence is
+///    returned.
+/// 3. Otherwise the substring between the first `{` and the last `}` is
+///    returned as a best-effort object slice.
+///
+/// Throws [FormatException] if the response contains no `{` and no fences.
+String extractJsonObject(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.startsWith('{')) return trimmed;
+
+  final fenceStart = trimmed.indexOf('```');
+  if (fenceStart >= 0) {
+    final afterFence = trimmed.indexOf('\n', fenceStart);
+    final endFence = trimmed.lastIndexOf('```');
+    if (afterFence >= 0 && endFence > afterFence) {
+      return trimmed.substring(afterFence + 1, endFence).trim();
+    }
+  }
+
+  final start = trimmed.indexOf('{');
+  final end = trimmed.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    return trimmed.substring(start, end + 1);
+  }
+
+  throw const FormatException('LLM response is not JSON');
+}

--- a/lib/core/validation/byok_http.dart
+++ b/lib/core/validation/byok_http.dart
@@ -1,0 +1,19 @@
+/// BYOK HTTP policy helpers co-located with the URL guard so the
+/// "is the URL allowed + how do we normalize it" pair lives together.
+///
+/// `byok_llm_model_factory.dart` historically owned [normalizeByokBaseUrl];
+/// it lives here now that the Whisper / speech / model-fetch HTTP clients
+/// also need it (see `lib/features/ai/data/byok/byok_http_client.dart`).
+library;
+
+export 'package:enjoy_player/core/validation/byok_url_guard.dart'
+    show isByokBaseUrlAllowed;
+
+/// Strip trailing `/` characters from a BYOK base URL.
+String normalizeByokBaseUrl(String raw) {
+  var url = raw.trim();
+  while (url.endsWith('/')) {
+    url = url.substring(0, url.length - 1);
+  }
+  return url;
+}

--- a/lib/features/ai/data/byok/byok_asr_azure_capability.dart
+++ b/lib/features/ai/data/byok/byok_asr_azure_capability.dart
@@ -5,13 +5,12 @@ import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/data/api/byok_secret_store.dart';
 import 'package:enjoy_player/features/ai/data/azure_assessment_wav_normalizer.dart';
 import 'package:enjoy_player/features/ai/data/azure_language_mapper.dart';
-import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_speech_guards.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/asr_capability.dart';
 import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
 import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
 import 'package:enjoy_player/features/ai/domain/models/asr_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/asr_result.dart';
-import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
@@ -29,22 +28,12 @@ final class ByokAsrAzureCapability implements AsrCapability {
 
   @override
   Future<AsrResult> transcribe(AsrRequest request) async {
-    if (_config.kind != SpeechByokKind.azureSpeech) {
-      throw StateError('Azure ASR BYOK requires azureSpeech configuration');
-    }
-
-    final region = _config.region?.trim();
-    if (region == null || region.isEmpty) {
-      throw const ApiException(
-        message: 'Azure region is not configured for ASR BYOK',
-        statusCode: 400,
-      );
-    }
-
-    final subscriptionKey = await _secrets.readApiKey(ModalityKind.asr);
-    if (subscriptionKey == null || subscriptionKey.trim().isEmpty) {
-      throw const ByokNotConfiguredFailure(ModalityKind.asr);
-    }
+    final (:region, apiKey: subscriptionKey) = await guardAzureSpeechConfig(
+      config: _config,
+      secrets: _secrets,
+      kind: ModalityKind.asr,
+      capabilityLabel: 'ASR',
+    );
 
     final azureLanguage = mapTranscriptLanguageToAzure(request.language);
     if (azureLanguage == null) {
@@ -66,7 +55,7 @@ final class ByokAsrAzureCapability implements AsrCapability {
         AzureSpeechTranscriptionParams(
           audioPath: audioPath,
           language: azureLanguage,
-          subscriptionKey: subscriptionKey.trim(),
+          subscriptionKey: subscriptionKey,
           region: region,
         ),
       );

--- a/lib/features/ai/data/byok/byok_asr_openai_capability.dart
+++ b/lib/features/ai/data/byok/byok_asr_openai_capability.dart
@@ -1,14 +1,12 @@
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
-import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/data/api/byok_secret_store.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_speech_guards.dart';
 import 'package:enjoy_player/features/ai/data/byok/byok_whisper_client.dart';
-import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/asr_capability.dart';
 import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
 import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
 import 'package:enjoy_player/features/ai/domain/models/asr_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/asr_result.dart';
-import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
 import 'package:http/http.dart' as http;
 
 /// ASR via user OpenAI-compatible Whisper endpoint.
@@ -25,29 +23,16 @@ final class ByokAsrOpenAiCapability implements AsrCapability {
 
   @override
   Future<AsrResult> transcribe(AsrRequest request) async {
-    if (_config.kind != SpeechByokKind.openAiCompatible) {
-      throw StateError(
-        'OpenAI ASR BYOK requires openAiCompatible configuration',
-      );
-    }
-
-    final baseUrl = _config.baseUrl?.trim();
-    final model = _config.model?.trim();
-    if (baseUrl == null || baseUrl.isEmpty || model == null || model.isEmpty) {
-      throw const ApiException(
-        message: 'ASR BYOK base URL and model are not configured',
-        statusCode: 400,
-      );
-    }
-
-    final apiKey = await _secrets.readApiKey(ModalityKind.asr);
-    if (apiKey == null || apiKey.trim().isEmpty) {
-      throw const ByokNotConfiguredFailure(ModalityKind.asr);
-    }
+    final (:baseUrl, :model, :apiKey) = await guardOpenAiSpeechConfig(
+      config: _config,
+      secrets: _secrets,
+      kind: ModalityKind.asr,
+      capabilityLabel: 'ASR',
+    );
 
     final map = await postWhisperTranscription(
       baseUrl: baseUrl,
-      apiKey: apiKey.trim(),
+      apiKey: apiKey,
       audioBytes: request.audioBytes,
       filename: request.filename,
       model: model,

--- a/lib/features/ai/data/byok/byok_assessment_azure_capability.dart
+++ b/lib/features/ai/data/byok/byok_assessment_azure_capability.dart
@@ -1,14 +1,12 @@
 import 'package:azure_speech/azure_speech.dart';
 import 'package:enjoy_player/data/api/byok_secret_store.dart';
-import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/features/ai/data/azure_assessment_runner.dart';
-import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_speech_guards.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/assessment_capability.dart';
 import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
 import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
 import 'package:enjoy_player/features/ai/domain/models/assessment_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/assessment_result.dart';
-import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
 
 /// Pronunciation assessment via user Azure Speech subscription key + region.
 final class ByokAssessmentAzureCapability implements AssessmentCapability {
@@ -24,28 +22,18 @@ final class ByokAssessmentAzureCapability implements AssessmentCapability {
 
   @override
   Future<AssessmentResult> assess(AssessmentRequest request) async {
-    if (_config.kind != SpeechByokKind.azureSpeech) {
-      throw StateError('Assessment BYOK requires Azure Speech configuration');
-    }
-
-    final region = _config.region?.trim();
-    if (region == null || region.isEmpty) {
-      throw const ApiException(
-        message: 'Azure region is not configured for assessment BYOK',
-        statusCode: 400,
-      );
-    }
-
-    final subscriptionKey = await _secrets.readApiKey(ModalityKind.assessment);
-    if (subscriptionKey == null || subscriptionKey.trim().isEmpty) {
-      throw const ByokNotConfiguredFailure(ModalityKind.assessment);
-    }
+    final (:region, apiKey: subscriptionKey) = await guardAzureSpeechConfig(
+      config: _config,
+      secrets: _secrets,
+      kind: ModalityKind.assessment,
+      capabilityLabel: 'assessment',
+    );
 
     return runAzurePronunciationAssessment(
       request: request,
       sdk: _sdk,
       region: region,
-      subscriptionKey: subscriptionKey.trim(),
+      subscriptionKey: subscriptionKey,
     );
   }
 }

--- a/lib/features/ai/data/byok/byok_dictionary_capability.dart
+++ b/lib/features/ai/data/byok/byok_dictionary_capability.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
+import 'package:enjoy_player/core/json/json_from_llm.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/dictionary_capability.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/llm_capability.dart';
 import 'package:enjoy_player/features/ai/domain/models/dictionary_result.dart';
@@ -28,33 +29,11 @@ final class ByokDictionaryCapability implements DictionaryCapability {
       maxTokens: 2048,
     );
 
-    final jsonText = _extractJsonObject(raw);
+    final jsonText = extractJsonObject(raw);
     final map = jsonDecode(jsonText) as Map<String, dynamic>;
     map['sourceLanguage'] ??= workerLanguageBase(sourceLanguage);
     map['targetLanguage'] ??= workerLanguageBase(targetLanguage);
     map['word'] ??= word;
     return DictionaryResult.fromJson(map);
-  }
-
-  String _extractJsonObject(String raw) {
-    final trimmed = raw.trim();
-    if (trimmed.startsWith('{')) return trimmed;
-
-    final fenceStart = trimmed.indexOf('```');
-    if (fenceStart >= 0) {
-      final afterFence = trimmed.indexOf('\n', fenceStart);
-      final endFence = trimmed.lastIndexOf('```');
-      if (afterFence >= 0 && endFence > afterFence) {
-        return trimmed.substring(afterFence + 1, endFence).trim();
-      }
-    }
-
-    final start = trimmed.indexOf('{');
-    final end = trimmed.lastIndexOf('}');
-    if (start >= 0 && end > start) {
-      return trimmed.substring(start, end + 1);
-    }
-
-    throw const FormatException('Dictionary BYOK response is not JSON');
   }
 }

--- a/lib/features/ai/data/byok/byok_http_client.dart
+++ b/lib/features/ai/data/byok/byok_http_client.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:enjoy_player/core/validation/byok_http.dart';
+import 'package:enjoy_player/data/api/api_exception.dart';
+
+/// Shared guard for BYOK HTTP base URLs. Validates [baseUrl] via
+/// [isByokBaseUrlAllowed], normalizes trailing slashes, and joins
+/// [path] (if non-empty) to produce the final [Uri]. Throws
+/// [ApiException] (400) with a [purpose]-specific message on rejection.
+Uri guardByokBaseUrl({
+  required String baseUrl,
+  required String path,
+  required String purpose,
+}) {
+  if (!isByokBaseUrlAllowed(baseUrl)) {
+    throw ApiException(
+      message: 'Invalid base URL for $purpose',
+      statusCode: 400,
+    );
+  }
+  final root = normalizeByokBaseUrl(baseUrl);
+  final uri = path.isEmpty
+      ? Uri.parse(root)
+      : Uri.parse('$root/${path.startsWith('/') ? path.substring(1) : path}');
+  return uri;
+}
+
+/// Standard `Authorization: Bearer <apiKey>` header for OpenAI-compatible
+/// BYOK endpoints.
+Map<String, String> byokBearerHeaders({
+  required String apiKey,
+  String accept = 'application/json',
+}) => {'Authorization': 'Bearer ${apiKey.trim()}', 'Accept': accept};
+
+/// Decode the body of a non-2xx BYOK response. JSON-decoded payloads are
+/// returned as-is; non-JSON payloads fall back to the raw string so callers
+/// can surface the server's plain-text error to users without losing it.
+Object? decodeByokErrorBody(String body) {
+  try {
+    return jsonDecode(body);
+  } catch (_) {
+    return body;
+  }
+}
+
+/// Throw [ApiException] for a non-2xx BYOK response. Always `Never` so it
+/// can be used as the terminating arm of an `if`/`else` without a synthetic
+/// return.
+Never throwByokHttpError({
+  required String purpose,
+  required int statusCode,
+  required String body,
+}) {
+  throw ApiException(
+    message: '$purpose failed ($statusCode)',
+    statusCode: statusCode,
+    body: decodeByokErrorBody(body),
+  );
+}

--- a/lib/features/ai/data/byok/byok_llm_model_factory.dart
+++ b/lib/features/ai/data/byok/byok_llm_model_factory.dart
@@ -3,8 +3,12 @@ import 'package:ai_sdk_google/ai_sdk_google.dart';
 import 'package:ai_sdk_openai/ai_sdk_openai.dart';
 import 'package:ai_sdk_provider/ai_sdk_provider.dart';
 
+import 'package:enjoy_player/core/validation/byok_http.dart';
 import 'package:enjoy_player/features/ai/domain/llm_api_spec.dart';
 import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
+
+export 'package:enjoy_player/core/validation/byok_http.dart'
+    show normalizeByokBaseUrl;
 
 /// Builds an [LanguageModelV3] for BYOK LLM calls from persisted config + key.
 LanguageModelV3 createByokLanguageModel({
@@ -26,12 +30,4 @@ LanguageModelV3 createByokLanguageModel({
       baseUrl: baseUrl,
     )(config.model),
   };
-}
-
-String normalizeByokBaseUrl(String raw) {
-  var url = raw.trim();
-  while (url.endsWith('/')) {
-    url = url.substring(0, url.length - 1);
-  }
-  return url;
 }

--- a/lib/features/ai/data/byok/byok_openai_models.dart
+++ b/lib/features/ai/data/byok/byok_openai_models.dart
@@ -1,8 +1,6 @@
 import 'dart:convert';
 
-import 'package:enjoy_player/core/validation/byok_url_guard.dart';
-import 'package:enjoy_player/data/api/api_exception.dart';
-import 'package:enjoy_player/features/ai/data/byok/byok_llm_model_factory.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_http_client.dart';
 import 'package:http/http.dart' as http;
 
 /// Lists models from an OpenAI-compatible `GET /models` endpoint.
@@ -10,26 +8,22 @@ Future<List<String>> fetchOpenAiCompatibleModels({
   required String baseUrl,
   required String apiKey,
 }) async {
-  if (!isByokBaseUrlAllowed(baseUrl)) {
-    throw const ApiException(
-      message: 'Invalid base URL for model fetch',
-      statusCode: 400,
-    );
-  }
+  final uri = guardByokBaseUrl(
+    baseUrl: baseUrl,
+    path: 'models',
+    purpose: 'model fetch',
+  );
 
-  final root = normalizeByokBaseUrl(baseUrl);
   final response = await http.get(
-    Uri.parse('$root/models'),
-    headers: {
-      'Authorization': 'Bearer ${apiKey.trim()}',
-      'Accept': 'application/json',
-    },
+    uri,
+    headers: byokBearerHeaders(apiKey: apiKey),
   );
 
   if (response.statusCode < 200 || response.statusCode >= 300) {
-    throw ApiException(
-      message: 'Failed to fetch models (${response.statusCode})',
+    throwByokHttpError(
+      purpose: 'Failed to fetch models',
       statusCode: response.statusCode,
+      body: response.body,
     );
   }
 

--- a/lib/features/ai/data/byok/byok_openai_speech_client.dart
+++ b/lib/features/ai/data/byok/byok_openai_speech_client.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:enjoy_player/core/validation/byok_url_guard.dart';
-import 'package:enjoy_player/data/api/api_exception.dart';
-import 'package:enjoy_player/features/ai/data/byok/byok_llm_model_factory.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_http_client.dart';
 import 'package:http/http.dart' as http;
 
 /// OpenAI-compatible `POST /audio/speech` with user credentials.
@@ -15,24 +13,19 @@ Future<Uint8List> postOpenAiSpeech({
   String voice = 'alloy',
   http.Client? client,
 }) async {
-  if (!isByokBaseUrlAllowed(baseUrl)) {
-    throw const ApiException(
-      message: 'Invalid base URL for OpenAI speech synthesis',
-      statusCode: 400,
-    );
-  }
-
-  final root = normalizeByokBaseUrl(baseUrl);
-  final uri = Uri.parse('$root/audio/speech');
+  final uri = guardByokBaseUrl(
+    baseUrl: baseUrl,
+    path: 'audio/speech',
+    purpose: 'OpenAI speech synthesis',
+  );
   final httpClient = client ?? http.Client();
 
   try {
     final response = await httpClient.post(
       uri,
       headers: {
-        'Authorization': 'Bearer ${apiKey.trim()}',
+        ...byokBearerHeaders(apiKey: apiKey, accept: 'audio/mpeg'),
         'Content-Type': 'application/json',
-        'Accept': 'audio/mpeg',
       },
       body: jsonEncode(<String, Object>{
         'model': model,
@@ -45,16 +38,10 @@ Future<Uint8List> postOpenAiSpeech({
       return Uint8List.fromList(response.bodyBytes);
     }
 
-    Object? parsed;
-    try {
-      parsed = jsonDecode(response.body);
-    } catch (_) {
-      parsed = response.body;
-    }
-    throw ApiException(
-      message: 'Speech synthesis failed (${response.statusCode})',
+    throwByokHttpError(
+      purpose: 'Speech synthesis',
       statusCode: response.statusCode,
-      body: parsed,
+      body: response.body,
     );
   } finally {
     if (client == null) {

--- a/lib/features/ai/data/byok/byok_speech_guards.dart
+++ b/lib/features/ai/data/byok/byok_speech_guards.dart
@@ -1,0 +1,109 @@
+import 'package:enjoy_player/data/api/api_exception.dart';
+import 'package:enjoy_player/data/api/byok_secret_store.dart';
+import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
+import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
+import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
+import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
+
+/// Persisted `SpeechByokConfig.kind` does not match the capability's expected
+/// sub-protocol (e.g. an Azure Speech capability was given an OpenAI-compatible
+/// configuration). Raised **before** any network or SDK call so the caller can
+/// surface a misconfiguration without leaking a generic [StateError].
+final class ByokMisconfiguredFailure implements Exception {
+  const ByokMisconfiguredFailure({
+    required this.expected,
+    required this.actual,
+    required this.capabilityLabel,
+  });
+
+  final SpeechByokKind expected;
+  final SpeechByokKind actual;
+  final String capabilityLabel;
+
+  @override
+  String toString() =>
+      'ByokMisconfiguredFailure($capabilityLabel: expected ${expected.name}, '
+      'got ${actual.name})';
+}
+
+typedef AzureSpeechCredentials = ({String region, String apiKey});
+typedef OpenAiSpeechCredentials = ({
+  String baseUrl,
+  String model,
+  String apiKey,
+});
+
+/// Validates an Azure-Speech [SpeechByokConfig] and returns the trimmed
+/// `region` + BYOK API key for [ModalityKind.kind].
+///
+/// Throws:
+/// - [ByokMisconfiguredFailure] if `config.kind != azureSpeech`.
+/// - [ApiException] (400) if the region is missing.
+/// - [ByokNotConfiguredFailure] if the BYOK API key is missing or blank.
+Future<AzureSpeechCredentials> guardAzureSpeechConfig({
+  required SpeechByokConfig config,
+  required ByokSecretStoreBase secrets,
+  required ModalityKind kind,
+  required String capabilityLabel,
+}) async {
+  if (config.kind != SpeechByokKind.azureSpeech) {
+    throw ByokMisconfiguredFailure(
+      expected: SpeechByokKind.azureSpeech,
+      actual: config.kind,
+      capabilityLabel: capabilityLabel,
+    );
+  }
+
+  final region = config.region?.trim();
+  if (region == null || region.isEmpty) {
+    throw ApiException(
+      message: 'Azure region is not configured for $capabilityLabel BYOK',
+      statusCode: 400,
+    );
+  }
+
+  final apiKey = await secrets.readApiKey(kind);
+  if (apiKey == null || apiKey.trim().isEmpty) {
+    throw ByokNotConfiguredFailure(kind);
+  }
+
+  return (region: region, apiKey: apiKey.trim());
+}
+
+/// Validates an OpenAI-compatible [SpeechByokConfig] and returns the trimmed
+/// `baseUrl` + `model` + BYOK API key for [ModalityKind.kind].
+///
+/// Throws:
+/// - [ByokMisconfiguredFailure] if `config.kind != openAiCompatible`.
+/// - [ApiException] (400) if `baseUrl` or `model` is missing.
+/// - [ByokNotConfiguredFailure] if the BYOK API key is missing or blank.
+Future<OpenAiSpeechCredentials> guardOpenAiSpeechConfig({
+  required SpeechByokConfig config,
+  required ByokSecretStoreBase secrets,
+  required ModalityKind kind,
+  required String capabilityLabel,
+}) async {
+  if (config.kind != SpeechByokKind.openAiCompatible) {
+    throw ByokMisconfiguredFailure(
+      expected: SpeechByokKind.openAiCompatible,
+      actual: config.kind,
+      capabilityLabel: capabilityLabel,
+    );
+  }
+
+  final baseUrl = config.baseUrl?.trim();
+  final model = config.model?.trim();
+  if (baseUrl == null || baseUrl.isEmpty || model == null || model.isEmpty) {
+    throw ApiException(
+      message: '$capabilityLabel BYOK base URL and model are not configured',
+      statusCode: 400,
+    );
+  }
+
+  final apiKey = await secrets.readApiKey(kind);
+  if (apiKey == null || apiKey.trim().isEmpty) {
+    throw ByokNotConfiguredFailure(kind);
+  }
+
+  return (baseUrl: baseUrl, model: model, apiKey: apiKey.trim());
+}

--- a/lib/features/ai/data/byok/byok_tts_azure_capability.dart
+++ b/lib/features/ai/data/byok/byok_tts_azure_capability.dart
@@ -2,13 +2,12 @@ import 'package:azure_speech/azure_speech.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/data/api/byok_secret_store.dart';
 import 'package:enjoy_player/features/ai/data/azure_language_mapper.dart';
-import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_speech_guards.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/tts_capability.dart';
 import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
 import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
 import 'package:enjoy_player/features/ai/domain/models/tts_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/tts_result.dart';
-import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
 
 /// TTS via user Azure Speech subscription key + region (native synthesis).
 final class ByokTtsAzureCapability implements TtsCapability {
@@ -24,22 +23,12 @@ final class ByokTtsAzureCapability implements TtsCapability {
 
   @override
   Future<TtsResult> synthesize(TtsRequest request) async {
-    if (_config.kind != SpeechByokKind.azureSpeech) {
-      throw StateError('Azure TTS BYOK requires azureSpeech configuration');
-    }
-
-    final region = _config.region?.trim();
-    if (region == null || region.isEmpty) {
-      throw const ApiException(
-        message: 'Azure region is not configured for TTS BYOK',
-        statusCode: 400,
-      );
-    }
-
-    final subscriptionKey = await _secrets.readApiKey(ModalityKind.tts);
-    if (subscriptionKey == null || subscriptionKey.trim().isEmpty) {
-      throw const ByokNotConfiguredFailure(ModalityKind.tts);
-    }
+    final (:region, apiKey: subscriptionKey) = await guardAzureSpeechConfig(
+      config: _config,
+      secrets: _secrets,
+      kind: ModalityKind.tts,
+      capabilityLabel: 'TTS',
+    );
 
     final text = request.text.trim();
     if (text.isEmpty) {
@@ -65,7 +54,7 @@ final class ByokTtsAzureCapability implements TtsCapability {
         AzureSpeechSynthesisParams(
           text: text,
           language: azureLanguage,
-          subscriptionKey: subscriptionKey.trim(),
+          subscriptionKey: subscriptionKey,
           region: region,
           voice: voice,
         ),

--- a/lib/features/ai/data/byok/byok_tts_openai_capability.dart
+++ b/lib/features/ai/data/byok/byok_tts_openai_capability.dart
@@ -1,13 +1,12 @@
 import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/data/api/byok_secret_store.dart';
 import 'package:enjoy_player/features/ai/data/byok/byok_openai_speech_client.dart';
-import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_speech_guards.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/tts_capability.dart';
 import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
 import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
 import 'package:enjoy_player/features/ai/domain/models/tts_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/tts_result.dart';
-import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
 import 'package:http/http.dart' as http;
 
 /// TTS via user OpenAI-compatible speech endpoint.
@@ -24,25 +23,12 @@ final class ByokTtsOpenAiCapability implements TtsCapability {
 
   @override
   Future<TtsResult> synthesize(TtsRequest request) async {
-    if (_config.kind != SpeechByokKind.openAiCompatible) {
-      throw StateError(
-        'OpenAI TTS BYOK requires openAiCompatible configuration',
-      );
-    }
-
-    final baseUrl = _config.baseUrl?.trim();
-    final model = _config.model?.trim();
-    if (baseUrl == null || baseUrl.isEmpty || model == null || model.isEmpty) {
-      throw const ApiException(
-        message: 'TTS BYOK base URL and model are not configured',
-        statusCode: 400,
-      );
-    }
-
-    final apiKey = await _secrets.readApiKey(ModalityKind.tts);
-    if (apiKey == null || apiKey.trim().isEmpty) {
-      throw const ByokNotConfiguredFailure(ModalityKind.tts);
-    }
+    final (:baseUrl, :model, :apiKey) = await guardOpenAiSpeechConfig(
+      config: _config,
+      secrets: _secrets,
+      kind: ModalityKind.tts,
+      capabilityLabel: 'TTS',
+    );
 
     final text = request.text.trim();
     if (text.isEmpty) {
@@ -54,7 +40,7 @@ final class ByokTtsOpenAiCapability implements TtsCapability {
 
     final audioBytes = await postOpenAiSpeech(
       baseUrl: baseUrl,
-      apiKey: apiKey.trim(),
+      apiKey: apiKey,
       model: model,
       input: text,
       voice: request.voice?.trim().isNotEmpty == true

--- a/lib/features/ai/data/byok/byok_whisper_client.dart
+++ b/lib/features/ai/data/byok/byok_whisper_client.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
-import 'package:enjoy_player/core/validation/byok_url_guard.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
-import 'package:enjoy_player/features/ai/data/byok/byok_llm_model_factory.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_http_client.dart';
 import 'package:http/http.dart' as http;
 
 /// OpenAI-compatible Whisper `POST /audio/transcriptions` with user credentials.
@@ -17,19 +16,14 @@ Future<Map<String, dynamic>> postWhisperTranscription({
   String responseFormat = 'json',
   http.Client? client,
 }) async {
-  if (!isByokBaseUrlAllowed(baseUrl)) {
-    throw const ApiException(
-      message: 'Invalid base URL for Whisper transcription',
-      statusCode: 400,
-    );
-  }
-
-  final root = normalizeByokBaseUrl(baseUrl);
-  final uri = Uri.parse('$root/audio/transcriptions');
+  final uri = guardByokBaseUrl(
+    baseUrl: baseUrl,
+    path: 'audio/transcriptions',
+    purpose: 'Whisper transcription',
+  );
 
   final request = http.MultipartRequest('POST', uri);
-  request.headers['Accept'] = 'application/json';
-  request.headers['Authorization'] = 'Bearer ${apiKey.trim()}';
+  request.headers.addAll(byokBearerHeaders(apiKey: apiKey));
   request.files.add(
     http.MultipartFile.fromBytes('file', audioBytes, filename: filename),
   );
@@ -64,16 +58,10 @@ Future<Map<String, dynamic>> postWhisperTranscription({
       );
     }
 
-    Object? parsed;
-    try {
-      parsed = jsonDecode(body);
-    } catch (_) {
-      parsed = body;
-    }
-    throw ApiException(
-      message: 'Whisper transcription failed (${streamed.statusCode})',
+    throwByokHttpError(
+      purpose: 'Whisper transcription',
       statusCode: streamed.statusCode,
-      body: parsed,
+      body: body,
     );
   } finally {
     if (client == null) {

--- a/test/core/json/json_from_llm_test.dart
+++ b/test/core/json/json_from_llm_test.dart
@@ -1,0 +1,30 @@
+import 'package:enjoy_player/core/json/json_from_llm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('extractJsonObject', () {
+    test('returns the trimmed input verbatim when it starts with `{`', () {
+      const raw = '{"word":"hi","senses":[]}';
+      expect(extractJsonObject(raw), raw);
+    });
+
+    test('strips a single ```json fenced block', () {
+      const raw = '```json\n{"word":"hi","senses":[]}\n```';
+      expect(extractJsonObject(raw), '{"word":"hi","senses":[]}');
+    });
+
+    test('strips an unfenced ``` block', () {
+      const raw = '```\n{"word":"hi"}\n```';
+      expect(extractJsonObject(raw), '{"word":"hi"}');
+    });
+
+    test('falls back to the outermost braces when no fences are present', () {
+      const raw = 'Sure! Here you go: {"word":"hi","senses":[]} cheers';
+      expect(extractJsonObject(raw), '{"word":"hi","senses":[]}');
+    });
+
+    test('throws FormatException when the response is not JSON at all', () {
+      expect(() => extractJsonObject('plain text'), throwsFormatException);
+    });
+  });
+}

--- a/test/core/validation/byok_http_test.dart
+++ b/test/core/validation/byok_http_test.dart
@@ -1,0 +1,34 @@
+import 'package:enjoy_player/core/validation/byok_http.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('normalizeByokBaseUrl', () {
+    test('strips a single trailing slash', () {
+      expect(
+        normalizeByokBaseUrl('https://api.openai.com/v1/'),
+        'https://api.openai.com/v1',
+      );
+    });
+
+    test('strips multiple trailing slashes', () {
+      expect(
+        normalizeByokBaseUrl('https://api.openai.com/v1///'),
+        'https://api.openai.com/v1',
+      );
+    });
+
+    test('trims whitespace before stripping slashes', () {
+      expect(
+        normalizeByokBaseUrl('  https://api.openai.com/v1/  '),
+        'https://api.openai.com/v1',
+      );
+    });
+
+    test('returns the input unchanged when there is no trailing slash', () {
+      expect(
+        normalizeByokBaseUrl('https://api.openai.com/v1'),
+        'https://api.openai.com/v1',
+      );
+    });
+  });
+}

--- a/test/features/ai/data/byok/byok_http_client_test.dart
+++ b/test/features/ai/data/byok/byok_http_client_test.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+
+import 'package:enjoy_player/data/api/api_exception.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_http_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('guardByokBaseUrl', () {
+    test('builds a Uri from a valid base URL and joins a path', () {
+      final uri = guardByokBaseUrl(
+        baseUrl: 'https://api.openai.com/v1/',
+        path: 'audio/speech',
+        purpose: 'OpenAI speech synthesis',
+      );
+      expect(uri.toString(), 'https://api.openai.com/v1/audio/speech');
+    });
+
+    test('drops the leading slash on the joined path', () {
+      final uri = guardByokBaseUrl(
+        baseUrl: 'https://api.openai.com/v1',
+        path: '/models',
+        purpose: 'model fetch',
+      );
+      expect(uri.toString(), 'https://api.openai.com/v1/models');
+    });
+
+    test('returns the base Uri when path is empty', () {
+      final uri = guardByokBaseUrl(
+        baseUrl: 'https://api.openai.com/v1',
+        path: '',
+        purpose: 'model fetch',
+      );
+      expect(uri.toString(), 'https://api.openai.com/v1');
+    });
+
+    test('throws ApiException(400) when the base URL is rejected', () {
+      expect(
+        () => guardByokBaseUrl(
+          baseUrl: 'http://api.openai.com/v1',
+          path: 'audio/speech',
+          purpose: 'OpenAI speech synthesis',
+        ),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 400)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('OpenAI speech synthesis'),
+              ),
+        ),
+      );
+    });
+  });
+
+  group('byokBearerHeaders', () {
+    test('trims the apiKey and defaults Accept to application/json', () {
+      expect(byokBearerHeaders(apiKey: '  sk-test  '), {
+        'Authorization': 'Bearer sk-test',
+        'Accept': 'application/json',
+      });
+    });
+
+    test('honors a custom Accept value', () {
+      expect(byokBearerHeaders(apiKey: 'sk-test', accept: 'audio/mpeg'), {
+        'Authorization': 'Bearer sk-test',
+        'Accept': 'audio/mpeg',
+      });
+    });
+  });
+
+  group('decodeByokErrorBody', () {
+    test('decodes a JSON object payload', () {
+      final decoded = decodeByokErrorBody('{"error":"bad"}');
+      expect(decoded, {'error': 'bad'});
+    });
+
+    test('falls back to the raw string for non-JSON payloads', () {
+      expect(decodeByokErrorBody('plain text error'), 'plain text error');
+    });
+  });
+
+  group('throwByokHttpError', () {
+    test('builds an ApiException with the decoded JSON body', () {
+      expect(
+        () => throwByokHttpError(
+          purpose: 'Whisper transcription',
+          statusCode: 502,
+          body: jsonEncode({'error': 'oops'}),
+        ),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 502)
+              .having(
+                (e) => e.message,
+                'message',
+                'Whisper transcription failed (502)',
+              )
+              .having((e) => e.body, 'body', {'error': 'oops'}),
+        ),
+      );
+    });
+
+    test('falls back to the raw string when the body is not JSON', () {
+      expect(
+        () => throwByokHttpError(
+          purpose: 'Speech synthesis',
+          statusCode: 500,
+          body: 'gateway exploded',
+        ),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 500)
+              .having(
+                (e) => e.message,
+                'message',
+                'Speech synthesis failed (500)',
+              )
+              .having((e) => e.body, 'body', 'gateway exploded'),
+        ),
+      );
+    });
+  });
+}

--- a/test/features/ai/data/byok/byok_speech_guards_test.dart
+++ b/test/features/ai/data/byok/byok_speech_guards_test.dart
@@ -1,0 +1,212 @@
+import 'package:enjoy_player/data/api/api_exception.dart';
+import 'package:enjoy_player/data/api/byok_secret_store.dart';
+import 'package:enjoy_player/features/ai/data/byok/byok_speech_guards.dart';
+import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
+import 'package:enjoy_player/features/ai/domain/modality_byok_config.dart';
+import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
+import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeSecretStore implements ByokSecretStoreBase {
+  _FakeSecretStore(this._key);
+
+  final String? _key;
+
+  @override
+  Future<void> deleteApiKey(ModalityKind modality) async {}
+
+  @override
+  Future<bool> hasApiKey(ModalityKind modality) async =>
+      _key != null && _key.isNotEmpty;
+
+  @override
+  Future<String?> readApiKey(ModalityKind modality) async => _key;
+
+  @override
+  Future<void> writeApiKey(ModalityKind modality, String apiKey) async {}
+}
+
+void main() {
+  group('guardAzureSpeechConfig', () {
+    test(
+      'returns trimmed region + apiKey on a valid azureSpeech config',
+      () async {
+        final creds = await guardAzureSpeechConfig(
+          config: const SpeechByokConfig(
+            kind: SpeechByokKind.azureSpeech,
+            region: '  eastus  ',
+          ),
+          secrets: _FakeSecretStore('  azure-sub-key  '),
+          kind: ModalityKind.asr,
+          capabilityLabel: 'ASR',
+        );
+        expect(creds.region, 'eastus');
+        expect(creds.apiKey, 'azure-sub-key');
+      },
+    );
+
+    test(
+      'throws ByokMisconfiguredFailure when kind is openAiCompatible',
+      () async {
+        await expectLater(
+          guardAzureSpeechConfig(
+            config: const SpeechByokConfig(
+              kind: SpeechByokKind.openAiCompatible,
+              region: 'eastus',
+              baseUrl: 'https://api.openai.com/v1',
+              model: 'whisper-1',
+            ),
+            secrets: _FakeSecretStore('azure-sub-key'),
+            kind: ModalityKind.asr,
+            capabilityLabel: 'ASR',
+          ),
+          throwsA(
+            isA<ByokMisconfiguredFailure>()
+                .having(
+                  (f) => f.expected,
+                  'expected',
+                  SpeechByokKind.azureSpeech,
+                )
+                .having(
+                  (f) => f.actual,
+                  'actual',
+                  SpeechByokKind.openAiCompatible,
+                )
+                .having((f) => f.capabilityLabel, 'capabilityLabel', 'ASR'),
+          ),
+        );
+      },
+    );
+
+    test('throws ApiException(400) when region is empty', () async {
+      await expectLater(
+        guardAzureSpeechConfig(
+          config: const SpeechByokConfig(
+            kind: SpeechByokKind.azureSpeech,
+            region: '   ',
+          ),
+          secrets: _FakeSecretStore('azure-sub-key'),
+          kind: ModalityKind.tts,
+          capabilityLabel: 'TTS',
+        ),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 400)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('Azure region is not configured for TTS'),
+              ),
+        ),
+      );
+    });
+
+    test('throws ByokNotConfiguredFailure when API key is missing', () async {
+      await expectLater(
+        guardAzureSpeechConfig(
+          config: const SpeechByokConfig(
+            kind: SpeechByokKind.azureSpeech,
+            region: 'eastus',
+          ),
+          secrets: _FakeSecretStore(null),
+          kind: ModalityKind.assessment,
+          capabilityLabel: 'assessment',
+        ),
+        throwsA(
+          isA<ByokNotConfiguredFailure>().having(
+            (f) => f.modality,
+            'modality',
+            ModalityKind.assessment,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('guardOpenAiSpeechConfig', () {
+    test(
+      'returns trimmed baseUrl + model + apiKey on a valid config',
+      () async {
+        final creds = await guardOpenAiSpeechConfig(
+          config: const SpeechByokConfig(
+            kind: SpeechByokKind.openAiCompatible,
+            baseUrl: '  https://api.openai.com/v1  ',
+            model: '  whisper-1  ',
+          ),
+          secrets: _FakeSecretStore('  sk-test  '),
+          kind: ModalityKind.asr,
+          capabilityLabel: 'ASR',
+        );
+        expect(creds.baseUrl, 'https://api.openai.com/v1');
+        expect(creds.model, 'whisper-1');
+        expect(creds.apiKey, 'sk-test');
+      },
+    );
+
+    test('throws ByokMisconfiguredFailure when kind is azureSpeech', () async {
+      await expectLater(
+        guardOpenAiSpeechConfig(
+          config: const SpeechByokConfig(
+            kind: SpeechByokKind.azureSpeech,
+            region: 'eastus',
+          ),
+          secrets: _FakeSecretStore('sk-test'),
+          kind: ModalityKind.tts,
+          capabilityLabel: 'TTS',
+        ),
+        throwsA(
+          isA<ByokMisconfiguredFailure>().having(
+            (f) => f.expected,
+            'expected',
+            SpeechByokKind.openAiCompatible,
+          ),
+        ),
+      );
+    });
+
+    test('throws ApiException(400) when baseUrl or model is missing', () async {
+      await expectLater(
+        guardOpenAiSpeechConfig(
+          config: const SpeechByokConfig(
+            kind: SpeechByokKind.openAiCompatible,
+            baseUrl: 'https://api.openai.com/v1',
+          ),
+          secrets: _FakeSecretStore('sk-test'),
+          kind: ModalityKind.asr,
+          capabilityLabel: 'ASR',
+        ),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 400)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('ASR BYOK base URL and model'),
+              ),
+        ),
+      );
+    });
+
+    test('throws ByokNotConfiguredFailure when API key is blank', () async {
+      await expectLater(
+        guardOpenAiSpeechConfig(
+          config: const SpeechByokConfig(
+            kind: SpeechByokKind.openAiCompatible,
+            baseUrl: 'https://api.openai.com/v1',
+            model: 'tts-1',
+          ),
+          secrets: _FakeSecretStore('   '),
+          kind: ModalityKind.tts,
+          capabilityLabel: 'TTS',
+        ),
+        throwsA(
+          isA<ByokNotConfiguredFailure>().having(
+            (f) => f.modality,
+            'modality',
+            ModalityKind.tts,
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Resolves the three duplicate-code-detector reports that targeted the
BYOK AI feature layer. All three are real, ~230 lines of behaviour-
preserving deduplication:

* **#276 — speech config + secret guards.** 5 `Byok*Capability`
  classes repeated ~120 lines of kind-check / region-or-baseUrl-and-
  model validation / secret read boilerplate. Extracted into
  `lib/features/ai/data/byok/byok_speech_guards.dart`
  (`guardAzureSpeechConfig`, `guardOpenAiSpeechConfig`) returning
  trimmed credentials via records, with a typed
  `ByokMisconfiguredFailure` (replaces the `StateError` leak).

* **#277 — BYOK HTTP base-URL guard + error-response parsing.**
  Three client helpers repeated the URL-allowlist check, the
  trailing-slash normalisation, the `Authorization` header, and
  the `jsonDecode`-or-fallback body parsing. Centralised in
  `lib/features/ai/data/byok/byok_http_client.dart`
  (`guardByokBaseUrl`, `byokBearerHeaders`, `throwByokHttpError`),
  and `normalizeByokBaseUrl` moved next to `isByokBaseUrlAllowed`
  in `lib/core/validation/byok_http.dart`. The old import path
  (`byok_llm_model_factory.dart`) still re-exports the symbol so
  the test suite is unaffected.

* **#278 — LLM JSON-object extraction.** `byok_dictionary_capability`
  re-implemented the "strip fences, fall back to outermost braces"
  recipe inline. Moved to `lib/core/json/json_from_llm.dart` so
  any LLM-backed capability can share the single source of truth.
  (The broader `LlmPromptCapability` mixin suggested in the report
  was skipped — the LLM-backed and REST-backed capabilities diverge
  too much for a single helper to be a clear win.)

## Verification

```
flutter analyze          No issues found
flutter test             All 1125 tests pass (2 skipped)
check_dart_format        clean (after --fix)
check_codegen_drift      ok (no schema changes)
```

## Lines

```
10 capability/client files:  -196 lines (duplication removed)
4 new helper files:          +232 lines (single source of truth)
4 new helper test files:     +400 lines (focused coverage)
net lib change:              +36 lines
```

## Tests added

* `test/features/ai/data/byok/byok_speech_guards_test.dart` —
  happy path + each `ByokMisconfiguredFailure` / `ApiException(400)` /
  `ByokNotConfiguredFailure` arm, with modality and capabilityLabel
  fields verified.
* `test/features/ai/data/byok/byok_http_client_test.dart` — URL join
  with/without trailing slash, header trimming, JSON vs raw body
  decoding, ApiException shape.
* `test/core/json/json_from_llm_test.dart` — verbatim passthrough,
  fence stripping (with and without language tag), brace fallback,
  FormatException on non-JSON.
* `test/core/validation/byok_http_test.dart` — trailing-slash /
  whitespace handling.

The existing capability tests (`throwsA(isA<Exception>())`,
header / URL / language assertions) pass unchanged.

Closes #276, #277, #278.