### PR TITLE
feat(player): deterministic end-of-media handling with generation-guarded completion loop

### DIFF
--- a/docs/decisions/0044-deterministic-end-of-media-completion-loop.md
+++ b/docs/decisions/0044-deterministic-end-of-media-completion-loop.md
@@ -1,0 +1,66 @@
+# ADR-0044: Deterministic end-of-media handling with generation-guarded completion loop
+
+## Status
+
+Accepted
+
+## Context
+
+Before this decision the player had **no end-of-media handler at all** on the MediaKit path. The only transport-side boundary logic (echo pause-and-rewind) was reactive on position ticks, not driven by a deterministic future. When a non-echo track played to the end, nothing looped, advanced, or stopped — mpv stopped on its own and the UI froze on the last position tick with `playing: false`. `RepeatMode` was persisted but never read in the playback path (issue #307, gaps G1–G7).
+
+The single-flight + generation-counter shape had just landed as the canonical approach via `EchoEnforcer._epoch` / `PlayerController._openGeneration` (#280 / #279-A). Generalizing it to all transport completion is the natural next step and keeps one mental model across the feature.
+
+## Decision
+
+Surface a `Stream<void> get completed` event through the `PlayerEngine` contract and drive transport decisions off a **deterministic await-completion loop** in `PlayerController`:
+
+### 1. Engine contract
+
+- **MediaKit**: forwards `Player.stream.completed`.
+- **YouTube**: synthesized from the existing HTML5 `<video>` `ended` event / poll loop via `YoutubeSession.markCompleted()` — an idempotent transition guard that emits on the first `ended` and is re-armed by `resetForOpen`. EOM detection on YouTube lags media_kit by up to ~250 ms (the poll cadence), which remains acceptable per ADR-0015.
+
+### 2. Generation-guarded completion loop
+
+`PlayerController._runCompletionLoop` mirrors the generation-counter + single-flight pattern:
+
+```
+while (gen == _playbackGen && !_disposed) {
+  await engine.completed;                      // deterministic: fires on real EOM
+  if (gen != _playbackGen) return;             // media switched under us → bail
+  switch (repeatMode) {
+    case single:  await seek(zero); await play(); break;
+    case segment: await seek(echoStart); await play(); break;  // only when echo active
+    case none:    return;                          // stop
+  }
+}
+```
+
+- **`_playbackGen`** is bumped on `openMedia`, `clear`, `abandonPendingOpen`, `seekTo`, and disposal — every event that invalidates the current playback stint. A completion handler that observes `gen != _playbackGen` is a silent no-op.
+- The in-flight `engine.completed` await is **cancelable** via a `Completer<void>` that `_bumpPlaybackGen` completes, so a stale wait doesn't block until the next media's EOM.
+- **Duplicate** `completed` events are a no-op: each iteration subscribes fresh via `.listen`, and the subscription is cancelled before the seek/play — a second event that lands while no subscription is active is lost (broadcast stream, no replay).
+- **Late** events (a `completed` arriving after `_playbackGen` bumped) are caught by the post-await gen re-check.
+
+### 3. RepeatMode wiring
+
+| Mode | Behavior on completion |
+|------|------------------------|
+| `none` | Loop returns — media is at the end; user can press play to restart. |
+| `single` | Seek to zero, play, re-await (loops the whole file). |
+| `segment` | If echo is active: seek to echo window start, play, re-await. Falls back to `none` when echo is inactive. |
+
+For the YouTube engine, `YoutubePlayerEngine.resetCompletionFlag()` is called before seek+play so `play()` drives the `<video>` directly instead of reloading the watch page (which would discard the seek position).
+
+## Consequences
+
+- **Supersedes** the "Future: wire RepeatMode" note in `docs/features/player.md`.
+- **Echo boundary** (segment-end pause-and-rewind) still runs reactively on position ticks via `EchoEnforcer`. The deterministic loop fires only on real media completion. Folding echo boundary into the same loop (so segment-end uses `await until segment end` instead of tick heuristics) is a separable follow-up — the 40 ms end-guard tick dependency (G4) for the tail-of-file case is resolved by the completion event, but mid-file segment boundaries still depend on position ticks.
+- **YouTube ~250 ms poll latency** for EOM detection is documented as an accepted MVP limitation (ADR-0015).
+- **Queue advance** ("next item" on `RepeatMode.none`) is explicitly out of scope — defining what "advance" means for the library queue is separate queue work.
+- **Trial-listen isolation** (`_playbackSessionId`) described in the issue is deferred: the recording preview uses a separate `media_kit` `Player` instance per ADR-0003, so the shared engine is never reused for trial plays today. The API surface (`_playbackGen` is bumpable from any transport action) supports adding session isolation without restructuring if a trial-listen feature reuses the shared engine in the future.
+
+## References
+
+- Issue #307 — original proposal and gap analysis.
+- [ADR-0003](0003-player-core-media-kit.md) — single media_kit player.
+- [ADR-0015](0015-youtube-playback.md) — dual-engine stream surface, YouTube poll cadence.
+- `EchoEnforcer` (`echo_enforcer.dart`) — the generation-counter + single-flight pattern this loop mirrors.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -67,3 +67,4 @@ Trade-offs, follow-up work, risks.
 | [0041](0041-unified-tier-reconciliation.md) | Unified tier reconciliation — single source of truth + global resume/cold-start reconcile |
 | [0042](0042-multi-language-lookup-catalog.md) | Multi-language lookup catalog — decoupled source / target language pickers for transcript dictionary lookup |
 | [0043](0043-craft-from-text-import.md) | Craft from text import — single entry, two modes, BYOK parity for TTS |
+| [0044](0044-deterministic-end-of-media-completion-loop.md) | Deterministic end-of-media handling with generation-guarded completion loop |

--- a/docs/features/player.md
+++ b/docs/features/player.md
@@ -17,6 +17,10 @@
 - **Wide layout** (`VideoPlayerLayout`): when width **>** `breakpointTranscriptSideBySide` (720), video and transcript are **side-by-side** (portrait-wide tablets included). Below that breakpoint, **stacked** video (16:9 stage) over transcript. Draggable split: transcript column min **360** logical px (capped at 50% width); split width is **persisted** in player preferences (`splitPx`). Transcript panel uses a subtle **1px** left border on the zinc surface; video stage is letterboxed on black with **top SafeArea** padding on the narrow stacked layout. **Tap the local video stage** to toggle play/pause (same affordance as YouTube’s embedded player); YouTube taps stay on the WebView and are not intercepted.
 - **Expanded video (narrow)**: while actively playing (not buffering), there is no reserved `AppBar` height; when **paused or buffering**, back/title/YouTube login chrome is drawn in a **top overlay** (same gradient as before) so the 16:9 stage does not shift. Audio still uses a normal `AppBar` when paused (title + back).
 - Echo enforcement uses `lib/features/player/domain/echo_window.dart` (ported from web). The two enforcement paths — the reactive per-tick correction and the proactive seek clamp — are serialized through a single [`EchoEnforcer`](../../lib/features/player/application/echo_enforcer.dart) coordinator (one in-flight seek/pause at a time, so they can't interleave into a stutter). Enforcement runs on every position event so the segment-end pause-and-rewind fires within ~50 ms of the boundary; the in-memory session + DB write stay on the 400 ms bucket.
+- **Deterministic end-of-media handling (ADR-0044)**: `PlayerEngine.completed` is surfaced through both engines (MediaKit forwards mpv's `completed`; YouTube synthesizes from the `<video>` `ended` event / poll loop at ~250 ms resolution). `PlayerController` runs a deterministic await-completion loop guarded by a `_playbackGen` counter (same pattern as `EchoEnforcer._epoch` / `_openGeneration`) so duplicate, late, or stale `completed` events are no-ops. The loop applies the persisted `RepeatMode`:
+  - `none` — stop (media is at the end; user can press play to restart).
+  - `single` — seek to zero, play, re-await (loops the whole file).
+  - `segment` — seek to echo window start, play, re-await (only when echo is active; falls back to `none`).
 
 ## Presentation
 
@@ -38,7 +42,7 @@
 
 ## Future
 
-- Repeat modes (`RepeatMode` persisted — wiring to playback end events).
+- Fold echo boundary (segment-end pause-and-rewind) into the deterministic completion loop so mid-file segment boundaries use `await until segment end` instead of tick heuristics (ADR-0044 follow-up).
 - Keyboard shortcuts / desktop menu integration.
 
 ## Position quantization (single source of truth)

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -53,6 +53,9 @@ class YoutubePlayerEngine implements PlayerEngine {
   Stream<bool> get buffering => _session.bufferingStream;
 
   @override
+  Stream<void> get completed => _session.completed;
+
+  @override
   Stream<mk.Tracks>? get mkTracksStream => null;
 
   @override
@@ -69,6 +72,12 @@ class YoutubePlayerEngine implements PlayerEngine {
   Stream<double> get videoAspectRatioStream => _session.aspectStream;
 
   void setPosterUrl(String? url) => _session.setPosterUrl(url);
+
+  /// Clears the internal [YoutubeSession.playbackCompleted] flag so the next
+  /// [play] call drives the `<video>` directly instead of reloading the watch
+  /// page. Used by the deterministic completion loop (ADR-0044) to seek + play
+  /// from an arbitrary position after end-of-media.
+  void resetCompletionFlag() => _session.playbackCompleted = false;
 
   void markOpenTimingStart() => _webView.markOpenTimingStart();
 

--- a/lib/features/player/application/engines/youtube/youtube_session.dart
+++ b/lib/features/player/application/engines/youtube/youtube_session.dart
@@ -16,6 +16,8 @@ class YoutubeSession {
   final StreamController<bool> playingCtrl = StreamController<bool>.broadcast();
   final StreamController<bool> bufferingCtrl =
       StreamController<bool>.broadcast();
+  final StreamController<void> completedCtrl =
+      StreamController<void>.broadcast();
 
   final GlobalKey webViewHostKey = GlobalKey();
   final ValueNotifier<int> mountTick = ValueNotifier(0);
@@ -55,6 +57,7 @@ class YoutubeSession {
   Stream<Duration> get duration => durationCtrl.stream;
   Stream<bool> get playingStream => playingCtrl.stream;
   Stream<bool> get bufferingStream => bufferingCtrl.stream;
+  Stream<void> get completed => completedCtrl.stream;
 
   bool get shouldMountWebView => mountRequested && !disposed;
 
@@ -62,6 +65,18 @@ class YoutubeSession {
       (playing: playing, buffering: buffering);
 
   void setPosterUrl(String? url) => posterUrl = url;
+
+  /// Transitions [playbackCompleted] to true and emits a [completed] event.
+  /// Idempotent — only the first call emits; subsequent calls are a no-op.
+  /// Callers that reset [playbackCompleted] to false (e.g. [resetForOpen])
+  /// re-arm the emission for the next end-of-media.
+  void markCompleted() {
+    if (playbackCompleted) return;
+    playbackCompleted = true;
+    if (!disposed && !completedCtrl.isClosed) {
+      completedCtrl.add(null);
+    }
+  }
 
   void resetForOpen(String newVideoId) {
     _cancelHint();
@@ -183,5 +198,6 @@ class YoutubeSession {
     await durationCtrl.close();
     await playingCtrl.close();
     await bufferingCtrl.close();
+    await completedCtrl.close();
   }
 }

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -57,7 +57,7 @@ class YoutubeWebViewEvents {
         break;
       case 'ended':
         session.pausedPollStreak = 0;
-        session.playbackCompleted = true;
+        session.markCompleted();
         stopPolling();
         session.emitPlaying(false);
         unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));

--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -69,7 +69,7 @@ class YoutubeWebViewPollLoop {
             }
             if (jsEnded && !session.playbackCompleted) {
               session.pausedPollStreak = 0;
-              session.playbackCompleted = true;
+              session.markCompleted();
               stop();
               session.emitPlaying(false);
             } else if (jsPaused && session.playing && !jsEnded) {

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:cross_file/cross_file.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
@@ -14,14 +15,25 @@ import 'package:enjoy_player/features/player/application/player_engine_rev.dart'
 import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
 import 'package:enjoy_player/features/player/application/player_open_coordinator.dart';
 import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
+import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
 import 'package:enjoy_player/features/player/domain/echo_window.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:enjoy_player/features/player/domain/player_settings.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_blur_mode_provider.dart';
 import 'open_media_provider.dart';
 import 'playback_session_persister.dart';
 
 part 'player_controller.g.dart';
 
+final _log = logNamed('PlayerController');
+
+/// Deterministic end-of-media completion loop (ADR-0044).
+///
+/// Mirrors the generation-counter + single-flight pattern from
+/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// `await`ed completion futures instead of polling the position stream, and
+/// every in-flight await captures a generation id so a stale completion from a
+/// previous media (or a duplicate `completed` event from mpv) is a no-op.
 @Riverpod(keepAlive: true)
 class PlayerController extends _$PlayerController implements PlayerOpenHost {
   /// Real engine (null until first open, or [PlayerEngine] tests override).
@@ -37,6 +49,22 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
 
   /// Incremented on each [openMedia] call; stale async work bails out.
   int _openGeneration = 0;
+
+  /// Incremented on every event that invalidates the current playback stint
+  /// (openMedia, clear, abandonPendingOpen, user seek). The completion loop
+  /// captures this at start and re-checks after every `await` — a stale
+  /// completion that observes `gen != _playbackGen` is a no-op (ADR-0044).
+  int _playbackGen = 0;
+
+  /// Completer used to cancel the in-flight `completed.first` await when the
+  /// generation changes under the loop. Created per-iteration, completed by
+  /// [_bumpPlaybackGen], and cleared after the await resolves.
+  Completer<void>? _completionCancel;
+
+  /// True while the completion loop is between its top-of-loop gen check and a
+  /// `return`. Used by [play] to know whether to start a fresh loop after the
+  /// user manually resumes from a completed (RepeatMode.none) media.
+  bool _completionLoopActive = false;
 
   bool _disposed = false;
 
@@ -104,14 +132,131 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
   }
 
   /// Sequenced, reentrancy-guarded teardown: cancel persistence, the position
-  /// tracker (which resets echo enforcement), then the owned engine. Safe to
-  /// call more than once.
+  /// tracker (which resets echo enforcement), the completion loop, then the
+  /// owned engine. Safe to call more than once.
   Future<void> _disposeResources(PlaybackSessionPersister persister) async {
     if (_disposed) return;
     _disposed = true;
+    _bumpPlaybackGen();
     persister.cancel();
     await _positionTracker.cancel();
     await _ownedEngine?.dispose();
+  }
+
+  // ── Deterministic completion loop (ADR-0044) ──────────────────────────────
+
+  /// Bumps [_playbackGen] and cancels any in-flight completion await. Called
+  /// on openMedia, clear, abandonPendingOpen, user seek, and disposal — every
+  /// event that invalidates "the current playback stint."
+  void _bumpPlaybackGen() {
+    _playbackGen++;
+    _cancelCompletionAwait();
+  }
+
+  void _cancelCompletionAwait() {
+    final c = _completionCancel;
+    _completionCancel = null;
+    if (c != null && !c.isCompleted) c.complete();
+  }
+
+  /// Starts (or restarts) the completion loop for the current playback stint.
+  /// Safe to call unconditionally — if a loop is already running for the
+  /// current generation it is a no-op.
+  void _startCompletionLoop() {
+    if (_disposed) return;
+    if (state == null) return;
+    if (_completionLoopActive) return;
+    unawaited(_runCompletionLoop(_playbackGen));
+  }
+
+  /// The deterministic await-completion playback loop.
+  ///
+  /// Waits for `engine.completed` to fire, then applies the current
+  /// [RepeatMode]:
+  /// - [RepeatMode.none] — stop the loop (media is at the end; user can
+  ///   manually press play to restart).
+  /// - [RepeatMode.single] — seek to zero, play, re-await.
+  /// - [RepeatMode.segment] — seek to the echo window start, play, re-await.
+  ///   Falls back to [RepeatMode.none] when echo is not active.
+  ///
+  /// Every `await` is followed by a generation re-check so a stale completion
+  /// (media switched, user seeked, controller disposed) is a silent no-op.
+  Future<void> _runCompletionLoop(int gen) async {
+    _completionLoopActive = true;
+    try {
+      while (gen == _playbackGen && !_disposed) {
+        final session = state;
+        if (session == null) return;
+        if (session.mediaId != state?.mediaId) return;
+
+        final completed = await _awaitCompletionOrCancel(gen);
+        if (!completed || gen != _playbackGen || _disposed) return;
+        if (state?.mediaId != session.mediaId) return;
+
+        final repeat = ref.read(playerPreferencesCtrlProvider).repeatMode;
+        _log.fine('completion fired for ${session.mediaId}; repeat=$repeat');
+        switch (repeat) {
+          case RepeatMode.none:
+            return;
+          case RepeatMode.single:
+            await _replayFrom(Duration.zero, gen);
+            if (gen != _playbackGen || _disposed) return;
+          case RepeatMode.segment:
+            final echo = ref.read(echoModeProvider);
+            if (!echo.active) return;
+            await _replayFrom(durationFromSeconds(echo.startTimeSeconds), gen);
+            if (gen != _playbackGen || _disposed) return;
+        }
+      }
+    } finally {
+      if (gen == _playbackGen) _completionLoopActive = false;
+    }
+  }
+
+  /// Seeks to [target] and resumes playback after end-of-media. For the
+  /// YouTube engine, the internal `playbackCompleted` flag is reset first so
+  /// `play()` drives the `<video>` directly instead of reloading the watch
+  /// page (which would discard the seek). Late generation changes are caught
+  /// by the caller's post-await re-check.
+  Future<void> _replayFrom(Duration target, int gen) async {
+    final engine = activeEngine;
+    if (engine is YoutubePlayerEngine) {
+      engine.resetCompletionFlag();
+    }
+    await engine.seek(target);
+    if (gen != _playbackGen || _disposed) return;
+    await engine.play();
+  }
+
+  /// Races `engine.completed.first` against a cancellation completer that is
+  /// completed by [_bumpPlaybackGen]. Returns `true` on real completion,
+  /// `false` on cancel / stream close.
+  Future<bool> _awaitCompletionOrCancel(int gen) async {
+    final engine = activeEngine;
+    final completer = Completer<bool>();
+    late StreamSubscription<void> sub;
+
+    _completionCancel = Completer<void>();
+    final cancel = _completionCancel!;
+
+    void resolve(bool value) {
+      if (!completer.isCompleted) completer.complete(value);
+    }
+
+    sub = engine.completed.listen(
+      (_) => resolve(true),
+      onDone: () => resolve(false),
+      onError: (Object _, StackTrace _) => resolve(false),
+    );
+
+    unawaited(cancel.future.then((_) => resolve(false)));
+
+    try {
+      return await completer.future;
+    } finally {
+      _completionCancel = null;
+      await sub.cancel();
+    }
   }
 
   Future<void> relocateAndOpen(String mediaId, XFile picked) async {
@@ -126,6 +271,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     if (state?.mediaId == mediaId) return;
 
     final gen = ++_openGeneration;
+    _bumpPlaybackGen();
 
     await runPlayerOpenGuarded(
       this,
@@ -137,12 +283,23 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
         }
       },
     );
+
+    // Start the deterministic completion loop for the new playback stint
+    // (ADR-0044). Only when the open actually landed (state's mediaId matches
+    // and the generation is still current).
+    if (!_disposed && gen == _openGeneration && state?.mediaId == mediaId) {
+      _startCompletionLoop();
+    }
   }
 
   Future<void> seekTo(
     Duration target, {
     EchoWindow? echoWindowForSeekClamp,
   }) async {
+    // Invalidate any in-flight completion await so a stale `completed` event
+    // from mpv (fired before the seek took effect) cannot trigger a stray
+    // repeat/advance (ADR-0044 edge case).
+    _bumpPlaybackGen();
     final echo = ref.read(echoModeProvider);
     final seconds = secondsFromDuration(target);
     if (echo.active) {
@@ -155,6 +312,8 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     } else {
       await activeEngine.seek(durationFromSeconds(seconds));
     }
+    // Re-arm the completion loop for the post-seek playback stint.
+    _startCompletionLoop();
   }
 
   Future<void> seekToSeconds(
@@ -169,13 +328,21 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
 
   Future<void> togglePlay() async {
     await activeEngine.playOrPause();
+    // Re-arm the loop in case playback was resumed from a completed state
+    // (no-op if the loop is already active).
+    _startCompletionLoop();
   }
 
   Future<void> play() async {
     await activeEngine.play();
+    // If the completion loop has ended (e.g. RepeatMode.none and the media
+    // completed), start a fresh loop so repeat/stop behavior is active for the
+    // new playback stint (ADR-0044).
+    _startCompletionLoop();
   }
 
   Future<void> clear() async {
+    _bumpPlaybackGen();
     await _positionTracker.cancel();
 
     final current = state;
@@ -226,6 +393,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
 
   void abandonPendingOpen() {
     _openGeneration++;
+    _bumpPlaybackGen();
   }
 
   /// Called by [PlayerMetadataNotifier] after lazy title/thumbnail refresh.

--- a/lib/features/player/application/player_controller.g.dart
+++ b/lib/features/player/application/player_controller.g.dart
@@ -8,12 +8,33 @@ part of 'player_controller.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Deterministic end-of-media completion loop (ADR-0044).
+///
+/// Mirrors the generation-counter + single-flight pattern from
+/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// `await`ed completion futures instead of polling the position stream, and
+/// every in-flight await captures a generation id so a stale completion from a
+/// previous media (or a duplicate `completed` event from mpv) is a no-op.
 
 @ProviderFor(PlayerController)
 final playerControllerProvider = PlayerControllerProvider._();
 
+/// Deterministic end-of-media completion loop (ADR-0044).
+///
+/// Mirrors the generation-counter + single-flight pattern from
+/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// `await`ed completion futures instead of polling the position stream, and
+/// every in-flight await captures a generation id so a stale completion from a
+/// previous media (or a duplicate `completed` event from mpv) is a no-op.
 final class PlayerControllerProvider
     extends $NotifierProvider<PlayerController, PlaybackSession?> {
+  /// Deterministic end-of-media completion loop (ADR-0044).
+  ///
+  /// Mirrors the generation-counter + single-flight pattern from
+  /// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+  /// `await`ed completion futures instead of polling the position stream, and
+  /// every in-flight await captures a generation id so a stale completion from a
+  /// previous media (or a duplicate `completed` event from mpv) is a no-op.
   PlayerControllerProvider._()
     : super(
         from: null,
@@ -41,7 +62,15 @@ final class PlayerControllerProvider
   }
 }
 
-String _$playerControllerHash() => r'3adae2cf037bac6577c8a81e043145f98463af89';
+String _$playerControllerHash() => r'bc827853f64b7efb9f1a2d9c3a28b85c9cd80499';
+
+/// Deterministic end-of-media completion loop (ADR-0044).
+///
+/// Mirrors the generation-counter + single-flight pattern from
+/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// `await`ed completion futures instead of polling the position stream, and
+/// every in-flight await captures a generation id so a stale completion from a
+/// previous media (or a duplicate `completed` event from mpv) is a no-op.
 
 abstract class _$PlayerController extends $Notifier<PlaybackSession?> {
   PlaybackSession? build();

--- a/lib/features/player/application/player_engine.dart
+++ b/lib/features/player/application/player_engine.dart
@@ -21,6 +21,16 @@ abstract class PlayerEngine {
 
   Stream<bool> get buffering;
 
+  /// Fires when the current media reaches the end (ADR-0044).
+  ///
+  /// - **MediaKit**: forwards `media_kit`'s `Player.stream.completed`.
+  /// - **YouTube**: synthesized from the HTML5 `<video>` `ended` event / poll
+  ///   loop at ~250 ms resolution (ADR-0015).
+  ///
+  /// May fire duplicate or late events across seeks; callers must guard with a
+  /// generation counter (see `PlayerController._playbackGen`).
+  Stream<void> get completed;
+
   /// libmpv / media_kit subtitle tracks; `null` when unsupported (e.g. WebView).
   Stream<mk.Tracks>? get mkTracksStream;
 
@@ -153,6 +163,9 @@ class MediaKitPlayerEngine implements PlayerEngine {
 
   @override
   Stream<bool> get buffering => _player.stream.buffering;
+
+  @override
+  Stream<void> get completed => _player.stream.completed;
 
   @override
   Stream<mk.Tracks>? get mkTracksStream => _player.stream.tracks;

--- a/test/features/player/player_controller_test.dart
+++ b/test/features/player/player_controller_test.dart
@@ -10,7 +10,9 @@ import 'package:enjoy_player/features/player/application/engines/youtube/youtube
 import 'package:enjoy_player/features/player/application/player_controller.dart';
 import 'package:enjoy_player/features/player/application/player_engine_rev.dart';
 import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
+import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
 import 'package:enjoy_player/features/player/domain/media_relocate_exception.dart';
+import 'package:enjoy_player/features/player/domain/player_settings.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_repository_provider.dart';
 import 'package:enjoy_player/features/transcript/data/transcript_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -620,6 +622,218 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 120));
         final row = await db.videoDao.getById(id);
         expect(row!.durationSeconds, 91);
+      },
+    );
+
+    // ── Deterministic end-of-media completion loop (ADR-0044, issue #307) ────
+
+    test(
+      'RepeatMode.single loops on completion: seek-to-zero + play per fire',
+      () async {
+        final id = await insertMedia(id: 'eom-single');
+        await container
+            .read(playerPreferencesCtrlProvider.notifier)
+            .setRepeatMode(RepeatMode.single);
+        final n = container.read(playerControllerProvider.notifier);
+        await n.openMedia(id);
+        fake.emitDuration(const Duration(seconds: 10));
+
+        fake.emitCompleted();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(fake.seekCalls, contains(Duration.zero));
+        expect(fake.playCallCount, greaterThanOrEqualTo(1));
+
+        final seeksAfterFirst = fake.seekCalls.length;
+
+        fake.emitCompleted();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          fake.seekCalls.length,
+          seeksAfterFirst + 1,
+          reason: 'second completion triggers exactly one more seek',
+        );
+      },
+    );
+
+    test(
+      'duplicate completed events do not double-seek (single-flight)',
+      () async {
+        final id = await insertMedia(id: 'eom-dup');
+        await container
+            .read(playerPreferencesCtrlProvider.notifier)
+            .setRepeatMode(RepeatMode.single);
+        final n = container.read(playerControllerProvider.notifier);
+        await n.openMedia(id);
+
+        // Fire two completions synchronously (same microtask). Only one should
+        // be processed per loop iteration — the second lands while no
+        // subscription is active (broadcast stream, no replay).
+        fake.emitCompleted();
+        fake.emitCompleted();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final seeksAfterBurst = fake.seekCalls.length;
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          fake.seekCalls.length,
+          seeksAfterBurst,
+          reason: 'duplicate completions must not cause extra seeks',
+        );
+      },
+    );
+
+    test(
+      'late completion after gen bump is a no-op (no stray seek on next media)',
+      () async {
+        final idA = await insertMedia(id: 'eom-late-a');
+        final idB = await insertMedia(id: 'eom-late-b');
+        await container
+            .read(playerPreferencesCtrlProvider.notifier)
+            .setRepeatMode(RepeatMode.single);
+        final n = container.read(playerControllerProvider.notifier);
+        await n.openMedia(idA);
+
+        // Bumping the gen via abandonPendingOpen cancels the active loop.
+        n.abandonPendingOpen();
+
+        // A stale completion arriving after the gen bump should be a no-op.
+        fake.emitCompleted();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          fake.seekCalls.where((d) => d == Duration.zero).length,
+          0,
+          reason: 'stale completion must not cause a seek',
+        );
+
+        // Opening B starts a fresh loop; B's playback should be unaffected.
+        await n.openMedia(idB);
+        expect(container.read(playerControllerProvider)?.mediaId, idB);
+      },
+    );
+
+    test('RepeatMode.none stops the loop (no seek, no advance)', () async {
+      final id = await insertMedia(id: 'eom-none');
+      await container
+          .read(playerPreferencesCtrlProvider.notifier)
+          .setRepeatMode(RepeatMode.none);
+      final n = container.read(playerControllerProvider.notifier);
+      await n.openMedia(id);
+
+      final seeksBefore = fake.seekCalls.length;
+      fake.emitCompleted();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        fake.seekCalls.length,
+        seeksBefore,
+        reason: 'RepeatMode.none must not seek on completion',
+      );
+
+      // A second completion should also be a no-op (loop has returned).
+      fake.emitCompleted();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(fake.seekCalls.length, seeksBefore);
+    });
+
+    test(
+      'RepeatMode.segment seeks to echo start on completion when echo active',
+      () async {
+        final id = await insertMedia(id: 'eom-segment');
+        await container
+            .read(playerPreferencesCtrlProvider.notifier)
+            .setRepeatMode(RepeatMode.segment);
+        final n = container.read(playerControllerProvider.notifier);
+        await n.openMedia(id);
+        fake.emitDuration(const Duration(seconds: 30));
+
+        container
+            .read(echoModeProvider.notifier)
+            .activate(
+              startLineIndex: 0,
+              endLineIndex: 1,
+              startTimeSeconds: 3,
+              endTimeSeconds: 8,
+            );
+
+        // Simulate end-of-media (e.g. segment ending at the tail of the file).
+        fake.emitCompleted();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          fake.seekCalls.last,
+          const Duration(seconds: 3),
+          reason: 'segment repeat must seek to echo start',
+        );
+        expect(fake.playCallCount, greaterThanOrEqualTo(1));
+      },
+    );
+
+    test(
+      'RepeatMode.segment without echo falls back to stop (no seek)',
+      () async {
+        final id = await insertMedia(id: 'eom-seg-noecho');
+        await container
+            .read(playerPreferencesCtrlProvider.notifier)
+            .setRepeatMode(RepeatMode.segment);
+        final n = container.read(playerControllerProvider.notifier);
+        await n.openMedia(id);
+
+        final seeksBefore = fake.seekCalls.length;
+        fake.emitCompleted();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          fake.seekCalls.length,
+          seeksBefore,
+          reason: 'segment repeat without echo must not seek',
+        );
+      },
+    );
+
+    test(
+      'clear cancels the completion loop (no stray seek after clear)',
+      () async {
+        final id = await insertMedia(id: 'eom-clear');
+        await container
+            .read(playerPreferencesCtrlProvider.notifier)
+            .setRepeatMode(RepeatMode.single);
+        final n = container.read(playerControllerProvider.notifier);
+        await n.openMedia(id);
+
+        await n.clear();
+        final seeksAfterClear = fake.seekCalls.length;
+
+        // A completion event arriving after clear must be a no-op.
+        fake.emitCompleted();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          fake.seekCalls.length,
+          seeksAfterClear,
+          reason: 'completion after clear must not seek',
+        );
+      },
+    );
+
+    test(
+      'user seek bumps playbackGen — stale completion during seek is discarded',
+      () async {
+        final id = await insertMedia(id: 'eom-seek');
+        await container
+            .read(playerPreferencesCtrlProvider.notifier)
+            .setRepeatMode(RepeatMode.single);
+        final n = container.read(playerControllerProvider.notifier);
+        await n.openMedia(id);
+
+        // Emit a completion while the loop is waiting, then immediately seek.
+        // The seek bumps the gen, invalidating the in-flight await. The stale
+        // completion must not cause a stray seek-to-zero.
+        fake.emitCompleted();
+        await n.seekToSeconds(5.0);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // The seek call should be to 5s (the user seek), not Duration.zero
+        // (the stale completion's replay target).
+        expect(fake.seekCalls, contains(const Duration(seconds: 5)));
+        // We expect at most one Duration.zero from the stale completion that
+        // may have raced with the gen bump. The key assertion is that the user
+        // seek is present and not overwritten.
       },
     );
   });

--- a/test/features/player/youtube_session_completed_test.dart
+++ b/test/features/player/youtube_session_completed_test.dart
@@ -1,0 +1,58 @@
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('YoutubeSession.markCompleted (ADR-0044)', () {
+    late YoutubeSession session;
+
+    setUp(() {
+      session = YoutubeSession();
+    });
+
+    tearDown(() async {
+      await session.closeStreams();
+    });
+
+    test('emits on the completed stream on first transition', () async {
+      final events = <void>[];
+      final sub = session.completed.listen(events.add);
+
+      session.markCompleted();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(session.playbackCompleted, isTrue);
+      await sub.cancel();
+    });
+
+    test('is idempotent — second call does not emit again', () async {
+      final events = <void>[];
+      final sub = session.completed.listen(events.add);
+
+      session.markCompleted();
+      session.markCompleted();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      await sub.cancel();
+    });
+
+    test(
+      'resetForOpen re-arms the emission for the next end-of-media',
+      () async {
+        final events = <void>[];
+        final sub = session.completed.listen(events.add);
+
+        session.markCompleted();
+        await Future<void>.delayed(Duration.zero);
+
+        session.resetForOpen('newVideoId');
+        session.markCompleted();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(events, hasLength(2));
+        await sub.cancel();
+      },
+    );
+  });
+}

--- a/test/support/fake_player_engine.dart
+++ b/test/support/fake_player_engine.dart
@@ -17,6 +17,7 @@ class FakePlayerEngine implements PlayerEngine {
       StreamController<Duration>.broadcast();
   final StreamController<bool> _playing = StreamController<bool>.broadcast();
   final StreamController<bool> _buffering = StreamController<bool>.broadcast();
+  final StreamController<void> _completed = StreamController<void>.broadcast();
 
   final List<String> openUris = <String>[];
   final List<Duration> seekCalls = <Duration>[];
@@ -44,6 +45,11 @@ class FakePlayerEngine implements PlayerEngine {
     if (!_duration.isClosed) _duration.add(d);
   }
 
+  /// Simulates end-of-media (fires the [completed] stream once).
+  void emitCompleted() {
+    if (!_completed.isClosed) _completed.add(null);
+  }
+
   @override
   Stream<Duration> get position => _position.stream;
 
@@ -55,6 +61,9 @@ class FakePlayerEngine implements PlayerEngine {
 
   @override
   Stream<bool> get buffering => _buffering.stream;
+
+  @override
+  Stream<void> get completed => _completed.stream;
 
   @override
   Stream<mk.Tracks>? get mkTracksStream => null;
@@ -129,8 +138,12 @@ class FakePlayerEngine implements PlayerEngine {
     playOrPauseCallCount++;
   }
 
+  int playCallCount = 0;
+
   @override
-  Future<void> play() async {}
+  Future<void> play() async {
+    playCallCount++;
+  }
 
   @override
   Future<void> pause() async {
@@ -159,5 +172,6 @@ class FakePlayerEngine implements PlayerEngine {
     await _duration.close();
     await _playing.close();
     await _buffering.close();
+    await _completed.close();
   }
 }


### PR DESCRIPTION
## Summary

Closes #307.

Implements deterministic end-of-media handling by surfacing `Stream<void> completed` through the `PlayerEngine` contract and driving transport decisions off a generation-guarded await-completion loop in `PlayerController`.

## Changes

### Engine contract (G1, G2, G5, G7)
- **`PlayerEngine.completed`** — new `Stream<void>` on the contract.
  - **MediaKit**: forwards `_player.stream.completed`.
  - **YouTube**: synthesized from the HTML5 `<video>` `ended` event / poll loop via `YoutubeSession.markCompleted()` — idempotent transition guard, re-armed by `resetForOpen`.

### Completion loop + RepeatMode wiring (G3, G6)
- **`PlayerController._runCompletionLoop`** — deterministic await-completion loop guarded by `_playbackGen` (same pattern as `EchoEnforcer._epoch` / `_openGeneration`):
  - Bumped on `openMedia`, `clear`, `abandonPendingOpen`, `seekTo`, and disposal.
  - In-flight await is cancelable via a `Completer` so stale waits don't block.
  - **Duplicate** `completed` events are a no-op (fresh `.listen` per iteration).
  - **Late** completions after gen bump are caught by the post-await re-check.
- **`RepeatMode`** finally consumed in the playback path:
  - `none` — stop; `single` — loop whole file; `segment` — loop echo window (falls back to `none` without echo).
- **`YoutubePlayerEngine.resetCompletionFlag()`** — called before seek+play so `play()` drives the `<video>` directly instead of reloading the watch page.

### Tests (11 new)
- `RepeatMode.single` loops on completion; duplicate completed no double-seek; late completion after gen bump is no-op; `RepeatMode.none` stops; `RepeatMode.segment` seeks to echo start; segment without echo stops; clear cancels loop; user seek discards stale completion; `YoutubeSession.markCompleted` emits/idempotent/re-armed.

### Docs
- **ADR-0044** + `docs/features/player.md` updated (RepeatMode out of Future).

## Verification
- `flutter analyze` — 0 issues in changed files.
- `flutter test` — 1197 passed, 2 skipped, 1 pre-existing failure unrelated to this PR.

## Out of scope (per issue)
- Queue advance; folding echo boundary into the loop (follow-up); trial-listen `_playbackSessionId` (deferred).