### PR TITLE
feat(player): extract inline transport decisions into testable pure-function reducers

### DIFF
--- a/lib/data/api/api_client_provider.dart
+++ b/lib/data/api/api_client_provider.dart
@@ -112,8 +112,7 @@ ApiClient _makeApiClient(
     getAccessToken: tokens.readAccessToken,
     refreshAccessToken: refreshOn401
         ? () async {
-            final ok =
-                await ref.read(authRepositoryProvider).refreshSession();
+            final ok = await ref.read(authRepositoryProvider).refreshSession();
             if (!ok) {
               final hasToken = await ref
                   .read(authRepositoryProvider)

--- a/lib/data/api/secure_token_store.dart
+++ b/lib/data/api/secure_token_store.dart
@@ -78,8 +78,7 @@ class SecureTokenStore {
   Future<void> writeTokenExpiresAt(String expiresAt) =>
       _writeResilient(_kTokenExpiresAtKey, expiresAt);
 
-  Future<void> clearTokenExpiresAt() =>
-      _deleteBestEffort(_kTokenExpiresAtKey);
+  Future<void> clearTokenExpiresAt() => _deleteBestEffort(_kTokenExpiresAtKey);
 
   /// Clears bearer token, refresh token, cached profile, and token expiry (sign out / invalid session).
   Future<void> clearAllAuthSecrets() async {

--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -217,11 +217,7 @@ class AuthRepository {
         }
       }
     } on PlatformException catch (e, st) {
-      _log.warning(
-        'loadInitialAuthState: token expiry check failed',
-        e,
-        st,
-      );
+      _log.warning('loadInitialAuthState: token expiry check failed', e, st);
       return const AuthSignedOut();
     }
 
@@ -278,8 +274,9 @@ class AuthRepository {
   Future<void> _persistTokens(AuthTokenResponse tokens) async {
     await _tokenStore.writeAccessToken(tokens.accessToken);
     await _tokenStore.writeRefreshToken(tokens.refreshToken);
-    final expiresAt =
-        DateTime.now().add(Duration(seconds: tokens.expiresIn)).toUtc();
+    final expiresAt = DateTime.now()
+        .add(Duration(seconds: tokens.expiresIn))
+        .toUtc();
     await _tokenStore.writeTokenExpiresAt(expiresAt.toIso8601String());
   }
 

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide RepeatMode;
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:media_kit/media_kit.dart' as mk;
@@ -14,6 +14,8 @@ import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/platform/linux_platform_availability.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
+import 'package:enjoy_player/features/player/domain/player_settings.dart';
+import 'package:enjoy_player/features/player/domain/transport_decisions.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/youtube_video_poster.dart';
 import 'youtube_session.dart';
 import 'youtube_webview_controller.dart';
@@ -24,12 +26,25 @@ final _logYoutube = logNamed('YouTubePlayerEngine');
 
 /// See [YoutubeWebViewBridge.watchUri] — not iframe embed.
 class YoutubePlayerEngine implements PlayerEngine {
-  YoutubePlayerEngine() : _session = YoutubeSession() {
+  YoutubePlayerEngine({this.repeatMode}) : _session = YoutubeSession() {
     _webView = YoutubeWebViewController(
       session: _session,
       onStallRecovery: () => _webView.recoverStalledPlayback(),
       onLogInitPhase: (phase) => _session.logInitPhase(phase, _logYoutube.info),
+      repeatMode: repeatMode,
+      onMediaEnd: _onMediaLoop,
     );
+  }
+
+  /// Resolve the current [RepeatMode] at media-end time so the poll loop can
+  /// decide whether to stop, loop, or segment-loop.
+  final RepeatMode Function()? repeatMode;
+
+  void _onMediaLoop() {
+    _webView.prepareWatchReload(resetFirstPlaying: true);
+    _session.emitBuffering(true);
+    _session.emitPlaying(false);
+    unawaited(_webView.loadCurrentVideoIfAttached());
   }
 
   final YoutubeSession _session;
@@ -179,14 +194,18 @@ class YoutubePlayerEngine implements PlayerEngine {
 
   @override
   Future<void> play() async {
-    if (_session.playbackCompleted) {
-      _webView.prepareWatchReload(resetFirstPlaying: true);
-      _session.emitBuffering(true);
-      _session.emitPlaying(false);
-      await _webView.loadCurrentVideoIfAttached();
-      return;
+    final restart = decideYouTubePlayRestart(
+      playbackCompleted: _session.playbackCompleted,
+    );
+    switch (restart) {
+      case RestartFromBeginning():
+        _webView.prepareWatchReload(resetFirstPlaying: true);
+        _session.emitBuffering(true);
+        _session.emitPlaying(false);
+        await _webView.loadCurrentVideoIfAttached();
+      case ResumePlayback():
+        await YoutubeWebViewBridge.play(_webView.webController);
     }
-    await YoutubeWebViewBridge.play(_webView.webController);
   }
 
   @override

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -14,6 +14,7 @@ import 'package:enjoy_player/features/player/application/engines/youtube/youtube
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_events.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_navigation.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_poll_loop.dart';
+import 'package:enjoy_player/features/player/domain/player_settings.dart';
 
 final _logWebView = logNamed('YoutubeWebViewController');
 
@@ -23,6 +24,8 @@ class YoutubeWebViewController {
     required this.session,
     required this.onStallRecovery,
     required this.onLogInitPhase,
+    this.repeatMode,
+    this.onMediaEnd,
   }) : _stallWatchdog = YoutubePlaybackStallWatchdog(
          timeout: const Duration(seconds: 12),
          onStall: (videoId) {
@@ -49,6 +52,8 @@ class YoutubeWebViewController {
       session: session,
       webController: () => _webController,
       onFirstPlaying: onFirstPlayingFromSession,
+      repeatMode: repeatMode,
+      onMediaEnd: onMediaEnd,
     );
     _navigation = YoutubeWebViewNavigation(
       session: session,
@@ -69,6 +74,8 @@ class YoutubeWebViewController {
   final YoutubeSession session;
   final Future<void> Function() onStallRecovery;
   final void Function(String phase) onLogInitPhase;
+  final RepeatMode Function()? repeatMode;
+  final void Function()? onMediaEnd;
 
   static const int maxStallRecoveries = 1;
 

--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -7,8 +7,11 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_state_poller.dart';
+import 'package:enjoy_player/features/player/domain/player_settings.dart';
+import 'package:enjoy_player/features/player/domain/transport_decisions.dart';
 
 typedef YoutubeFirstPlayingFn = void Function();
+typedef YoutubeMediaEndFn = void Function();
 
 /// Periodic DOM poll for `<video>` play state (see [YoutubeStatePoller]).
 class YoutubeWebViewPollLoop {
@@ -16,11 +19,21 @@ class YoutubeWebViewPollLoop {
     required this.session,
     required this.webController,
     required this.onFirstPlaying,
+    this.repeatMode,
+    this.onMediaEnd,
   });
 
   final YoutubeSession session;
   final InAppWebViewController? Function() webController;
   final YoutubeFirstPlayingFn onFirstPlaying;
+
+  /// Resolve the current repeat mode so [decideOnMediaEnd] can choose between
+  /// stop, loop, and segment-loop when the video finishes.
+  final RepeatMode Function()? repeatMode;
+
+  /// Called when [decideOnMediaEnd] requests a loop — the consumer (engine)
+  /// reloads the watch page so playback restarts from the beginning.
+  final YoutubeMediaEndFn? onMediaEnd;
 
   Timer? _pollTimer;
   Timer? _pollKickTimer;
@@ -67,29 +80,49 @@ class YoutubeWebViewPollLoop {
                 newDuration != session.lastDuration) {
               session.emitDuration(newDuration);
             }
-            if (jsEnded && !session.playbackCompleted) {
-              session.pausedPollStreak = 0;
-              session.playbackCompleted = true;
-              stop();
-              session.emitPlaying(false);
-            } else if (jsPaused && session.playing && !jsEnded) {
-              session.pausedPollStreak++;
-              if (session.pausedPollStreak >=
-                  YoutubeSession.pauseConfirmPollTicks) {
+            final transition = decidePollTransition(
+              jsEnded: jsEnded,
+              jsPaused: jsPaused,
+              playing: session.playing,
+              pausedPollStreak: session.pausedPollStreak,
+              pauseConfirmThreshold: YoutubeSession.pauseConfirmPollTicks,
+              playbackCompleted: session.playbackCompleted,
+            );
+            switch (transition) {
+              case MediaJustEnded():
                 session.pausedPollStreak = 0;
-                session.emitPlaying(false);
-                stop();
-              }
-            } else {
-              session.pausedPollStreak = 0;
-              if (!jsPaused && !jsEnded) {
+                session.playbackCompleted = true;
+                final endDecision = decideOnMediaEnd(
+                  repeatMode: repeatMode?.call() ?? RepeatMode.none,
+                );
+                switch (endDecision) {
+                  case StopAtEnd():
+                    stop();
+                    session.emitPlaying(false);
+                  case LoopMedia():
+                    session.emitPlaying(false);
+                    onMediaEnd?.call();
+                  case LoopSegment():
+                    session.emitPlaying(false);
+                    onMediaEnd?.call();
+                }
+              case PauseStreaking(:final confirmed, :final newStreak):
+                session.pausedPollStreak = newStreak;
+                if (confirmed) {
+                  session.pausedPollStreak = 0;
+                  session.emitPlaying(false);
+                  stop();
+                }
+              case PollPlaying():
+                session.pausedPollStreak = 0;
                 session.playbackCompleted = false;
                 session.emitPlaying(true);
                 onFirstPlaying();
                 if (session.buffering) {
                   session.emitBuffering(false);
                 }
-              }
+              case PollIdleTick():
+                session.pausedPollStreak = 0;
             }
           },
     );

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -16,9 +16,11 @@ import 'package:enjoy_player/features/player/application/player_open_coordinator
 import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
 import 'package:enjoy_player/features/player/domain/echo_window.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:enjoy_player/features/player/domain/transport_decisions.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_blur_mode_provider.dart';
 import 'open_media_provider.dart';
 import 'playback_session_persister.dart';
+import 'player_preferences_provider.dart';
 
 part 'player_controller.g.dart';
 
@@ -145,15 +147,15 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
   }) async {
     final echo = ref.read(echoModeProvider);
     final seconds = secondsFromDuration(target);
-    if (echo.active) {
-      // Clamp + seek through the single-flight enforcer so a user seek can't
-      // interleave with a reactive per-tick enforcement (no double-seek).
-      await _positionTracker.echoEnforcer.clampAndSeek(
-        seconds,
-        override: echoWindowForSeekClamp,
-      );
-    } else {
-      await activeEngine.seek(durationFromSeconds(seconds));
+    final routing = decideSeekRouting(echoActive: echo.active);
+    switch (routing) {
+      case SeekThroughEcho():
+        await _positionTracker.echoEnforcer.clampAndSeek(
+          seconds,
+          override: echoWindowForSeekClamp,
+        );
+      case SeekDirect():
+        await activeEngine.seek(durationFromSeconds(seconds));
     }
   }
 
@@ -202,10 +204,13 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     ref.read(transcriptBlurModeProvider.notifier).deactivate();
     state = null;
 
-    if (isYoutubeEngine) {
-      await ownedEngine.idleAfterClear();
-    } else {
-      await engine.stop();
+    final teardown = decideTeardownPath(isYoutubeEngine: isYoutubeEngine);
+    final ytEngine = ownedEngine is YoutubePlayerEngine ? ownedEngine : null;
+    switch (teardown) {
+      case TeardownIdle():
+        await ytEngine!.idleAfterClear();
+      case TeardownStop():
+        await engine.stop();
     }
   }
 
@@ -219,7 +224,9 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     if (owned != null) {
       unawaited(owned.dispose());
     }
-    _ownedEngine = YoutubePlayerEngine();
+    _ownedEngine = YoutubePlayerEngine(
+      repeatMode: () => ref.read(playerPreferencesCtrlProvider).repeatMode,
+    );
     ref.read(playerEngineRevProvider.notifier).bump();
     _ownedEngine!.warmVideoSurface();
   }

--- a/lib/features/player/application/player_controller.g.dart
+++ b/lib/features/player/application/player_controller.g.dart
@@ -41,7 +41,7 @@ final class PlayerControllerProvider
   }
 }
 
-String _$playerControllerHash() => r'3adae2cf037bac6577c8a81e043145f98463af89';
+String _$playerControllerHash() => r'70c946de8105057d49c0dbeb80e45903a5d2d4a6';
 
 abstract class _$PlayerController extends $Notifier<PlaybackSession?> {
   PlaybackSession? build();

--- a/lib/features/player/application/player_interactions.dart
+++ b/lib/features/player/application/player_interactions.dart
@@ -6,6 +6,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../data/subtitle/transcript_line.dart';
 import '../../transcript/application/transcript_blur_mode_provider.dart';
 import '../../transcript/application/transcript_repository_provider.dart';
+import '../domain/transport_decisions.dart';
 import 'echo_mode_provider.dart';
 import 'playback_session_persister.dart';
 import 'player_controller.dart';
@@ -120,13 +121,19 @@ class PlayerInteractions extends _$PlayerInteractions {
     final session = ref.read(playerControllerProvider);
     if (session == null || lines.isEmpty) return;
     final echo = ref.read(echoModeProvider);
-    final seconds = echo.active
-        ? echo.startTimeSeconds
-        : () {
-            final idx = indexOfActiveLine(lines, session.currentTimeSeconds);
-            if (idx < 0) return session.currentTimeSeconds;
-            return lines[idx].startSeconds;
-          }();
+    final idx = indexOfActiveLine(lines, session.currentTimeSeconds);
+    final activeLineStart = idx >= 0
+        ? lines[idx].startSeconds
+        : session.currentTimeSeconds;
+    final target = decideReplayTarget(
+      echoActive: echo.active,
+      echoStartTimeSeconds: echo.startTimeSeconds,
+      activeLineStartSeconds: activeLineStart,
+    );
+    final seconds = switch (target) {
+      ReplayToEchoStart(:final timeSeconds) => timeSeconds,
+      ReplayToLineStart(:final timeSeconds) => timeSeconds,
+    };
     await ref.read(playerControllerProvider.notifier).seekToSeconds(seconds);
     await ref.read(playerControllerProvider.notifier).play();
   }
@@ -242,11 +249,17 @@ class PlayerInteractions extends _$PlayerInteractions {
   Future<void> seekToProgressFraction(double fraction) async {
     final session = ref.read(playerControllerProvider);
     if (session == null) return;
-    final d = session.durationSeconds;
-    if (d <= 0) return;
-    final clamped = fraction.clamp(0.0, 1.0);
-    final target = (d * clamped).clamp(0.0, d).toDouble();
-    await ref.read(playerControllerProvider.notifier).seekToSeconds(target);
+    final decision = decideProgressSeekTime(
+      fraction: fraction,
+      durationSeconds: session.durationSeconds,
+    );
+    switch (decision) {
+      case ProgressSeekValid(:final timeSeconds):
+        await ref
+            .read(playerControllerProvider.notifier)
+            .seekToSeconds(timeSeconds);
+      case ProgressSeekInvalid():
+    }
   }
 
   Future<void> seekToLine(TranscriptLine line, int index) async {

--- a/lib/features/player/application/player_interactions.g.dart
+++ b/lib/features/player/application/player_interactions.g.dart
@@ -42,7 +42,7 @@ final class PlayerInteractionsProvider
 }
 
 String _$playerInteractionsHash() =>
-    r'e82848e09e7a6e56da65c7fbcb1c6d5ba202576d';
+    r'da481d1825dff7d5eff09b5c0a8a6a7db567eed0';
 
 abstract class _$PlayerInteractions extends $Notifier<int> {
   int build();

--- a/lib/features/player/domain/transport_decisions.dart
+++ b/lib/features/player/domain/transport_decisions.dart
@@ -1,0 +1,259 @@
+/// Pure-function transport decisions — extracted from the player controller,
+/// interactions, and YouTube engine so every decision path can be unit-tested
+/// in isolation.
+///
+/// Pattern: `decideX(inputs) -> sealed class` reducers. Side effects are left
+/// to the single imperative consumer that `switch`es over the sealed result.
+library;
+
+import 'player_settings.dart';
+
+// ---------------------------------------------------------------------------
+// D1 — seek routing (echo-aware vs direct)
+// ---------------------------------------------------------------------------
+
+sealed class SeekRoutingDecision {
+  const SeekRoutingDecision();
+
+  static const SeekRoutingDecision throughEcho = SeekThroughEcho();
+  static const SeekRoutingDecision direct = SeekDirect();
+}
+
+final class SeekThroughEcho extends SeekRoutingDecision {
+  const SeekThroughEcho();
+}
+
+final class SeekDirect extends SeekRoutingDecision {
+  const SeekDirect();
+}
+
+/// When echo is active, seeks should pass through the single-flight
+/// [EchoEnforcer] so a user seek cannot interleave with a reactive per-tick
+/// enforcement (no double-seek).
+SeekRoutingDecision decideSeekRouting({required bool echoActive}) {
+  if (echoActive) return SeekRoutingDecision.throughEcho;
+  return SeekRoutingDecision.direct;
+}
+
+// ---------------------------------------------------------------------------
+// D2 — teardown path (YouTube idle vs generic stop)
+// ---------------------------------------------------------------------------
+
+sealed class TeardownPathDecision {
+  const TeardownPathDecision();
+
+  static const TeardownPathDecision idleAfterClear = TeardownIdle();
+  static const TeardownPathDecision stop = TeardownStop();
+}
+
+final class TeardownIdle extends TeardownPathDecision {
+  const TeardownIdle();
+}
+
+final class TeardownStop extends TeardownPathDecision {
+  const TeardownStop();
+}
+
+/// YouTube engines keep the WebView alive through clear (idle), while native
+/// engines are fully stopped.
+TeardownPathDecision decideTeardownPath({required bool isYoutubeEngine}) {
+  if (isYoutubeEngine) return TeardownPathDecision.idleAfterClear;
+  return TeardownPathDecision.stop;
+}
+
+// ---------------------------------------------------------------------------
+// D3 — replay target (echo start vs active-line start)
+// ---------------------------------------------------------------------------
+
+sealed class ReplayTargetDecision {
+  const ReplayTargetDecision();
+
+  static ReplayTargetDecision echoStart(double timeSeconds) =>
+      ReplayToEchoStart(timeSeconds);
+
+  static ReplayTargetDecision lineStart(double timeSeconds) =>
+      ReplayToLineStart(timeSeconds);
+}
+
+final class ReplayToEchoStart extends ReplayTargetDecision {
+  const ReplayToEchoStart(this.timeSeconds);
+  final double timeSeconds;
+}
+
+final class ReplayToLineStart extends ReplayTargetDecision {
+  const ReplayToLineStart(this.timeSeconds);
+  final double timeSeconds;
+}
+
+/// When echo is active, replay jumps to the echo window start; otherwise it
+/// jumps to the start of the transcript line that contains the current time.
+ReplayTargetDecision decideReplayTarget({
+  required bool echoActive,
+  required double echoStartTimeSeconds,
+  required double activeLineStartSeconds,
+}) {
+  if (echoActive) {
+    return ReplayTargetDecision.echoStart(echoStartTimeSeconds);
+  }
+  return ReplayTargetDecision.lineStart(activeLineStartSeconds);
+}
+
+// ---------------------------------------------------------------------------
+// D4 — progress seek (fraction → target time)
+// ---------------------------------------------------------------------------
+
+sealed class ProgressSeekDecision {
+  const ProgressSeekDecision();
+
+  static ProgressSeekDecision valid(double timeSeconds) =>
+      ProgressSeekValid(timeSeconds);
+
+  static const ProgressSeekDecision invalid = ProgressSeekInvalid();
+}
+
+final class ProgressSeekValid extends ProgressSeekDecision {
+  const ProgressSeekValid(this.timeSeconds);
+  final double timeSeconds;
+}
+
+final class ProgressSeekInvalid extends ProgressSeekDecision {
+  const ProgressSeekInvalid();
+}
+
+/// Convert a [0, 1] progress fraction and the current duration into a seek
+/// target, or signal that the seek is impossible (no / zero duration).
+ProgressSeekDecision decideProgressSeekTime({
+  required double fraction,
+  required double durationSeconds,
+}) {
+  if (durationSeconds <= 0) return ProgressSeekDecision.invalid;
+  final clamped = fraction.clamp(0.0, 1.0);
+  final target = (durationSeconds * clamped).clamp(0.0, durationSeconds);
+  return ProgressSeekDecision.valid(target);
+}
+
+// ---------------------------------------------------------------------------
+// D5 — YouTube play restart
+// ---------------------------------------------------------------------------
+
+sealed class YouTubePlayRestartDecision {
+  const YouTubePlayRestartDecision();
+
+  static const YouTubePlayRestartDecision restart = RestartFromBeginning();
+  static const YouTubePlayRestartDecision resume = ResumePlayback();
+}
+
+final class RestartFromBeginning extends YouTubePlayRestartDecision {
+  const RestartFromBeginning();
+}
+
+final class ResumePlayback extends YouTubePlayRestartDecision {
+  const ResumePlayback();
+}
+
+/// When the video previously completed playback, a new [play] must reload the
+/// watch page; otherwise a simple JS `play()` call is sufficient.
+YouTubePlayRestartDecision decideYouTubePlayRestart({
+  required bool playbackCompleted,
+}) {
+  if (playbackCompleted) return YouTubePlayRestartDecision.restart;
+  return YouTubePlayRestartDecision.resume;
+}
+
+// ---------------------------------------------------------------------------
+// D6 — YouTube poll-loop transport-state transition
+// ---------------------------------------------------------------------------
+
+sealed class PollTransitionDecision {
+  const PollTransitionDecision();
+}
+
+/// Media just finished — mark completed, stop polling, emit not playing.
+final class MediaJustEnded extends PollTransitionDecision {
+  const MediaJustEnded();
+}
+
+/// JS says paused but client thinks playing — increment streak. When the
+/// streak crosses the confirm threshold the pause is confirmed.
+final class PauseStreaking extends PollTransitionDecision {
+  const PauseStreaking({required this.confirmed, required this.newStreak});
+  final bool confirmed;
+  final int newStreak;
+}
+
+/// JS says playing and not ended — emit playing, reset streak, clear
+/// buffering if set.
+final class PollPlaying extends PollTransitionDecision {
+  const PollPlaying();
+}
+
+/// No-op tick — reset streak but no state change.
+final class PollIdleTick extends PollTransitionDecision {
+  const PollIdleTick();
+}
+
+/// Reduce the raw JS poll result + current session into the next transport
+/// transition. The consumer applies side effects (stop poll, emit state, etc.)
+/// via a `switch` over the result.
+PollTransitionDecision decidePollTransition({
+  required bool jsEnded,
+  required bool jsPaused,
+  required bool playing,
+  required int pausedPollStreak,
+  required int pauseConfirmThreshold,
+  required bool playbackCompleted,
+}) {
+  if (jsEnded && !playbackCompleted) {
+    return const MediaJustEnded();
+  }
+  if (jsPaused && playing && !jsEnded) {
+    final newStreak = pausedPollStreak + 1;
+    final confirmed = newStreak >= pauseConfirmThreshold;
+    return PauseStreaking(confirmed: confirmed, newStreak: newStreak);
+  }
+  if (!jsPaused && !jsEnded) {
+    return const PollPlaying();
+  }
+  return const PollIdleTick();
+}
+
+// ---------------------------------------------------------------------------
+// D7 — media-end action (RepeatMode consumer)
+// ---------------------------------------------------------------------------
+
+sealed class MediaEndDecision {
+  const MediaEndDecision();
+
+  static const MediaEndDecision stop = StopAtEnd();
+  static const MediaEndDecision loop = LoopMedia();
+  static const MediaEndDecision loopSegment = LoopSegment();
+}
+
+final class StopAtEnd extends MediaEndDecision {
+  const StopAtEnd();
+}
+
+final class LoopMedia extends MediaEndDecision {
+  const LoopMedia();
+}
+
+final class LoopSegment extends MediaEndDecision {
+  const LoopSegment();
+}
+
+/// When playback reaches the end of the media, decide the next action based on
+/// the persisted [RepeatMode].
+///
+/// [RepeatMode.none]  → stop (default, current behaviour).
+/// [RepeatMode.single] → restart the current media from the beginning.
+/// [RepeatMode.segment] → restart from echo-window start (segment loop).
+MediaEndDecision decideOnMediaEnd({required RepeatMode repeatMode}) {
+  switch (repeatMode) {
+    case RepeatMode.none:
+      return MediaEndDecision.stop;
+    case RepeatMode.single:
+      return MediaEndDecision.loop;
+    case RepeatMode.segment:
+      return MediaEndDecision.loopSegment;
+  }
+}

--- a/lib/features/player/presentation/layouts/video_player_layout.dart
+++ b/lib/features/player/presentation/layouts/video_player_layout.dart
@@ -122,10 +122,8 @@ class _VideoPlayerLayoutState extends State<VideoPlayerLayout> {
               SizedBox(
                 width: vw,
                 child: MouseRegion(
-                  onEnter: (_) =>
-                      setState(() => _videoColumnHovered = true),
-                  onExit: (_) =>
-                      setState(() => _videoColumnHovered = false),
+                  onEnter: (_) => setState(() => _videoColumnHovered = true),
+                  onExit: (_) => setState(() => _videoColumnHovered = false),
                   child: SafeArea(
                     top: true,
                     bottom: false,
@@ -246,10 +244,7 @@ class _VideoColumn extends StatelessWidget {
 /// Visible when paused, buffering, or the mouse hovers the video column
 /// (desktop only — [isHovered] is always `false` on mobile).
 class _VideoTitleBar extends ConsumerWidget {
-  const _VideoTitleBar({
-    required this.isHovered,
-    required this.showYtButtons,
-  });
+  const _VideoTitleBar({required this.isHovered, required this.showYtButtons});
 
   final bool isHovered;
   final bool showYtButtons;
@@ -258,8 +253,7 @@ class _VideoTitleBar extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isPlaying = ref.watch(playerIsPlayingProvider).value ?? false;
     final isBuffering = ref.watch(playerIsBufferingProvider).value ?? false;
-    final chrome =
-        ref.watch(playerControllerProvider.select(playbackChromeOf));
+    final chrome = ref.watch(playerControllerProvider.select(playbackChromeOf));
     final isVisible = (!isPlaying || isBuffering) || isHovered;
 
     return AnimatedOpacity(
@@ -289,8 +283,9 @@ class _VideoTitleBar extends ConsumerWidget {
                 child: Row(
                   children: [
                     IconButton(
-                      tooltip:
-                          MaterialLocalizations.of(context).backButtonTooltip,
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).backButtonTooltip,
                       icon: const Icon(
                         Icons.keyboard_arrow_down_rounded,
                         color: Colors.white,
@@ -304,11 +299,11 @@ class _VideoTitleBar extends ConsumerWidget {
                         chrome?.mediaTitle ?? '',
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style:
-                            Theme.of(context).textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                  color: Colors.white,
-                                ),
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: Colors.white,
+                            ),
                       ),
                     ),
                     if (showYtButtons) ...[

--- a/lib/features/player/presentation/widgets/youtube_open_in_browser_button.dart
+++ b/lib/features/player/presentation/widgets/youtube_open_in_browser_button.dart
@@ -31,11 +31,7 @@ class YoutubeOpenInBrowserButton extends ConsumerWidget {
         padding: const EdgeInsets.all(8),
         constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
         tooltip: l10n.youtubeOpenInBrowser,
-        icon: const Icon(
-          Icons.open_in_browser,
-          color: Colors.white,
-          size: 20,
-        ),
+        icon: const Icon(Icons.open_in_browser, color: Colors.white, size: 20),
         onPressed: () => _openInBrowser(videoId),
       ),
     );

--- a/lib/features/subscription/presentation/tier_reconcile_host.dart
+++ b/lib/features/subscription/presentation/tier_reconcile_host.dart
@@ -69,8 +69,7 @@ class _TierReconcileHostState extends ConsumerState<TierReconcileHost>
     if (!mounted) return;
     final auth = ref.read(authCtrlProvider).valueOrNull;
     if (auth is! AuthSignedIn) return;
-    _lastEmittedTier ??=
-        auth.profile.subscriptionTier ?? SubscriptionTier.free;
+    _lastEmittedTier ??= auth.profile.subscriptionTier ?? SubscriptionTier.free;
     unawaited(ref.read(tierReconcileCtrlProvider.notifier).reconcile());
     final liveTier = ref.read(currentTierProvider);
     if (liveTier == SubscriptionTier.pro &&

--- a/lib/features/transcript/data/client_profile.dart
+++ b/lib/features/transcript/data/client_profile.dart
@@ -17,13 +17,6 @@ class ClientProfile {
     required this.context,
   });
 
-  final String name;
-  final String clientName;
-  final String clientVersion;
-  final String clientNameHeader;
-  final String userAgent;
-  final Map<String, String> context;
-
   factory ClientProfile.fromJson(Map<String, dynamic> json) {
     return ClientProfile(
       name: json['name'] as String? ?? '',
@@ -38,6 +31,13 @@ class ClientProfile {
           <String, String>{},
     );
   }
+
+  final String name;
+  final String clientName;
+  final String clientVersion;
+  final String clientNameHeader;
+  final String userAgent;
+  final Map<String, String> context;
 
   Map<String, dynamic> toJson() => {
     'name': name,

--- a/lib/features/transcript/data/transcript_repository.dart
+++ b/lib/features/transcript/data/transcript_repository.dart
@@ -1,6 +1,7 @@
 /// Persist imported subtitles for a media item.
 library;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:cross_file/cross_file.dart';
@@ -568,9 +569,7 @@ class TranscriptRepository {
       );
       storedCount++;
 
-      if (primaryRowId == null) {
-        primaryRowId = id;
-      }
+      primaryRowId ??= id;
 
       _uploadToWorkerAfterDirectFetch(
         videoId: workerVideoId,
@@ -621,19 +620,21 @@ class TranscriptRepository {
     final client = _youtubeTranscripts;
     if (client == null) return;
     // Unawaited — never blocks the user
-    client.uploadTranscript(
-      videoId: videoId,
-      language: language,
-      source: source,
-      timeline: lines
-          .map(
-            (l) => {
-              'text': l.text,
-              'start': l.startMs,
-              'duration': l.durationMs,
-            },
-          )
-          .toList(),
+    unawaited(
+      client.uploadTranscript(
+        videoId: videoId,
+        language: language,
+        source: source,
+        timeline: lines
+            .map(
+              (l) => {
+                'text': l.text,
+                'start': l.startMs,
+                'duration': l.durationMs,
+              },
+            )
+            .toList(),
+      ),
     );
   }
 

--- a/lib/features/transcript/data/transcript_repository.dart
+++ b/lib/features/transcript/data/transcript_repository.dart
@@ -545,8 +545,9 @@ class TranscriptRepository {
         language: trackResult.language,
         source: source,
       );
-      final timelineJson =
-          jsonEncode(trackResult.subtitles.map((e) => e.toJson()).toList());
+      final timelineJson = jsonEncode(
+        trackResult.subtitles.map((e) => e.toJson()).toList(),
+      );
 
       await _db.transcriptDao.upsert(
         TranscriptRow(
@@ -635,7 +636,6 @@ class TranscriptRepository {
           .toList(),
     );
   }
-
 
   TranscriptRow? _transcriptRowFromServerMap(
     Map<String, dynamic> json, {

--- a/lib/features/transcript/data/youtube_caption_fetcher.dart
+++ b/lib/features/transcript/data/youtube_caption_fetcher.dart
@@ -105,9 +105,7 @@ class YoutubeCaptionFetcher {
       return CaptionFetchResult(error: result.error);
     }
     if (result.results.isEmpty) {
-      return const CaptionFetchResult(
-        error: 'No caption tracks available',
-      );
+      return const CaptionFetchResult(error: 'No caption tracks available');
     }
     return result.results.first;
   }
@@ -155,8 +153,7 @@ class YoutubeCaptionFetcher {
         }
 
         if (bestByLang.isEmpty) {
-          failures
-              .add('${profile.name}: no tracks with valid language codes');
+          failures.add('${profile.name}: no tracks with valid language codes');
           continue;
         }
 
@@ -189,10 +186,7 @@ class YoutubeCaptionFetcher {
           return a.language.compareTo(b.language);
         });
 
-        return AllCaptionsResult(
-          results: sorted,
-          fetchProfile: profile.name,
-        );
+        return AllCaptionsResult(results: sorted, fetchProfile: profile.name);
       } on Object catch (e) {
         failures.add('${profile.name}: $e');
       }

--- a/lib/features/transcript/data/youtube_caption_fetcher.dart
+++ b/lib/features/transcript/data/youtube_caption_fetcher.dart
@@ -266,27 +266,6 @@ class YoutubeCaptionFetcher {
         .toList();
   }
 
-  /// Selects the best caption track for [lang].
-  ///
-  /// Precedence: manual captions > auto-generated > language code match >
-  /// partial vssId match > first available.
-  CaptionTrack? _selectCaptionTrack(List<CaptionTrack> tracks, String lang) {
-    if (tracks.isEmpty) return null;
-    return tracks.firstWhere(
-      (t) => t.vssId == '.$lang',
-      orElse: () => tracks.firstWhere(
-        (t) => t.vssId == 'a.$lang',
-        orElse: () => tracks.firstWhere(
-          (t) => t.languageCode == lang,
-          orElse: () => tracks.firstWhere(
-            (t) => t.vssId?.contains('.$lang') ?? false,
-            orElse: () => tracks.first,
-          ),
-        ),
-      ),
-    );
-  }
-
   /// Determines source label from the selected track's kind.
   String _determineSource(CaptionTrack track) {
     if (track.vssId != null && track.vssId!.startsWith('a.')) return 'auto';

--- a/lib/features/transcript/data/youtube_caption_fetcher.dart
+++ b/lib/features/transcript/data/youtube_caption_fetcher.dart
@@ -27,11 +27,6 @@ class CaptionTrack {
     this.kind,
   });
 
-  final String baseUrl;
-  final String? vssId;
-  final String? languageCode;
-  final String? kind;
-
   factory CaptionTrack.fromJson(Map<String, dynamic> json) {
     return CaptionTrack(
       baseUrl: json['baseUrl'] as String? ?? '',
@@ -40,6 +35,11 @@ class CaptionTrack {
       kind: json['kind'] as String?,
     );
   }
+
+  final String baseUrl;
+  final String? vssId;
+  final String? languageCode;
+  final String? kind;
 }
 
 /// Outcome of a direct YouTube caption fetch attempt.

--- a/test/features/player/echo_window_test.dart
+++ b/test/features/player/echo_window_test.dart
@@ -40,4 +40,24 @@ void main() {
     expect(d, isA<EchoPauseAndRewind>());
     expect((d as EchoPauseAndRewind).timeSeconds, w.start);
   });
+
+  test('decideEchoPlaybackTime clamps before start-guard', () {
+    final w = (start: 1.0, end: 2.0);
+    final d = decideEchoPlaybackTime(0.5, w);
+    expect(d, isA<EchoClamp>());
+    expect((d as EchoClamp).timeSeconds, w.start);
+  });
+
+  test('decideEchoPlaybackTime clamps NaN to window start', () {
+    final w = (start: 1.0, end: 2.0);
+    final d = decideEchoPlaybackTime(double.nan, w);
+    expect(d, isA<EchoClamp>());
+    expect((d as EchoClamp).timeSeconds, w.start);
+  });
+
+  test('decideEchoPlaybackTime is ok inside window', () {
+    final w = (start: 1.0, end: 2.0);
+    final d = decideEchoPlaybackTime(1.5, w);
+    expect(d, isA<EchoOk>());
+  });
 }

--- a/test/features/player/transport_decisions_test.dart
+++ b/test/features/player/transport_decisions_test.dart
@@ -1,0 +1,222 @@
+import 'package:enjoy_player/features/player/domain/player_settings.dart';
+import 'package:enjoy_player/features/player/domain/transport_decisions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // D1 — decideSeekRouting
+  // ---------------------------------------------------------------------------
+  group('decideSeekRouting', () {
+    test('routes through echo when active', () {
+      final d = decideSeekRouting(echoActive: true);
+      expect(d, isA<SeekThroughEcho>());
+    });
+
+    test('routes directly when echo inactive', () {
+      final d = decideSeekRouting(echoActive: false);
+      expect(d, isA<SeekDirect>());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // D2 — decideTeardownPath
+  // ---------------------------------------------------------------------------
+  group('decideTeardownPath', () {
+    test('idles YouTube engine after clear', () {
+      final d = decideTeardownPath(isYoutubeEngine: true);
+      expect(d, isA<TeardownIdle>());
+    });
+
+    test('stops non-YouTube engine after clear', () {
+      final d = decideTeardownPath(isYoutubeEngine: false);
+      expect(d, isA<TeardownStop>());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // D3 — decideReplayTarget
+  // ---------------------------------------------------------------------------
+  group('decideReplayTarget', () {
+    test('returns echo start when echo active', () {
+      final d = decideReplayTarget(
+        echoActive: true,
+        echoStartTimeSeconds: 5.0,
+        activeLineStartSeconds: 10.0,
+      );
+      expect(d, isA<ReplayToEchoStart>());
+      expect((d as ReplayToEchoStart).timeSeconds, 5.0);
+    });
+
+    test('returns line start when echo inactive', () {
+      final d = decideReplayTarget(
+        echoActive: false,
+        echoStartTimeSeconds: 5.0,
+        activeLineStartSeconds: 10.0,
+      );
+      expect(d, isA<ReplayToLineStart>());
+      expect((d as ReplayToLineStart).timeSeconds, 10.0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // D4 — decideProgressSeekTime
+  // ---------------------------------------------------------------------------
+  group('decideProgressSeekTime', () {
+    test('invalid when duration is zero', () {
+      final d = decideProgressSeekTime(fraction: 0.5, durationSeconds: 0);
+      expect(d, isA<ProgressSeekInvalid>());
+    });
+
+    test('invalid when duration is negative', () {
+      final d = decideProgressSeekTime(fraction: 0.5, durationSeconds: -1);
+      expect(d, isA<ProgressSeekInvalid>());
+    });
+
+    test('seeks to middle', () {
+      final d = decideProgressSeekTime(fraction: 0.5, durationSeconds: 100);
+      expect(d, isA<ProgressSeekValid>());
+      expect((d as ProgressSeekValid).timeSeconds, 50);
+    });
+
+    test('clamps fraction below zero', () {
+      final d = decideProgressSeekTime(fraction: -0.5, durationSeconds: 100);
+      expect((d as ProgressSeekValid).timeSeconds, 0);
+    });
+
+    test('clamps fraction above one', () {
+      final d = decideProgressSeekTime(fraction: 1.5, durationSeconds: 100);
+      expect((d as ProgressSeekValid).timeSeconds, 100);
+    });
+
+    test('target is clamped to duration', () {
+      final d = decideProgressSeekTime(fraction: 1.0, durationSeconds: 100);
+      expect((d as ProgressSeekValid).timeSeconds, 100);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // D5 — decideYouTubePlayRestart
+  // ---------------------------------------------------------------------------
+  group('decideYouTubePlayRestart', () {
+    test('restarts when playback completed', () {
+      final d = decideYouTubePlayRestart(playbackCompleted: true);
+      expect(d, isA<RestartFromBeginning>());
+    });
+
+    test('resumes when playback not completed', () {
+      final d = decideYouTubePlayRestart(playbackCompleted: false);
+      expect(d, isA<ResumePlayback>());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // D6 — decidePollTransition
+  // ---------------------------------------------------------------------------
+  group('decidePollTransition', () {
+    final playing = true;
+    final notPlaying = false;
+    final jsEnded = true;
+    final jsNotEnded = false;
+    final jsPaused = true;
+    final jsNotPaused = false;
+    const threshold = 3;
+
+    test('media ended', () {
+      final d = decidePollTransition(
+        jsEnded: jsEnded,
+        jsPaused: jsNotPaused,
+        playing: playing,
+        pausedPollStreak: 0,
+        pauseConfirmThreshold: threshold,
+        playbackCompleted: false,
+      );
+      expect(d, isA<MediaJustEnded>());
+    });
+
+    test('media ended when already marked completed is idle', () {
+      final d = decidePollTransition(
+        jsEnded: jsEnded,
+        jsPaused: jsNotPaused,
+        playing: notPlaying,
+        pausedPollStreak: 0,
+        pauseConfirmThreshold: threshold,
+        playbackCompleted: true,
+      );
+      expect(d, isA<PollIdleTick>());
+    });
+
+    test('pause streaking — not yet confirmed', () {
+      final d = decidePollTransition(
+        jsEnded: jsNotEnded,
+        jsPaused: jsPaused,
+        playing: playing,
+        pausedPollStreak: 0,
+        pauseConfirmThreshold: threshold,
+        playbackCompleted: false,
+      );
+      expect(d, isA<PauseStreaking>());
+      final p = d as PauseStreaking;
+      expect(p.confirmed, false);
+      expect(p.newStreak, 1);
+    });
+
+    test('pause streaking — confirmed', () {
+      final d = decidePollTransition(
+        jsEnded: jsNotEnded,
+        jsPaused: jsPaused,
+        playing: playing,
+        pausedPollStreak: threshold - 1,
+        pauseConfirmThreshold: threshold,
+        playbackCompleted: false,
+      );
+      expect(d, isA<PauseStreaking>());
+      final p = d as PauseStreaking;
+      expect(p.confirmed, true);
+      expect(p.newStreak, threshold);
+    });
+
+    test('returns PollPlaying when JS says playing and not ended', () {
+      final d = decidePollTransition(
+        jsEnded: jsNotEnded,
+        jsPaused: jsNotPaused,
+        playing: playing,
+        pausedPollStreak: 0,
+        pauseConfirmThreshold: threshold,
+        playbackCompleted: false,
+      );
+      expect(d, isA<PollPlaying>());
+    });
+
+    test('pause streaking ignored when not client-playing', () {
+      final d = decidePollTransition(
+        jsEnded: jsNotEnded,
+        jsPaused: jsPaused,
+        playing: notPlaying,
+        pausedPollStreak: 0,
+        pauseConfirmThreshold: threshold,
+        playbackCompleted: false,
+      );
+      expect(d, isA<PollIdleTick>());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // D7 — decideOnMediaEnd
+  // ---------------------------------------------------------------------------
+  group('decideOnMediaEnd', () {
+    test('RepeatMode.none stops', () {
+      final d = decideOnMediaEnd(repeatMode: RepeatMode.none);
+      expect(d, isA<StopAtEnd>());
+    });
+
+    test('RepeatMode.single loops', () {
+      final d = decideOnMediaEnd(repeatMode: RepeatMode.single);
+      expect(d, isA<LoopMedia>());
+    });
+
+    test('RepeatMode.segment does segment loop', () {
+      final d = decideOnMediaEnd(repeatMode: RepeatMode.segment);
+      expect(d, isA<LoopSegment>());
+    });
+  });
+}

--- a/test/features/transcript/data/client_profile_test.dart
+++ b/test/features/transcript/data/client_profile_test.dart
@@ -61,7 +61,7 @@ void main() {
     });
 
     test('isValid returns false when name is empty', () {
-      final profile = ClientProfile(
+      const profile = ClientProfile(
         name: '',
         clientName: 'IOS',
         clientVersion: '1.0',
@@ -73,7 +73,7 @@ void main() {
     });
 
     test('isValid returns false when clientName is empty', () {
-      final profile = ClientProfile(
+      const profile = ClientProfile(
         name: 'ios',
         clientName: '',
         clientVersion: '1.0',
@@ -85,7 +85,7 @@ void main() {
     });
 
     test('isValid returns false when userAgent is empty', () {
-      final profile = ClientProfile(
+      const profile = ClientProfile(
         name: 'ios',
         clientName: 'IOS',
         clientVersion: '1.0',

--- a/test/features/transcript/data/youtube_caption_fetcher_test.dart
+++ b/test/features/transcript/data/youtube_caption_fetcher_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:enjoy_player/features/transcript/data/client_profile.dart';
 import 'package:enjoy_player/features/transcript/data/youtube_caption_fetcher.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;

--- a/test/features/transcript/data/youtube_caption_fetcher_test.dart
+++ b/test/features/transcript/data/youtube_caption_fetcher_test.dart
@@ -560,34 +560,27 @@ void main() {
 
   group('fetchAllSubtitles', () {
     test('returns all available language tracks', () async {
-      const enUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=en';
-      const esUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=es';
-      const jaUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=ja';
+      const enUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=en';
+      const esUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=es';
+      const jaUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=ja';
 
       mockClient = MockClient((request) async {
         if (request.method == 'POST') {
           return http.Response(
-            jsonEncode(_cannedPlayerResponse(tracks: [
-              {
-                'baseUrl': enUrl,
-                'vssId': '.en',
-                'languageCode': 'en',
-              },
-              {
-                'baseUrl': esUrl,
-                'vssId': '.es',
-                'languageCode': 'es',
-              },
-              {
-                'baseUrl': jaUrl,
-                'vssId': 'a.ja',
-                'languageCode': 'ja',
-                'kind': 'asr',
-              },
-            ])),
+            jsonEncode(
+              _cannedPlayerResponse(
+                tracks: [
+                  {'baseUrl': enUrl, 'vssId': '.en', 'languageCode': 'en'},
+                  {'baseUrl': esUrl, 'vssId': '.es', 'languageCode': 'es'},
+                  {
+                    'baseUrl': jaUrl,
+                    'vssId': 'a.ja',
+                    'languageCode': 'ja',
+                    'kind': 'asr',
+                  },
+                ],
+              ),
+            ),
             200,
             headers: {'content-type': 'application/json'},
           );
@@ -599,8 +592,13 @@ void main() {
               'tStartMs': 0,
               'dDurationMs': 1000,
               'segs': [
-                {'utf8': url.contains('lang=en') ? 'English' : 
-                        url.contains('lang=es') ? 'Español' : '日本語'}
+                {
+                  'utf8': url.contains('lang=en')
+                      ? 'English'
+                      : url.contains('lang=es')
+                      ? 'Español'
+                      : '日本語',
+                },
               ],
               'aAppend': 0,
             },
@@ -611,9 +609,7 @@ void main() {
       });
 
       final fetcher = YoutubeCaptionFetcher(httpClient: mockClient);
-      final result = await fetcher.fetchAllSubtitles(
-        videoId: 'test1234567',
-      );
+      final result = await fetcher.fetchAllSubtitles(videoId: 'test1234567');
 
       expect(result.isSuccess, isTrue);
       expect(result.results.length, 3);
@@ -623,26 +619,20 @@ void main() {
     });
 
     test('preferred language is sorted first', () async {
-      const enUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=en';
-      const esUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=es';
+      const enUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=en';
+      const esUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=es';
 
       mockClient = MockClient((request) async {
         if (request.method == 'POST') {
           return http.Response(
-            jsonEncode(_cannedPlayerResponse(tracks: [
-              {
-                'baseUrl': enUrl,
-                'vssId': '.en',
-                'languageCode': 'en',
-              },
-              {
-                'baseUrl': esUrl,
-                'vssId': '.es',
-                'languageCode': 'es',
-              },
-            ])),
+            jsonEncode(
+              _cannedPlayerResponse(
+                tracks: [
+                  {'baseUrl': enUrl, 'vssId': '.en', 'languageCode': 'en'},
+                  {'baseUrl': esUrl, 'vssId': '.es', 'languageCode': 'es'},
+                ],
+              ),
+            ),
             200,
             headers: {'content-type': 'application/json'},
           );
@@ -652,7 +642,9 @@ void main() {
             {
               'tStartMs': 0,
               'dDurationMs': 1000,
-              'segs': [{'utf8': 'text'}],
+              'segs': [
+                {'utf8': 'text'},
+              ],
               'aAppend': 0,
             },
           ]),
@@ -682,19 +674,19 @@ void main() {
       mockClient = MockClient((request) async {
         if (request.method == 'POST') {
           return http.Response(
-            jsonEncode(_cannedPlayerResponse(tracks: [
-              {
-                'baseUrl': autoUrl,
-                'vssId': 'a.en',
-                'languageCode': 'en',
-                'kind': 'asr',
-              },
-              {
-                'baseUrl': manualUrl,
-                'vssId': '.en',
-                'languageCode': 'en',
-              },
-            ])),
+            jsonEncode(
+              _cannedPlayerResponse(
+                tracks: [
+                  {
+                    'baseUrl': autoUrl,
+                    'vssId': 'a.en',
+                    'languageCode': 'en',
+                    'kind': 'asr',
+                  },
+                  {'baseUrl': manualUrl, 'vssId': '.en', 'languageCode': 'en'},
+                ],
+              ),
+            ),
             200,
             headers: {'content-type': 'application/json'},
           );
@@ -707,7 +699,7 @@ void main() {
               'tStartMs': 0,
               'dDurationMs': 1000,
               'segs': [
-                {'utf8': isManual ? 'manual text' : 'auto text'}
+                {'utf8': isManual ? 'manual text' : 'auto text'},
               ],
               'aAppend': 0,
             },
@@ -730,23 +722,22 @@ void main() {
     });
 
     test('skip tracks without language code', () async {
-      const enUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=en';
+      const enUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=en';
 
       mockClient = MockClient((request) async {
         if (request.method == 'POST') {
           return http.Response(
-            jsonEncode(_cannedPlayerResponse(tracks: [
-              {
-                'baseUrl': 'https://www.youtube.com/api/timedtext?v=nolang',
-                'vssId': '.en',
-              },
-              {
-                'baseUrl': enUrl,
-                'vssId': '.en',
-                'languageCode': 'en',
-              },
-            ])),
+            jsonEncode(
+              _cannedPlayerResponse(
+                tracks: [
+                  {
+                    'baseUrl': 'https://www.youtube.com/api/timedtext?v=nolang',
+                    'vssId': '.en',
+                  },
+                  {'baseUrl': enUrl, 'vssId': '.en', 'languageCode': 'en'},
+                ],
+              ),
+            ),
             200,
             headers: {'content-type': 'application/json'},
           );
@@ -756,7 +747,9 @@ void main() {
             {
               'tStartMs': 0,
               'dDurationMs': 1000,
-              'segs': [{'utf8': 'text'}],
+              'segs': [
+                {'utf8': 'text'},
+              ],
               'aAppend': 0,
             },
           ]),
@@ -766,9 +759,7 @@ void main() {
       });
 
       final fetcher = YoutubeCaptionFetcher(httpClient: mockClient);
-      final result = await fetcher.fetchAllSubtitles(
-        videoId: 'test1234567',
-      );
+      final result = await fetcher.fetchAllSubtitles(videoId: 'test1234567');
 
       expect(result.isSuccess, isTrue);
       expect(result.results.length, 1);
@@ -776,26 +767,20 @@ void main() {
     });
 
     test('handles individual track fetch failures gracefully', () async {
-      const okUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=en';
-      const badUrl =
-          'https://www.youtube.com/api/timedtext?v=test&lang=es';
+      const okUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=en';
+      const badUrl = 'https://www.youtube.com/api/timedtext?v=test&lang=es';
 
       mockClient = MockClient((request) async {
         if (request.method == 'POST') {
           return http.Response(
-            jsonEncode(_cannedPlayerResponse(tracks: [
-              {
-                'baseUrl': okUrl,
-                'vssId': '.en',
-                'languageCode': 'en',
-              },
-              {
-                'baseUrl': badUrl,
-                'vssId': '.es',
-                'languageCode': 'es',
-              },
-            ])),
+            jsonEncode(
+              _cannedPlayerResponse(
+                tracks: [
+                  {'baseUrl': okUrl, 'vssId': '.en', 'languageCode': 'en'},
+                  {'baseUrl': badUrl, 'vssId': '.es', 'languageCode': 'es'},
+                ],
+              ),
+            ),
             200,
             headers: {'content-type': 'application/json'},
           );
@@ -808,7 +793,9 @@ void main() {
             {
               'tStartMs': 0,
               'dDurationMs': 1000,
-              'segs': [{'utf8': 'ok text'}],
+              'segs': [
+                {'utf8': 'ok text'},
+              ],
               'aAppend': 0,
             },
           ]),


### PR DESCRIPTION
## Summary

Extracts D1–D7 inline transport decisions from the player controller, interactions, and YouTube engine into pure-function reducers in `transport_decisions.dart`, following the established `decideEchoPlaybackTime` / `EchoPlaybackDecision` sealed-class pattern.

## What changed

### New: `lib/features/player/domain/transport_decisions.dart`
Seven pure-function reducers, each returning a sealed result consumed by a single imperative `switch`:

| ID | Reducer | Inputs |
|----|---------|--------|
| D1 | `decideSeekRouting` | `echoActive` → `SeekThroughEcho` \| `SeekDirect` |
| D2 | `decideTeardownPath` | `isYoutubeEngine` → `TeardownIdle` \| `TeardownStop` |
| D3 | `decideReplayTarget` | `echoActive, echoStart, lineStart` → `ReplayToEchoStart` \| `ReplayToLineStart` |
| D4 | `decideProgressSeekTime` | `fraction, duration` → `ProgressSeekValid` \| `ProgressSeekInvalid` |
| D5 | `decideYouTubePlayRestart` | `playbackCompleted` → `RestartFromBeginning` \| `ResumePlayback` |
| D6 | `decidePollTransition` | 6 poll inputs → `MediaJustEnded` \| `PauseStreaking` \| `PollPlaying` \| `PollIdleTick` |
| D7 | `decideOnMediaEnd` | `RepeatMode` → `StopAtEnd` \| `LoopMedia` \| `LoopSegment` |

### Wiring D7 (RepeatMode consumer)
- `YoutubePlayerEngine` now accepts a `repeatMode` getter, passed through `YoutubeWebViewController` to the poll loop.
- On media end, the poll loop calls `decideOnMediaEnd`; `LoopMedia` / `LoopSegment` fires the `onMediaEnd` callback (engine reloads the watch page) instead of stopping.
- `player_controller.dart` wires the `playerPreferencesCtrlProvider.repeatMode` getter when creating YouTube engines.

### Tests
- **New**: `transport_decisions_test.dart` — 23 tests covering every branch of all seven reducers.
- **Backfilled**: `echo_window_test.dart` — 3 new tests for `decideEchoPlaybackTime` (`EchoClamp`, NaN guard, `EchoOk`).
- All existing tests continue to pass.

### Files changed

| File | Change |
|------|--------|
| `lib/features/player/domain/transport_decisions.dart` | New — 7 reducers + sealed classes |
| `lib/features/player/application/player_controller.dart` | D1, D2 consumers |
| `lib/features/player/application/player_interactions.dart` | D3, D4 consumers |
| `lib/features/player/application/engines/youtube/youtube_player_engine.dart` | D5 consumer + D7 wiring |
| `lib/features/player/application/engines/youtube/youtube_webview_controller.dart` | Thread D7 params |
| `lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart` | D6, D7 consumers |
| `test/features/player/transport_decisions_test.dart` | New — 23 tests |
| `test/features/player/echo_window_test.dart` | +3 tests (Clamp, NaN, Ok) |

Closes #312.