### PR TITLE
fix: resolve duplicate code issues #336 #337 #338

### DIFF
--- a/lib/core/presentation/form_section_label.dart
+++ b/lib/core/presentation/form_section_label.dart
@@ -1,0 +1,33 @@
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+
+class FormSectionLabel extends StatelessWidget {
+  const FormSectionLabel({super.key, required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = EnjoyThemeTokens.of(context);
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Row(
+      children: [
+        Icon(icon, size: 16, color: cs.primary),
+        SizedBox(width: t.space8),
+        Text(
+          text,
+          style: tt.labelLarge?.copyWith(
+            color: cs.onSurface,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/presentation/loading_icon.dart
+++ b/lib/core/presentation/loading_icon.dart
@@ -1,0 +1,36 @@
+library;
+
+import 'package:flutter/material.dart';
+
+class LoadingIcon extends StatelessWidget {
+  const LoadingIcon({
+    super.key,
+    this.size = 18,
+    this.strokeWidth = 2,
+    this.color,
+    this.brightSurface = false,
+  });
+
+  final double size;
+  final double strokeWidth;
+  final Color? color;
+  final bool brightSurface;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedColor =
+        color ??
+        (brightSurface
+            ? Theme.of(context).colorScheme.onPrimary
+            : Theme.of(context).colorScheme.primary);
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CircularProgressIndicator(
+        strokeWidth: strokeWidth,
+        color: resolvedColor,
+      ),
+    );
+  }
+}

--- a/lib/core/theme/widgets/media_card.dart
+++ b/lib/core/theme/widgets/media_card.dart
@@ -11,6 +11,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/core/interaction/haptics.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/platform/mobile_platform.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
@@ -756,13 +757,9 @@ class _Thumbnail extends StatelessWidget {
     return ColoredBox(
       color: cs.surfaceContainerHighest,
       child: Center(
-        child: SizedBox(
-          width: 22,
-          height: 22,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-            color: cs.onSurfaceVariant.withValues(alpha: 0.45),
-          ),
+        child: LoadingIcon(
+          size: 22,
+          color: cs.onSurfaceVariant.withValues(alpha: 0.45),
         ),
       ),
     );

--- a/lib/features/ai/presentation/settings/widgets/llm_byok_form.dart
+++ b/lib/features/ai/presentation/settings/widgets/llm_byok_form.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/form_section_label.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/features/ai/data/byok/byok_openai_models.dart';
 import 'package:enjoy_player/features/ai/domain/llm_api_spec.dart';
@@ -51,7 +53,7 @@ class _LlmByokFormState extends State<LlmByokForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _FormSectionLabel(
+        FormSectionLabel(
           icon: Icons.hub_outlined,
           text: l10n.settingsAiProvidersLlmSpecLabel,
         ),
@@ -88,7 +90,7 @@ class _LlmByokFormState extends State<LlmByokForm> {
         ),
         SizedBox(height: t.space16),
         if (presets.isNotEmpty) ...[
-          _FormSectionLabel(
+          FormSectionLabel(
             icon: Icons.bolt_outlined,
             text: l10n.settingsAiProvidersPresetsLabel,
           ),
@@ -168,11 +170,7 @@ class _LlmByokFormState extends State<LlmByokForm> {
                   OutlinedButton.icon(
                     onPressed: _fetchingModels ? null : _fetchModels,
                     icon: _fetchingModels
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
+                        ? const LoadingIcon(size: 16)
                         : const Icon(Icons.list_outlined),
                     label: Text(l10n.settingsAiProvidersFetchModels),
                   ),
@@ -244,33 +242,5 @@ class _LlmByokFormState extends State<LlmByokForm> {
         setState(() => _fetchingModels = false);
       }
     }
-  }
-}
-
-class _FormSectionLabel extends StatelessWidget {
-  const _FormSectionLabel({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    final t = EnjoyThemeTokens.of(context);
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Row(
-      children: [
-        Icon(icon, size: 16, color: cs.primary),
-        SizedBox(width: t.space8),
-        Text(
-          text,
-          style: tt.labelLarge?.copyWith(
-            color: cs.onSurface,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-      ],
-    );
   }
 }

--- a/lib/features/ai/presentation/settings/widgets/modality_provider_card.dart
+++ b/lib/features/ai/presentation/settings/widgets/modality_provider_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
@@ -347,11 +348,7 @@ class _ModalityProviderCardState extends ConsumerState<ModalityProviderCard> {
                     child: EnjoyButton.primary(
                       onPressed: _saving ? null : _save,
                       child: _saving
-                          ? const SizedBox(
-                              height: 20,
-                              width: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
+                          ? const LoadingIcon(size: 20)
                           : Text(l10n.settingsAiProvidersSave),
                     ),
                   ),

--- a/lib/features/ai/presentation/settings/widgets/speech_byok_form.dart
+++ b/lib/features/ai/presentation/settings/widgets/speech_byok_form.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/form_section_label.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
 import 'package:enjoy_player/features/ai/presentation/settings/widgets/byok_api_key_field.dart';
@@ -64,7 +65,7 @@ class _SpeechByokFormState extends State<SpeechByokForm> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         if (widget.mode == SpeechByokFormMode.speech) ...[
-          _SpeechSectionLabel(
+          FormSectionLabel(
             icon: Icons.route_outlined,
             text: l10n.settingsAiProvidersSpeechKindLabel,
           ),
@@ -142,34 +143,6 @@ class _SpeechByokFormState extends State<SpeechByokForm> {
             autocorrect: false,
           ),
         ],
-      ],
-    );
-  }
-}
-
-class _SpeechSectionLabel extends StatelessWidget {
-  const _SpeechSectionLabel({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    final t = EnjoyThemeTokens.of(context);
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Row(
-      children: [
-        Icon(icon, size: 16, color: cs.primary),
-        SizedBox(width: t.space8),
-        Text(
-          text,
-          style: tt.labelLarge?.copyWith(
-            color: cs.onSurface,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
       ],
     );
   }

--- a/lib/features/auth/presentation/profile_preferences_screen.dart
+++ b/lib/features/auth/presentation/profile_preferences_screen.dart
@@ -8,6 +8,7 @@ import 'package:enjoy_player/core/application/app_language_catalog.dart';
 import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/presentation/language_labels.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
@@ -269,11 +270,7 @@ class _ProfilePreferencesScreenState
                             }
                           },
                     child: _saving
-                        ? const SizedBox(
-                            height: 22,
-                            width: 22,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
+                        ? const LoadingIcon(size: 22)
                         : Text(l10n.profileSave),
                   ),
                 ],

--- a/lib/features/auth/presentation/widgets/email_otp_sign_in_flow.dart
+++ b/lib/features/auth/presentation/widgets/email_otp_sign_in_flow.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
@@ -311,14 +312,7 @@ class _EmailStep extends StatelessWidget {
           EnjoyButton.primary(
             onPressed: busy ? null : onSubmit,
             child: busy
-                ? SizedBox(
-                    height: 22,
-                    width: 22,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: cs.onPrimary,
-                    ),
-                  )
+                ? const LoadingIcon(size: 22, brightSurface: true)
                 : Text(l10n.authSendOtp),
           ),
         ],
@@ -467,14 +461,7 @@ class _OtpStepState extends State<_OtpStep> {
                 ? null
                 : () => widget.onVerify(_code),
             child: widget.busy
-                ? SizedBox(
-                    height: 22,
-                    width: 22,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: cs.onPrimary,
-                    ),
-                  )
+                ? const LoadingIcon(size: 22, brightSurface: true)
                 : Text(l10n.authVerifyOtp),
           ),
           SizedBox(height: t.space12),

--- a/lib/features/auth/presentation/widgets/sidebar_account_chip.dart
+++ b/lib/features/auth/presentation/widgets/sidebar_account_chip.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/utils/avatar_url.dart';
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
@@ -31,14 +32,7 @@ class SidebarAccountChip extends ConsumerWidget {
           if (authFlowInProgress(state)) {
             return ListTile(
               dense: true,
-              leading: SizedBox(
-                width: 22,
-                height: 22,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: cs.primary,
-                ),
-              ),
+              leading: const LoadingIcon(size: 22),
               title: Text(
                 state is AuthAwaitingOtp
                     ? l10n.authOtpTitle
@@ -116,13 +110,7 @@ class SidebarAccountChip extends ConsumerWidget {
         },
         loading: () => const SizedBox(
           height: 40,
-          child: Center(
-            child: SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
-          ),
+          child: Center(child: LoadingIcon(size: 20)),
         ),
         error: (Object e, StackTrace s) => const SizedBox.shrink(),
       ),

--- a/lib/features/cloud/presentation/cloud_library_body.dart
+++ b/lib/features/cloud/presentation/cloud_library_body.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -320,11 +321,7 @@ class _CloudAudioRowState extends ConsumerState<_CloudAudioRow> {
 
     Widget? trailing;
     if (_busy) {
-      trailing = const SizedBox(
-        width: 22,
-        height: 22,
-        child: CircularProgressIndicator(strokeWidth: 2),
-      );
+      trailing = const LoadingIcon(size: 22);
     } else if (_inLibrary == true) {
       trailing = Icon(Icons.check_circle_rounded, color: cs.primary, size: 22);
     } else {
@@ -538,16 +535,7 @@ class _CloudVideoTileState extends ConsumerState<_CloudVideoTile> {
 
     Widget overlay;
     if (_busy) {
-      overlay = cornerChip(
-        SizedBox(
-          width: 20,
-          height: 20,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-            color: cs.onSurfaceVariant,
-          ),
-        ),
-      );
+      overlay = cornerChip(LoadingIcon(size: 20, color: cs.onSurfaceVariant));
     } else if (_inLibrary == true) {
       overlay = cornerChip(
         Icon(Icons.check_circle_rounded, color: cs.primary, size: 22),

--- a/lib/features/craft/presentation/synthesize_tool.dart
+++ b/lib/features/craft/presentation/synthesize_tool.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/routing/player_navigation.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/craft_request.dart';
@@ -109,11 +110,7 @@ class _SynthesizeToolState extends ConsumerState<SynthesizeTool> {
                     ? null
                     : () => _synthesizeWithOverlay(l10n),
                 icon: state.isSynthesizing
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 16)
                     : const Icon(Icons.record_voice_over_rounded, size: 18),
                 label: Text(
                   state.hasPreview
@@ -143,11 +140,7 @@ class _SynthesizeToolState extends ConsumerState<SynthesizeTool> {
                 child: FilledButton.icon(
                   onPressed: state.isSaving ? null : _save,
                   icon: state.isSaving
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
+                      ? const LoadingIcon(size: 16)
                       : const Icon(Icons.save_rounded, size: 18),
                   label: Text(l10n.craftSaveToLibrary),
                 ),

--- a/lib/features/craft/presentation/translate_tool.dart
+++ b/lib/features/craft/presentation/translate_tool.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
 import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/craft_request.dart';
 import 'package:enjoy_player/features/craft/domain/translation_style.dart';
@@ -142,11 +143,7 @@ class _TranslateToolState extends ConsumerState<TranslateTool> {
                     ? null
                     : controller.translate,
                 icon: state.isTranslating
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 16)
                     : const Icon(Icons.translate_rounded, size: 18),
                 label: Text(
                   state.translatedText != null

--- a/lib/features/discover/presentation/discover_channel_filter_strip.dart
+++ b/lib/features/discover/presentation/discover_channel_filter_strip.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/interaction/horizontal_drag_scroll_behavior.dart';
 import 'package:enjoy_player/core/interaction/haptics.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/utils/remote_thumbnail_url.dart';
@@ -54,13 +55,7 @@ class _DiscoverChannelFilterStripState
     return subsAsync.when(
       loading: () => const SizedBox(
         height: DiscoverChannelFilterStrip.rowHeight,
-        child: Center(
-          child: SizedBox(
-            width: 18,
-            height: 18,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
+        child: Center(child: LoadingIcon(size: 18)),
       ),
       error: (_, _) => const SizedBox.shrink(),
       data: (subs) {

--- a/lib/features/discover/presentation/discover_feed_tile.dart
+++ b/lib/features/discover/presentation/discover_feed_tile.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart';
 
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
 import 'package:enjoy_player/core/ids/enjoy_ids.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/features/player/application/youtube_warm.dart';
@@ -301,13 +302,10 @@ class _VideoThumbnail extends StatelessWidget {
               ColoredBox(
                 color: Colors.black.withValues(alpha: 0.45),
                 child: const Center(
-                  child: SizedBox(
-                    width: 28,
-                    height: 28,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2.5,
-                      color: Colors.white,
-                    ),
+                  child: LoadingIcon(
+                    size: 28,
+                    strokeWidth: 2.5,
+                    color: Colors.white,
                   ),
                 ),
               ),

--- a/lib/features/discover/presentation/discover_manage_channels.dart
+++ b/lib/features/discover/presentation/discover_manage_channels.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
 import 'package:enjoy_player/core/theme/widgets/sheet_drag_handle.dart';
 import 'package:enjoy_player/core/theme/widgets/skeleton.dart';
@@ -109,7 +110,7 @@ class DiscoverManageChannelsView extends ConsumerWidget {
           recommendedAsync.when(
             loading: () => const SizedBox(
               height: DiscoverRecommendedAvatarStrip.rowHeight,
-              child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+              child: Center(child: LoadingIcon()),
             ),
             error: (_, _) => Text(
               l10n.discoverRecommendedLoadFailed,
@@ -118,7 +119,7 @@ class DiscoverManageChannelsView extends ConsumerWidget {
             data: (recommended) => subscriptionsAsync.when(
               loading: () => const SizedBox(
                 height: DiscoverRecommendedAvatarStrip.rowHeight,
-                child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+                child: Center(child: LoadingIcon()),
               ),
               error: (_, _) => const SizedBox.shrink(),
               data: (subs) => DiscoverRecommendedAvatarStrip(

--- a/lib/features/discover/presentation/discover_screen.dart
+++ b/lib/features/discover/presentation/discover_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/utils/sliver_key_index.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -28,7 +29,6 @@ class DiscoverScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
     final t = EnjoyThemeTokens.of(context);
-    final cs = Theme.of(context).colorScheme;
     final refreshing = ref.watch(discoverRefreshStateProvider);
     final selectedChannelId = ref.watch(discoverSelectedChannelProvider);
     final subscriptionsAsync = ref.watch(discoverSubscriptionsProvider);
@@ -63,14 +63,7 @@ class DiscoverScreen extends ConsumerWidget {
                             ? null
                             : () => unawaited(onRefresh()),
                         icon: refreshing
-                            ? SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: cs.primary,
-                                ),
-                              )
+                            ? const LoadingIcon(size: 20)
                             : const Icon(Icons.refresh_rounded),
                       )
                     : null,

--- a/lib/features/discover/presentation/discover_subscribe_sheet.dart
+++ b/lib/features/discover/presentation/discover_subscribe_sheet.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
 import 'package:enjoy_player/core/theme/widgets/sheet_drag_handle.dart';
 import 'package:enjoy_player/features/discover/application/discover_providers.dart';
@@ -117,11 +118,7 @@ class _DiscoverSubscribeSheetState
               FilledButton(
                 onPressed: _submitting ? null : () => unawaited(_submit()),
                 child: _submitting
-                    ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 20)
                     : Text(l10n.discoverSubscribeAction),
               ),
             ],

--- a/lib/features/library/presentation/library_actions.dart
+++ b/lib/features/library/presentation/library_actions.dart
@@ -13,6 +13,7 @@ import 'package:go_router/go_router.dart';
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
 import 'package:enjoy_player/core/errors/app_failure.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/data/files/media_resolver.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
@@ -75,11 +76,7 @@ Future<void> importMediaFromPicker(BuildContext context, WidgetRef ref) async {
           child: AlertDialog(
             content: Row(
               children: [
-                const SizedBox(
-                  width: 32,
-                  height: 32,
-                  child: CircularProgressIndicator(strokeWidth: 3),
-                ),
+                const LoadingIcon(size: 32, strokeWidth: 3),
                 const SizedBox(width: 24),
                 Expanded(child: Text(d.importingMedia)),
               ],
@@ -279,11 +276,7 @@ Future<void> importYoutubeFromDialog(
           child: AlertDialog(
             content: Row(
               children: [
-                const SizedBox(
-                  width: 32,
-                  height: 32,
-                  child: CircularProgressIndicator(strokeWidth: 3),
-                ),
+                const LoadingIcon(size: 32, strokeWidth: 3),
                 const SizedBox(width: 24),
                 Expanded(child: Text(d.youtubeImporting)),
               ],

--- a/lib/features/lookup/presentation/widgets/lookup_error_row.dart
+++ b/lib/features/lookup/presentation/widgets/lookup_error_row.dart
@@ -3,6 +3,7 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
@@ -101,14 +102,7 @@ class _LookupErrorRowState extends State<LookupErrorRow> {
               ),
               onPressed: busy ? null : _handleRetry,
               icon: busy
-                  ? SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: scheme.primary,
-                      ),
-                    )
+                  ? const LoadingIcon(size: 18)
                   : const Icon(Icons.refresh_rounded, size: 20),
               label: Text(l10n.lookupErrorRetry),
             ),

--- a/lib/features/lookup/presentation/widgets/lookup_refresh_icon_button.dart
+++ b/lib/features/lookup/presentation/widgets/lookup_refresh_icon_button.dart
@@ -2,6 +2,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
+
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Header-area refresh control for lookup sheet sections (cache bust + refetch).
@@ -49,7 +51,6 @@ class _LookupRefreshIconButtonState extends State<LookupRefreshIconButton> {
   @override
   Widget build(BuildContext context) {
     final busy = widget.isRefreshing || _tapLatched;
-    final scheme = Theme.of(context).colorScheme;
 
     return IconButton(
       style: IconButton.styleFrom(
@@ -62,14 +63,7 @@ class _LookupRefreshIconButtonState extends State<LookupRefreshIconButton> {
       tooltip: busy ? null : widget.l10n.lookupRefresh,
       onPressed: busy ? null : _handlePressed,
       icon: busy
-          ? SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: scheme.primary,
-              ),
-            )
+          ? const LoadingIcon(size: 20)
           : const Icon(Icons.refresh_rounded, size: 20),
     );
   }

--- a/lib/features/player/presentation/locate_media_screen.dart
+++ b/lib/features/player/presentation/locate_media_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/data/files/media_resolver.dart';
 import 'package:enjoy_player/features/library/domain/media.dart';
@@ -130,14 +131,7 @@ class _LocateMediaScreenState extends ConsumerState<LocateMediaScreen> {
               FilledButton.icon(
                 onPressed: _working ? null : _onChooseFile,
                 icon: _working
-                    ? SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: cs.onPrimary,
-                        ),
-                      )
+                    ? const LoadingIcon(size: 20, brightSurface: true)
                     : const Icon(Icons.folder_open),
                 label: Text(
                   _working ? l10n.importingMedia : l10n.mediaLocateChooseFile,

--- a/lib/features/player/presentation/widgets/transport/transport_cc_fullscreen.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_cc_fullscreen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/window/desktop_window.dart';
 import 'package:enjoy_player/core/window/window_fullscreen_provider.dart';
 import 'package:enjoy_player/features/transcript/application/all_transcripts_provider.dart';
@@ -34,13 +35,9 @@ class TransportCcButton extends ConsumerWidget {
         IconButton(
           tooltip: l10n.subtitles,
           icon: showSpinner
-              ? SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
+              ? LoadingIcon(
+                  size: 22,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
                 )
               : const Icon(Icons.closed_caption_outlined),
           onPressed: () => showSubtitleTrackPicker(context, ref, mediaId),

--- a/lib/features/player/presentation/widgets/transport/transport_play_ring_button.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_play_ring_button.dart
@@ -3,6 +3,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
+
 class TransportPlayRingButton extends StatefulWidget {
   const TransportPlayRingButton({
     super.key,
@@ -69,14 +71,7 @@ class _TransportPlayRingButtonState extends State<TransportPlayRingButton> {
                   ),
                   child: Center(
                     child: widget.buffering
-                        ? SizedBox(
-                            width: 22,
-                            height: 22,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: ringColor,
-                            ),
-                          )
+                        ? LoadingIcon(size: 22, color: ringColor)
                         : AnimatedSwitcher(
                             duration: const Duration(milliseconds: 180),
                             switchInCurve: Curves.easeOutCubic,

--- a/lib/features/settings/presentation/sync_status_screen.dart
+++ b/lib/features/settings/presentation/sync_status_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
 import 'package:enjoy_player/core/theme/widgets/skeleton.dart';
@@ -147,11 +148,7 @@ class _SignedInBody extends ConsumerWidget {
                 valueBadge: lastSyncAsync.when(
                   data: (iso) =>
                       SettingsValuePill(label: lastSyncLine(l10n, iso)),
-                  loading: () => const SizedBox(
-                    height: 18,
-                    width: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
+                  loading: () => const LoadingIcon(size: 18),
                   error: (e, _) => SettingsValuePill(
                     icon: Icons.error_outline_rounded,
                     label: l10n.error,
@@ -209,11 +206,7 @@ class _SignedInBody extends ConsumerWidget {
                 FilledButton.icon(
                   onPressed: busySync ? null : onSyncNow,
                   icon: busySync
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
+                      ? const LoadingIcon(size: 18)
                       : const Icon(Icons.sync_rounded),
                   label: Text(l10n.syncScreenSyncNow),
                 ),
@@ -223,11 +216,7 @@ class _SignedInBody extends ConsumerWidget {
                       ? null
                       : onRetryFailed,
                   icon: busyRetry
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
+                      ? const LoadingIcon(size: 18)
                       : const Icon(Icons.refresh_rounded),
                   label: Text(l10n.syncScreenRetryFailed),
                 ),

--- a/lib/features/settings/presentation/widgets/about_section_card.dart
+++ b/lib/features/settings/presentation/widgets/about_section_card.dart
@@ -9,6 +9,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:enjoy_player/core/application/app_links.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/diagnostics/diagnostic_export_flow.dart';
 import 'package:enjoy_player/core/diagnostics/diagnostics_verbose_provider.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
@@ -247,13 +248,8 @@ class _AboutSectionCardState extends ConsumerState<AboutSectionCard> {
                                           );
                                         },
                                       ),
-                                      loading: () => const SizedBox(
-                                        width: 24,
-                                        height: 24,
-                                        child: CircularProgressIndicator(
-                                          strokeWidth: 2,
-                                        ),
-                                      ),
+                                      loading: () =>
+                                          const LoadingIcon(size: 24),
                                       error: (_, _) => const SizedBox.shrink(),
                                     ),
                               ],

--- a/lib/features/settings/presentation/widgets/sections/developer_section.dart
+++ b/lib/features/settings/presentation/widgets/sections/developer_section.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/data/api/api_client_provider.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_row.dart';
@@ -173,11 +174,7 @@ class _ApiBaseUrlEditorState extends ConsumerState<_ApiBaseUrlEditor> {
                   }
                 },
           child: _saving
-              ? const SizedBox(
-                  height: 20,
-                  width: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
+              ? const LoadingIcon(size: 20)
               : Text(l10n.settingsApiBaseUrlSave),
         ),
       ],
@@ -256,11 +253,7 @@ class _AiApiBaseUrlEditorState extends ConsumerState<_AiApiBaseUrlEditor> {
                         }
                       },
                 child: _saving
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 20)
                     : Text(l10n.settingsAiApiBaseUrlSave),
               ),
             ),

--- a/lib/features/shadow_reading/presentation/recording_assessment_button.dart
+++ b/lib/features/shadow_reading/presentation/recording_assessment_button.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/features/hotkeys/presentation/hotkey_tooltip_label.dart';
 import 'package:enjoy_player/features/shadow_reading/application/recording_assessment_controller.dart';
@@ -107,14 +108,7 @@ class RecordingAssessmentButton extends ConsumerWidget {
                     ),
               child: Center(
                 child: isAssessing
-                    ? SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: scheme.primary,
-                        ),
-                      )
+                    ? const LoadingIcon(size: 18)
                     : score != null
                     ? Text(
                         '$score',

--- a/lib/features/share_poster/domain/practice_poster_data.dart
+++ b/lib/features/share_poster/domain/practice_poster_data.dart
@@ -190,4 +190,3 @@ PracticePosterQuote? resolvePracticePosterQuote({
   if (longestRef == null) return null;
   return PracticePosterQuote(line: _quoteLineFromText(longestRef));
 }
-

--- a/lib/features/share_poster/presentation/practice_poster_preview_sheet.dart
+++ b/lib/features/share_poster/presentation/practice_poster_preview_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
@@ -180,17 +181,8 @@ class _PracticePosterPreviewSheetState
                   ),
                 )
               else if (data == null)
-                Expanded(
-                  child: Center(
-                    child: SizedBox(
-                      width: 28,
-                      height: 28,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2.5,
-                        color: cs.primary,
-                      ),
-                    ),
-                  ),
+                const Expanded(
+                  child: Center(child: LoadingIcon(size: 28, strokeWidth: 2.5)),
                 )
               else ...[
                 Expanded(
@@ -227,14 +219,7 @@ class _PracticePosterPreviewSheetState
                 EnjoyButton.primary(
                   onPressed: _canExport ? _onExport : null,
                   child: _exporting
-                      ? SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: cs.onPrimary,
-                          ),
-                        )
+                      ? const LoadingIcon(size: 20, brightSurface: true)
                       : Text(l10n.practicePosterShareAction),
                 ),
               ],

--- a/lib/features/subscription/presentation/widgets/purchase_sheet.dart
+++ b/lib/features/subscription/presentation/widgets/purchase_sheet.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/platform/subscription_purchase_capability.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -163,11 +164,7 @@ class _PurchaseSheetBodyState extends ConsumerState<_PurchaseSheetBody> {
               EnjoyButton.primary(
                 onPressed: busy ? null : _purchaseExternal,
                 child: busy
-                    ? const SizedBox(
-                        width: 22,
-                        height: 22,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 22)
                     : Text(l10n.subscriptionContinueToPayment),
               ),
             ],

--- a/lib/features/sync/data/sync_download_service.dart
+++ b/lib/features/sync/data/sync_download_service.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:enjoy_player/core/json/json_cast.dart';
+import 'package:enjoy_player/data/api/api_client.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/settings_keys.dart';
 import 'package:enjoy_player/data/api/services/audio_api.dart';
@@ -9,6 +10,12 @@ import 'package:enjoy_player/data/api/services/recording_api.dart';
 import 'package:enjoy_player/data/api/services/video_api.dart';
 import 'package:enjoy_player/features/sync/data/sync_serializers.dart';
 import 'package:enjoy_player/features/sync/domain/sync_types.dart';
+
+typedef _FetchPage =
+    Future<List<JsonMap>> Function({int? limit, String? updatedAfter});
+
+typedef _UpsertRow =
+    Future<void> Function({required String id, required JsonMap server});
 
 class SyncDownloadService {
   SyncDownloadService({
@@ -34,152 +41,68 @@ class SyncDownloadService {
   Future<SyncResult> downloadRecordings() =>
       _downloadRecordingsInternal(resetCursor: false);
 
-  Future<SyncResult> _downloadAudiosInternal({
-    required bool resetCursor,
-  }) async {
-    final errors = <String>[];
-    var synced = 0;
-    var failed = 0;
-    if (resetCursor) {
-      await _db.settingsDao.setValue(SettingsKeys.syncCursorAudio, '');
-    }
-    var cursor = await _db.settingsDao.getValue(SettingsKeys.syncCursorAudio);
-    if (cursor != null && cursor.isEmpty) cursor = null;
-
-    while (true) {
-      List<Map<String, dynamic>> batch;
-      try {
-        final raw = await _audioApi.audios(
-          limit: _pageSize,
-          updatedAfter: cursor,
-        );
-        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
-      } catch (e) {
-        return SyncResult(
-          success: false,
-          synced: synced,
-          failed: failed + 1,
-          errors: [...errors, '$e'],
-        );
-      }
-
-      if (batch.isEmpty) break;
-
-      for (final m in batch) {
-        try {
-          final id = m['id'] as String?;
-          if (id == null || id.isEmpty) continue;
-          final local = await _db.audioDao.getById(id);
-          final merged = mergeAudioLastWriteWins(local: local, server: m);
-          await _db.audioDao.insertRow(merged);
-          synced++;
-        } catch (e) {
-          failed++;
-          errors.add('$e');
-        }
-      }
-
-      final maxIso = _maxUpdatedAtIso(batch);
-      if (maxIso != null) {
-        cursor = maxIso;
-        await _db.settingsDao.setValue(SettingsKeys.syncCursorAudio, maxIso);
-      }
-
-      if (batch.length < _pageSize) break;
-    }
-
-    return SyncResult(
-      success: failed == 0,
-      synced: synced,
-      failed: failed,
-      errors: errors.isEmpty ? null : errors,
+  Future<SyncResult> _downloadAudiosInternal({required bool resetCursor}) {
+    return _downloadEntityInternal(
+      resetCursor: resetCursor,
+      cursorKey: SettingsKeys.syncCursorAudio,
+      fetch: _audioApi.audios,
+      upsert: ({required String id, required JsonMap server}) async {
+        final local = await _db.audioDao.getById(id);
+        final merged = mergeAudioLastWriteWins(local: local, server: server);
+        await _db.audioDao.insertRow(merged);
+      },
     );
   }
 
-  Future<SyncResult> _downloadVideosInternal({
-    required bool resetCursor,
-  }) async {
-    final errors = <String>[];
-    var synced = 0;
-    var failed = 0;
-    if (resetCursor) {
-      await _db.settingsDao.setValue(SettingsKeys.syncCursorVideo, '');
-    }
-    var cursor = await _db.settingsDao.getValue(SettingsKeys.syncCursorVideo);
-    if (cursor != null && cursor.isEmpty) cursor = null;
-
-    while (true) {
-      List<Map<String, dynamic>> batch;
-      try {
-        final raw = await _videoApi.videos(
-          limit: _pageSize,
-          updatedAfter: cursor,
-        );
-        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
-      } catch (e) {
-        return SyncResult(
-          success: false,
-          synced: synced,
-          failed: failed + 1,
-          errors: [...errors, '$e'],
-        );
-      }
-
-      if (batch.isEmpty) break;
-
-      for (final m in batch) {
-        try {
-          final id = m['id'] as String?;
-          if (id == null || id.isEmpty) continue;
-          final local = await _db.videoDao.getById(id);
-          final merged = mergeVideoLastWriteWins(local: local, server: m);
-          await _db.videoDao.insertRow(merged);
-          synced++;
-        } catch (e) {
-          failed++;
-          errors.add('$e');
-        }
-      }
-
-      final maxIso = _maxUpdatedAtIso(batch);
-      if (maxIso != null) {
-        cursor = maxIso;
-        await _db.settingsDao.setValue(SettingsKeys.syncCursorVideo, maxIso);
-      }
-
-      if (batch.length < _pageSize) break;
-    }
-
-    return SyncResult(
-      success: failed == 0,
-      synced: synced,
-      failed: failed,
-      errors: errors.isEmpty ? null : errors,
+  Future<SyncResult> _downloadVideosInternal({required bool resetCursor}) {
+    return _downloadEntityInternal(
+      resetCursor: resetCursor,
+      cursorKey: SettingsKeys.syncCursorVideo,
+      fetch: _videoApi.videos,
+      upsert: ({required String id, required JsonMap server}) async {
+        final local = await _db.videoDao.getById(id);
+        final merged = mergeVideoLastWriteWins(local: local, server: server);
+        await _db.videoDao.insertRow(merged);
+      },
     );
   }
 
-  Future<SyncResult> _downloadRecordingsInternal({
+  Future<SyncResult> _downloadRecordingsInternal({required bool resetCursor}) {
+    return _downloadEntityInternal(
+      resetCursor: resetCursor,
+      cursorKey: SettingsKeys.syncCursorRecording,
+      fetch: _recordingApi.recordings,
+      upsert: ({required String id, required JsonMap server}) async {
+        final local = await _db.recordingDao.getById(id);
+        final merged = mergeRecordingLastWriteWins(
+          local: local,
+          server: server,
+        );
+        await _db.recordingDao.insertRow(merged);
+      },
+    );
+  }
+
+  Future<SyncResult> _downloadEntityInternal({
     required bool resetCursor,
+    required String cursorKey,
+    required _FetchPage fetch,
+    required _UpsertRow upsert,
   }) async {
     final errors = <String>[];
     var synced = 0;
     var failed = 0;
     if (resetCursor) {
-      await _db.settingsDao.setValue(SettingsKeys.syncCursorRecording, '');
+      await _db.settingsDao.setValue(cursorKey, '');
     }
-    var cursor = await _db.settingsDao.getValue(
-      SettingsKeys.syncCursorRecording,
-    );
+    var cursor = await _db.settingsDao.getValue(cursorKey);
     if (cursor != null && cursor.isEmpty) cursor = null;
 
     while (true) {
-      List<Map<String, dynamic>> batch;
+      List<JsonMap> batch;
       try {
-        final raw = await _recordingApi.recordings(
-          limit: _pageSize,
-          updatedAfter: cursor,
-        );
-        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
+        final raw = await fetch(limit: _pageSize, updatedAfter: cursor);
+        batch = raw.map<JsonMap>(castJsonObject).toList();
       } catch (e) {
         return SyncResult(
           success: false,
@@ -195,9 +118,7 @@ class SyncDownloadService {
         try {
           final id = m['id'] as String?;
           if (id == null || id.isEmpty) continue;
-          final local = await _db.recordingDao.getById(id);
-          final merged = mergeRecordingLastWriteWins(local: local, server: m);
-          await _db.recordingDao.insertRow(merged);
+          await upsert(id: id, server: m);
           synced++;
         } catch (e) {
           failed++;
@@ -208,10 +129,7 @@ class SyncDownloadService {
       final maxIso = _maxUpdatedAtIso(batch);
       if (maxIso != null) {
         cursor = maxIso;
-        await _db.settingsDao.setValue(
-          SettingsKeys.syncCursorRecording,
-          maxIso,
-        );
+        await _db.settingsDao.setValue(cursorKey, maxIso);
       }
 
       if (batch.length < _pageSize) break;

--- a/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
+++ b/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
@@ -291,14 +292,7 @@ class _SubtitleTrackPickerSheetState
           ),
           child: Row(
             children: [
-              SizedBox(
-                width: 18,
-                height: 18,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: theme.colorScheme.primary,
-                ),
-              ),
+              const LoadingIcon(size: 18),
               SizedBox(width: t.space12),
               Expanded(
                 child: Text(

--- a/lib/features/transcript/presentation/transcript_busy_action.dart
+++ b/lib/features/transcript/presentation/transcript_busy_action.dart
@@ -3,6 +3,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
+
 /// Outlined or filled action button with inline loading spinner.
 class TranscriptBusyButton extends StatefulWidget {
   const TranscriptBusyButton({
@@ -38,16 +40,7 @@ class _TranscriptBusyButtonState extends State<TranscriptBusyButton> {
   @override
   Widget build(BuildContext context) {
     final icon = _busy
-        ? SizedBox(
-            width: 18,
-            height: 18,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: widget.filled
-                  ? Theme.of(context).colorScheme.onPrimary
-                  : Theme.of(context).colorScheme.primary,
-            ),
-          )
+        ? LoadingIcon(size: 18, brightSurface: widget.filled)
         : Icon(widget.icon);
 
     if (widget.filled) {
@@ -103,14 +96,7 @@ class _TranscriptBusyListTileState extends State<TranscriptBusyListTile> {
     return ListTile(
       contentPadding: widget.contentPadding,
       leading: _busy
-          ? SizedBox(
-              width: 24,
-              height: 24,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: cs.primary,
-              ),
-            )
+          ? const LoadingIcon(size: 24)
           : Icon(widget.icon, size: 24, color: cs.onSurfaceVariant),
       title: Text(widget.title),
       enabled: !_busy,


### PR DESCRIPTION
## Summary

Closes #336. Closes #337. Closes #338.

### #336 — Sync download deduplication
Extracted _downloadEntityInternal generic helper in sync_download_service.dart, collapsing three nearly-identical paginated download methods (~200 lines) into a single loop with entity-spec closures. Each entity (audio/video/recording) now contributes a 5-line call site.

### #337 — Identical form section labels
Created shared FormSectionLabel widget in lib/core/presentation/, replacing the byte-for-byte identical _FormSectionLabel (in llm_byok_form.dart) and _SpeechSectionLabel (in speech_byok_form.dart).

### #338 — Inline loading spinners
Created LoadingIcon widget in lib/core/presentation/ to replace 30+ instances of the SizedBox + CircularProgressIndicator busy-icon pattern across 29 files. Handles size, strokeWidth, color, and brightSurface theming.

## Verification
- \lutter analyze\: no issues
- \lutter test\: 1331 passed, 3 skipped, 0 failed