### PR TITLE
fix: deduplicate code — HMS parsing, ApiClient factory, recovery clipboard notice

### DIFF
--- a/lib/core/recovery/recovery_actions.dart
+++ b/lib/core/recovery/recovery_actions.dart
@@ -6,12 +6,15 @@ library;
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/logging/log_file_sink.dart';
+import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
 
 final _log = logNamed('RecoveryActions');
 
@@ -63,6 +66,17 @@ Future<bool> copyErrorToClipboard(Object error, StackTrace? stack) =>
       await Clipboard.setData(ClipboardData(text: buf.toString()));
       return true;
     });
+
+/// Shared clipboard-copy success / failure notice used by both
+/// [WidgetErrorSurface] and [RecoverySurface].
+Future<void> copyErrorShowNotice(BuildContext context, bool ok) async {
+  final l10n = AppLocalizations.of(context)!;
+  if (ok) {
+    AppNotice.success(context, l10n.recoveryCopiedToClipboard);
+  } else {
+    AppNotice.error(context, l10n.recoveryCopiedToClipboard);
+  }
+}
 
 /// Opens the rotating log directory in the platform file explorer.
 ///

--- a/lib/core/recovery/recovery_surface.dart
+++ b/lib/core/recovery/recovery_surface.dart
@@ -152,14 +152,7 @@ class _RecoverySurfaceState extends State<RecoverySurface>
 
   Future<void> _onCopy() => runBusyAction<bool>(
     () => copyErrorToClipboard(widget.error, widget.stack),
-    (ctx, ok) async {
-      final l10n = AppLocalizations.of(ctx)!;
-      if (ok) {
-        AppNotice.success(ctx, l10n.recoveryCopiedToClipboard);
-      } else {
-        AppNotice.error(ctx, l10n.recoveryCopiedToClipboard);
-      }
-    },
+    copyErrorShowNotice,
   );
 
   Future<void> _onOpenLogs() =>

--- a/lib/core/recovery/widget_error_surface.dart
+++ b/lib/core/recovery/widget_error_surface.dart
@@ -3,7 +3,6 @@ library;
 
 import 'package:flutter/material.dart';
 
-import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/recovery/recovery_actions.dart';
 import 'package:enjoy_player/core/recovery/recovery_busy_action.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -99,14 +98,7 @@ class _WidgetErrorSurfaceState extends State<WidgetErrorSurface>
 
   Future<void> _onCopy() => runBusyAction<bool>(
     () => copyErrorToClipboard(widget.details.exception, widget.details.stack),
-    (ctx, ok) async {
-      final l10n = AppLocalizations.of(ctx)!;
-      if (ok) {
-        AppNotice.success(ctx, l10n.recoveryCopiedToClipboard);
-      } else {
-        AppNotice.error(ctx, l10n.recoveryCopiedToClipboard);
-      }
-    },
+    copyErrorShowNotice,
   );
 }
 

--- a/lib/core/utils/duration_parsing.dart
+++ b/lib/core/utils/duration_parsing.dart
@@ -1,0 +1,31 @@
+/// Canonical HH:MM:SS(.mmm) → [Duration] parser used by subtitle parsers
+/// and ffmpeg probe output. Accepts both `.` and `,` as the sub-second
+/// separator (SRT uses comma).
+library;
+
+/// Parses `HH:MM:SS` or `HH:MM:SS.mmm` into a [Duration].
+/// Returns `null` on malformed input.
+///
+/// Accepts both `.` and `,` as the sub-second separator (SRT uses comma).
+/// Fractional seconds shorter than 3 digits are right-padded to
+/// milliseconds; longer fractions are truncated to 3 digits.
+Duration? tryParseHmsDuration(String input) {
+  final normalized = input.replaceAll(',', '.');
+  final parts = normalized.split(':');
+  if (parts.length < 2 || parts.length > 3) return null;
+
+  final hasHours = parts.length == 3;
+  final h = hasHours ? (int.tryParse(parts[0]) ?? 0) : 0;
+  final m = int.tryParse(parts[hasHours ? 1 : 0]) ?? 0;
+  final secParts = parts[hasHours ? 2 : 1].split('.');
+  final s = int.tryParse(secParts[0]) ?? 0;
+  var ms = 0;
+  if (secParts.length > 1) {
+    final frac = secParts[1];
+    ms = int.tryParse(frac.padRight(3, '0').substring(0, 3)) ?? 0;
+  }
+
+  if (h < 0 || m < 0 || m > 59 || s < 0 || s > 59) return null;
+
+  return Duration(hours: h, minutes: m, seconds: s, milliseconds: ms);
+}

--- a/lib/data/api/api_client_provider.dart
+++ b/lib/data/api/api_client_provider.dart
@@ -98,36 +98,44 @@ class AiApiBaseUrl extends _$AiApiBaseUrl {
   }
 }
 
-@Riverpod(keepAlive: true)
-ApiClient authApiClient(Ref ref) {
+ApiClient _makeApiClient(
+  Ref ref, {
+  required Future<String> Function() getBaseUrl,
+  bool refreshOn401 = false,
+}) {
   final httpClient = ref.watch(httpClientProvider);
   final tokens = ref.watch(secureTokenStoreProvider);
   return ApiClient(
     httpClient: httpClient,
-    getBaseUrl: () => ref.read(apiBaseUrlProvider.future),
+    getBaseUrl: getBaseUrl,
     getAccessToken: tokens.readAccessToken,
+    refreshAccessToken: refreshOn401
+        ? () => ref.read(authRepositoryProvider).refreshSession()
+        : null,
+  );
+}
+
+@Riverpod(keepAlive: true)
+ApiClient authApiClient(Ref ref) {
+  return _makeApiClient(
+    ref,
+    getBaseUrl: () => ref.read(apiBaseUrlProvider.future),
   );
 }
 
 @Riverpod(keepAlive: true)
 ApiClient apiClient(Ref ref) {
-  final httpClient = ref.watch(httpClientProvider);
-  final tokens = ref.watch(secureTokenStoreProvider);
-  return ApiClient(
-    httpClient: httpClient,
+  return _makeApiClient(
+    ref,
     getBaseUrl: () => ref.read(apiBaseUrlProvider.future),
-    getAccessToken: tokens.readAccessToken,
-    refreshAccessToken: () => ref.read(authRepositoryProvider).refreshSession(),
+    refreshOn401: true,
   );
 }
 
 @Riverpod(keepAlive: true)
 ApiClient aiApiClient(Ref ref) {
-  final httpClient = ref.watch(httpClientProvider);
-  final tokens = ref.watch(secureTokenStoreProvider);
-  return ApiClient(
-    httpClient: httpClient,
+  return _makeApiClient(
+    ref,
     getBaseUrl: () => ref.read(aiApiBaseUrlProvider.future),
-    getAccessToken: tokens.readAccessToken,
   );
 }

--- a/lib/data/api/api_client_provider.g.dart
+++ b/lib/data/api/api_client_provider.g.dart
@@ -177,7 +177,7 @@ final class AuthApiClientProvider
   }
 }
 
-String _$authApiClientHash() => r'0b150101c34b51340427d05b683b24424bd95c71';
+String _$authApiClientHash() => r'b455fc7cd17ee09a9e8d5432f4df9bb8f52d2f84';
 
 @ProviderFor(apiClient)
 final apiClientProvider = ApiClientProvider._();
@@ -218,7 +218,7 @@ final class ApiClientProvider
   }
 }
 
-String _$apiClientHash() => r'639f6035b7421b086667de4d7ea917db1c39f91a';
+String _$apiClientHash() => r'acc2099594dbad555e76774034b3dfde3226eb45';
 
 @ProviderFor(aiApiClient)
 final aiApiClientProvider = AiApiClientProvider._();
@@ -259,4 +259,4 @@ final class AiApiClientProvider
   }
 }
 
-String _$aiApiClientHash() => r'd10fd97a8380e7ac300798f36710f8979b61f1fa';
+String _$aiApiClientHash() => r'0b84dd6663113e853199c7b5896ab99e50d01d90';

--- a/lib/data/files/ffmpeg_media_probe.dart
+++ b/lib/data/files/ffmpeg_media_probe.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:enjoy_player/core/utils/duration_parsing.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 
@@ -65,10 +66,9 @@ class FfmpegMediaProbe {
       r'Duration:\s*(\d+):(\d+):(\d+)\.(\d+)',
     ).firstMatch(stderr);
     if (m == null) return null;
-    final h = int.parse(m.group(1)!);
-    final min = int.parse(m.group(2)!);
-    final s = int.parse(m.group(3)!);
-    return h * 3600 + min * 60 + s;
+    return tryParseHmsDuration(
+      '${m.group(1)!}:${m.group(2)!}:${m.group(3)!}.${m.group(4)!}',
+    )?.inSeconds;
   }
 
   /// ffmpeg stderr lines, e.g.

--- a/lib/data/subtitle/subtitle_parser.dart
+++ b/lib/data/subtitle/subtitle_parser.dart
@@ -1,6 +1,7 @@
 /// Strategy interface + dispatcher for subtitle formats.
 library;
 
+import 'package:enjoy_player/core/utils/duration_parsing.dart';
 import 'transcript_line.dart';
 
 abstract class SubtitleParser {
@@ -82,17 +83,8 @@ class SrtParser implements SubtitleParser {
     return cues;
   }
 
-  static int _parseTs(String raw) {
-    final normalized = raw.replaceAll(',', '.');
-    final parts = normalized.split(':');
-    if (parts.length != 3) return 0;
-    final h = int.tryParse(parts[0]) ?? 0;
-    final m = int.tryParse(parts[1]) ?? 0;
-    final secParts = parts[2].split('.');
-    final s = int.tryParse(secParts[0]) ?? 0;
-    final ms = secParts.length > 1 ? int.tryParse(secParts[1]) ?? 0 : 0;
-    return ((h * 3600 + m * 60 + s) * 1000 + ms);
-  }
+  static int _parseTs(String raw) =>
+      tryParseHmsDuration(raw)?.inMilliseconds ?? 0;
 }
 
 /// Minimal WebVTT cue parser (skips headers and NOTE regions).
@@ -188,9 +180,6 @@ class VttParser implements SubtitleParser {
 
   static int _parseVttTs(String? hOpt, String mm, String ss, String ms) {
     final h = hOpt != null ? int.tryParse(hOpt.replaceAll(':', '')) ?? 0 : 0;
-    final m = int.tryParse(mm) ?? 0;
-    final s = int.tryParse(ss) ?? 0;
-    final milli = int.tryParse(ms) ?? 0;
-    return (h * 3600 + m * 60 + s) * 1000 + milli;
+    return tryParseHmsDuration('$h:$mm:$ss.$ms')?.inMilliseconds ?? 0;
   }
 }

--- a/test/core/utils/duration_parsing_test.dart
+++ b/test/core/utils/duration_parsing_test.dart
@@ -1,0 +1,95 @@
+import 'package:enjoy_player/core/utils/duration_parsing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('tryParseHmsDuration', () {
+    group('SRT format (comma separator)', () {
+      test('00:01:23,456', () {
+        final d = tryParseHmsDuration('00:01:23,456');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 83456);
+        expect(d.inSeconds, 83);
+      });
+
+      test('01:23:45,100', () {
+        final d = tryParseHmsDuration('01:23:45,100');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 5025100);
+      });
+    });
+
+    group('VTT format (dot separator)', () {
+      test('00:01:23.456', () {
+        final d = tryParseHmsDuration('00:01:23.456');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 83456);
+      });
+    });
+
+    group('ffmpeg format', () {
+      test('01:23:45.67', () {
+        final d = tryParseHmsDuration('01:23:45.67');
+        expect(d, isNotNull);
+        expect(d!.inSeconds, 5025);
+        expect(d.inMilliseconds, 5025670);
+      });
+
+      test('00:00:00.00', () {
+        final d = tryParseHmsDuration('00:00:00.00');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 0);
+      });
+    });
+
+    group('edge cases', () {
+      test('no sub-seconds', () {
+        final d = tryParseHmsDuration('01:02:03');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 3723000);
+      });
+
+      test('H:MM:SS without leading zero', () {
+        final d = tryParseHmsDuration('1:02:03.456');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 3723456);
+      });
+
+      test('single-digit sub-seconds', () {
+        final d = tryParseHmsDuration('00:00:01.5');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 1500);
+      });
+
+      test('too many parts', () {
+        expect(tryParseHmsDuration('1:2:3:4'), isNull);
+      });
+
+      test('invalid numbers', () {
+        expect(tryParseHmsDuration('ab:cd:ef'), isNotNull);
+        expect(tryParseHmsDuration('ab:cd:ef')!.inMilliseconds, 0);
+      });
+
+      test('negative values', () {
+        expect(tryParseHmsDuration('-1:00:00'), isNull);
+      });
+
+      test('minutes out of range', () {
+        expect(tryParseHmsDuration('00:60:00'), isNull);
+      });
+
+      test('seconds out of range', () {
+        expect(tryParseHmsDuration('00:00:60'), isNull);
+      });
+
+      test('empty string', () {
+        expect(tryParseHmsDuration(''), isNull);
+      });
+
+      test('MM:SS only (no hours)', () {
+        final d = tryParseHmsDuration('01:30');
+        expect(d, isNotNull);
+        expect(d!.inMilliseconds, 90000);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #299, Closes #300, Closes #301

## What

Three targeted deduplication refactors identified by automated code analysis:

### #300 — HMS timestamp parsing
Extracted \	ryParseHmsDuration()\ into \lib/core/utils/duration_parsing.dart\ and replaced 3 duplicate \h*3600+m*60+s\ implementations in:
- \SrtParser._parseTs\
- \VttParser._parseVttTs\
- \FfmpegMediaProbe.parseDurationSeconds\

Returns \Duration?\, handles comma/dot separators, validates ranges. Added 15-unit test suite.

### #301 — ApiClient provider factory
Extracted \_makeApiClient\ factory into \pi_client_provider.dart\. All 3 providers (\uthApiClient\, \piClient\, \iApiClient\) now delegate to a single construction site. The \efreshAccessToken\ policy is explicit per provider via \efreshOn401\ flag.

**Note**: Kept existing refresh semantics — only \piClient\ passes \efreshOn401: true\. \uthApiClient\ and \iApiClient\ remain without auto-refresh, which is correct: auth client is for login/signup (no token yet), and AI endpoints may not need token refresh.

### #299 — Recovery clipboard notice
Extracted \copyErrorShowNotice()\ helper in \ecovery_actions.dart\. Both \WidgetErrorSurface\ and \RecoverySurface\ now pass the helper as a tear-off instead of duplicating the 8-line async notification callback.

**Not done**: Did not extract a shared \ErrorSurface\ widget scaffold. The two surfaces serve fundamentally different contexts — \WidgetErrorSurface\ is a minimal Material-only crash fallback (no Scaffold, no extra actions), while \RecoverySurface\ is a full Scaffold recovery screen with open-logs and destructive-reset actions. The intentional visual differences (icon, icon size, maxLines, wrapper widget) reflect these distinct use cases. Extracting a shared widget would create unnecessary coupling and obscure these intentional design choices.

## Verification
- \lutter analyze\ — no issues
- \lutter test\ — 166 tests pass across affected areas