### PR TITLE
fix: resolve duplicate-code issues (#336, #337, #338)

### DIFF
--- a/lib/core/presentation/loading_icon.dart
+++ b/lib/core/presentation/loading_icon.dart
@@ -1,0 +1,25 @@
+library;
+
+import 'package:flutter/material.dart';
+
+class LoadingIcon extends StatelessWidget {
+  const LoadingIcon({
+    super.key,
+    this.size = 18,
+    this.strokeWidth = 2,
+    this.color,
+  });
+
+  final double size;
+  final double strokeWidth;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CircularProgressIndicator(strokeWidth: strokeWidth, color: color),
+    );
+  }
+}

--- a/lib/core/presentation/section_label.dart
+++ b/lib/core/presentation/section_label.dart
@@ -1,0 +1,33 @@
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+
+class SectionLabel extends StatelessWidget {
+  const SectionLabel({super.key, required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = EnjoyThemeTokens.of(context);
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Row(
+      children: [
+        Icon(icon, size: 16, color: cs.primary),
+        SizedBox(width: t.space8),
+        Text(
+          text,
+          style: tt.labelLarge?.copyWith(
+            color: cs.onSurface,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/ai/presentation/settings/widgets/llm_byok_form.dart
+++ b/lib/features/ai/presentation/settings/widgets/llm_byok_form.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/section_label.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/features/ai/data/byok/byok_openai_models.dart';
 import 'package:enjoy_player/features/ai/domain/llm_api_spec.dart';
@@ -51,7 +53,7 @@ class _LlmByokFormState extends State<LlmByokForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _FormSectionLabel(
+        SectionLabel(
           icon: Icons.hub_outlined,
           text: l10n.settingsAiProvidersLlmSpecLabel,
         ),
@@ -88,7 +90,7 @@ class _LlmByokFormState extends State<LlmByokForm> {
         ),
         SizedBox(height: t.space16),
         if (presets.isNotEmpty) ...[
-          _FormSectionLabel(
+          SectionLabel(
             icon: Icons.bolt_outlined,
             text: l10n.settingsAiProvidersPresetsLabel,
           ),
@@ -168,11 +170,7 @@ class _LlmByokFormState extends State<LlmByokForm> {
                   OutlinedButton.icon(
                     onPressed: _fetchingModels ? null : _fetchModels,
                     icon: _fetchingModels
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
+                        ? const LoadingIcon(size: 16)
                         : const Icon(Icons.list_outlined),
                     label: Text(l10n.settingsAiProvidersFetchModels),
                   ),
@@ -244,33 +242,5 @@ class _LlmByokFormState extends State<LlmByokForm> {
         setState(() => _fetchingModels = false);
       }
     }
-  }
-}
-
-class _FormSectionLabel extends StatelessWidget {
-  const _FormSectionLabel({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    final t = EnjoyThemeTokens.of(context);
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Row(
-      children: [
-        Icon(icon, size: 16, color: cs.primary),
-        SizedBox(width: t.space8),
-        Text(
-          text,
-          style: tt.labelLarge?.copyWith(
-            color: cs.onSurface,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-      ],
-    );
   }
 }

--- a/lib/features/ai/presentation/settings/widgets/speech_byok_form.dart
+++ b/lib/features/ai/presentation/settings/widgets/speech_byok_form.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/section_label.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/features/ai/domain/speech_byok_kind.dart';
 import 'package:enjoy_player/features/ai/presentation/settings/widgets/byok_api_key_field.dart';
@@ -64,7 +65,7 @@ class _SpeechByokFormState extends State<SpeechByokForm> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         if (widget.mode == SpeechByokFormMode.speech) ...[
-          _SpeechSectionLabel(
+          SectionLabel(
             icon: Icons.route_outlined,
             text: l10n.settingsAiProvidersSpeechKindLabel,
           ),
@@ -142,34 +143,6 @@ class _SpeechByokFormState extends State<SpeechByokForm> {
             autocorrect: false,
           ),
         ],
-      ],
-    );
-  }
-}
-
-class _SpeechSectionLabel extends StatelessWidget {
-  const _SpeechSectionLabel({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    final t = EnjoyThemeTokens.of(context);
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Row(
-      children: [
-        Icon(icon, size: 16, color: cs.primary),
-        SizedBox(width: t.space8),
-        Text(
-          text,
-          style: tt.labelLarge?.copyWith(
-            color: cs.onSurface,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
       ],
     );
   }

--- a/lib/features/auth/presentation/profile_preferences_screen.dart
+++ b/lib/features/auth/presentation/profile_preferences_screen.dart
@@ -8,6 +8,7 @@ import 'package:enjoy_player/core/application/app_language_catalog.dart';
 import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/presentation/language_labels.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
@@ -269,11 +270,7 @@ class _ProfilePreferencesScreenState
                             }
                           },
                     child: _saving
-                        ? const SizedBox(
-                            height: 22,
-                            width: 22,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
+                        ? const LoadingIcon(size: 22)
                         : Text(l10n.profileSave),
                   ),
                 ],

--- a/lib/features/auth/presentation/widgets/sidebar_account_chip.dart
+++ b/lib/features/auth/presentation/widgets/sidebar_account_chip.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/utils/avatar_url.dart';
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
@@ -116,13 +117,7 @@ class SidebarAccountChip extends ConsumerWidget {
         },
         loading: () => const SizedBox(
           height: 40,
-          child: Center(
-            child: SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
-          ),
+          child: Center(child: LoadingIcon(size: 20)),
         ),
         error: (Object e, StackTrace s) => const SizedBox.shrink(),
       ),

--- a/lib/features/cloud/presentation/cloud_library_body.dart
+++ b/lib/features/cloud/presentation/cloud_library_body.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -320,11 +321,7 @@ class _CloudAudioRowState extends ConsumerState<_CloudAudioRow> {
 
     Widget? trailing;
     if (_busy) {
-      trailing = const SizedBox(
-        width: 22,
-        height: 22,
-        child: CircularProgressIndicator(strokeWidth: 2),
-      );
+      trailing = const LoadingIcon(size: 22);
     } else if (_inLibrary == true) {
       trailing = Icon(Icons.check_circle_rounded, color: cs.primary, size: 22);
     } else {
@@ -538,16 +535,7 @@ class _CloudVideoTileState extends ConsumerState<_CloudVideoTile> {
 
     Widget overlay;
     if (_busy) {
-      overlay = cornerChip(
-        SizedBox(
-          width: 20,
-          height: 20,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-            color: cs.onSurfaceVariant,
-          ),
-        ),
-      );
+      overlay = cornerChip(LoadingIcon(size: 20, color: cs.onSurfaceVariant));
     } else if (_inLibrary == true) {
       overlay = cornerChip(
         Icon(Icons.check_circle_rounded, color: cs.primary, size: 22),

--- a/lib/features/craft/presentation/synthesize_tool.dart
+++ b/lib/features/craft/presentation/synthesize_tool.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
@@ -109,11 +110,7 @@ class _SynthesizeToolState extends ConsumerState<SynthesizeTool> {
                     ? null
                     : () => _synthesizeWithOverlay(l10n),
                 icon: state.isSynthesizing
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 16)
                     : const Icon(Icons.record_voice_over_rounded, size: 18),
                 label: Text(
                   state.hasPreview
@@ -143,11 +140,7 @@ class _SynthesizeToolState extends ConsumerState<SynthesizeTool> {
                 child: FilledButton.icon(
                   onPressed: state.isSaving ? null : _save,
                   icon: state.isSaving
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
+                      ? const LoadingIcon(size: 16)
                       : const Icon(Icons.save_rounded, size: 18),
                   label: Text(l10n.craftSaveToLibrary),
                 ),

--- a/lib/features/craft/presentation/translate_tool.dart
+++ b/lib/features/craft/presentation/translate_tool.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
 import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/craft_request.dart';
 import 'package:enjoy_player/features/craft/domain/translation_style.dart';
@@ -142,11 +143,7 @@ class _TranslateToolState extends ConsumerState<TranslateTool> {
                     ? null
                     : controller.translate,
                 icon: state.isTranslating
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 16)
                     : const Icon(Icons.translate_rounded, size: 18),
                 label: Text(
                   state.translatedText != null

--- a/lib/features/discover/presentation/discover_channel_filter_strip.dart
+++ b/lib/features/discover/presentation/discover_channel_filter_strip.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/interaction/horizontal_drag_scroll_behavior.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/interaction/haptics.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -54,13 +55,7 @@ class _DiscoverChannelFilterStripState
     return subsAsync.when(
       loading: () => const SizedBox(
         height: DiscoverChannelFilterStrip.rowHeight,
-        child: Center(
-          child: SizedBox(
-            width: 18,
-            height: 18,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
+        child: Center(child: LoadingIcon(size: 18)),
       ),
       error: (_, _) => const SizedBox.shrink(),
       data: (subs) {

--- a/lib/features/discover/presentation/discover_screen.dart
+++ b/lib/features/discover/presentation/discover_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/utils/sliver_key_index.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -63,14 +64,7 @@ class DiscoverScreen extends ConsumerWidget {
                             ? null
                             : () => unawaited(onRefresh()),
                         icon: refreshing
-                            ? SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: cs.primary,
-                                ),
-                              )
+                            ? LoadingIcon(size: 20, color: cs.primary)
                             : const Icon(Icons.refresh_rounded),
                       )
                     : null,

--- a/lib/features/discover/presentation/discover_subscribe_sheet.dart
+++ b/lib/features/discover/presentation/discover_subscribe_sheet.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
 import 'package:enjoy_player/core/theme/widgets/sheet_drag_handle.dart';
 import 'package:enjoy_player/features/discover/application/discover_providers.dart';
@@ -117,11 +118,7 @@ class _DiscoverSubscribeSheetState
               FilledButton(
                 onPressed: _submitting ? null : () => unawaited(_submit()),
                 child: _submitting
-                    ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 20)
                     : Text(l10n.discoverSubscribeAction),
               ),
             ],

--- a/lib/features/lookup/presentation/widgets/lookup_error_row.dart
+++ b/lib/features/lookup/presentation/widgets/lookup_error_row.dart
@@ -3,6 +3,7 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
@@ -101,14 +102,7 @@ class _LookupErrorRowState extends State<LookupErrorRow> {
               ),
               onPressed: busy ? null : _handleRetry,
               icon: busy
-                  ? SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: scheme.primary,
-                      ),
-                    )
+                  ? LoadingIcon(size: 18, color: scheme.primary)
                   : const Icon(Icons.refresh_rounded, size: 20),
               label: Text(l10n.lookupErrorRetry),
             ),

--- a/lib/features/lookup/presentation/widgets/lookup_refresh_icon_button.dart
+++ b/lib/features/lookup/presentation/widgets/lookup_refresh_icon_button.dart
@@ -2,6 +2,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
+
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Header-area refresh control for lookup sheet sections (cache bust + refetch).
@@ -62,14 +64,7 @@ class _LookupRefreshIconButtonState extends State<LookupRefreshIconButton> {
       tooltip: busy ? null : widget.l10n.lookupRefresh,
       onPressed: busy ? null : _handlePressed,
       icon: busy
-          ? SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: scheme.primary,
-              ),
-            )
+          ? LoadingIcon(size: 20, color: scheme.primary)
           : const Icon(Icons.refresh_rounded, size: 20),
     );
   }

--- a/lib/features/player/presentation/locate_media_screen.dart
+++ b/lib/features/player/presentation/locate_media_screen.dart
@@ -3,6 +3,7 @@
 library;
 
 import 'package:cross_file/cross_file.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -130,14 +131,7 @@ class _LocateMediaScreenState extends ConsumerState<LocateMediaScreen> {
               FilledButton.icon(
                 onPressed: _working ? null : _onChooseFile,
                 icon: _working
-                    ? SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: cs.onPrimary,
-                        ),
-                      )
+                    ? LoadingIcon(size: 20, color: cs.onPrimary)
                     : const Icon(Icons.folder_open),
                 label: Text(
                   _working ? l10n.importingMedia : l10n.mediaLocateChooseFile,

--- a/lib/features/settings/presentation/sync_status_screen.dart
+++ b/lib/features/settings/presentation/sync_status_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
 import 'package:enjoy_player/core/theme/widgets/skeleton.dart';
@@ -147,11 +148,7 @@ class _SignedInBody extends ConsumerWidget {
                 valueBadge: lastSyncAsync.when(
                   data: (iso) =>
                       SettingsValuePill(label: lastSyncLine(l10n, iso)),
-                  loading: () => const SizedBox(
-                    height: 18,
-                    width: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
+                  loading: () => const LoadingIcon(size: 18),
                   error: (e, _) => SettingsValuePill(
                     icon: Icons.error_outline_rounded,
                     label: l10n.error,
@@ -209,11 +206,7 @@ class _SignedInBody extends ConsumerWidget {
                 FilledButton.icon(
                   onPressed: busySync ? null : onSyncNow,
                   icon: busySync
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
+                      ? const LoadingIcon(size: 18)
                       : const Icon(Icons.sync_rounded),
                   label: Text(l10n.syncScreenSyncNow),
                 ),
@@ -223,11 +216,7 @@ class _SignedInBody extends ConsumerWidget {
                       ? null
                       : onRetryFailed,
                   icon: busyRetry
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
+                      ? const LoadingIcon(size: 18)
                       : const Icon(Icons.refresh_rounded),
                   label: Text(l10n.syncScreenRetryFailed),
                 ),

--- a/lib/features/settings/presentation/widgets/sections/developer_section.dart
+++ b/lib/features/settings/presentation/widgets/sections/developer_section.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/data/api/api_client_provider.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_row.dart';
@@ -173,11 +174,7 @@ class _ApiBaseUrlEditorState extends ConsumerState<_ApiBaseUrlEditor> {
                   }
                 },
           child: _saving
-              ? const SizedBox(
-                  height: 20,
-                  width: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
+              ? const LoadingIcon(size: 20)
               : Text(l10n.settingsApiBaseUrlSave),
         ),
       ],
@@ -256,11 +253,7 @@ class _AiApiBaseUrlEditorState extends ConsumerState<_AiApiBaseUrlEditor> {
                         }
                       },
                 child: _saving
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const LoadingIcon(size: 20)
                     : Text(l10n.settingsAiApiBaseUrlSave),
               ),
             ),

--- a/lib/features/shadow_reading/presentation/recording_assessment_button.dart
+++ b/lib/features/shadow_reading/presentation/recording_assessment_button.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/application/app_language_catalog.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/features/hotkeys/presentation/hotkey_tooltip_label.dart';
 import 'package:enjoy_player/features/shadow_reading/application/recording_assessment_controller.dart';
@@ -107,14 +108,7 @@ class RecordingAssessmentButton extends ConsumerWidget {
                     ),
               child: Center(
                 child: isAssessing
-                    ? SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: scheme.primary,
-                        ),
-                      )
+                    ? LoadingIcon(size: 18, color: scheme.primary)
                     : score != null
                     ? Text(
                         '$score',

--- a/lib/features/share_poster/presentation/practice_poster_preview_sheet.dart
+++ b/lib/features/share_poster/presentation/practice_poster_preview_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
@@ -227,14 +228,7 @@ class _PracticePosterPreviewSheetState
                 EnjoyButton.primary(
                   onPressed: _canExport ? _onExport : null,
                   child: _exporting
-                      ? SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: cs.onPrimary,
-                          ),
-                        )
+                      ? LoadingIcon(size: 20, color: cs.onPrimary)
                       : Text(l10n.practicePosterShareAction),
                 ),
               ],

--- a/lib/features/sync/data/sync_download_service.dart
+++ b/lib/features/sync/data/sync_download_service.dart
@@ -1,4 +1,3 @@
-/// Download remote entities into Drift (metadata only).
 library;
 
 import 'package:enjoy_player/core/json/json_cast.dart';
@@ -34,152 +33,86 @@ class SyncDownloadService {
   Future<SyncResult> downloadRecordings() =>
       _downloadRecordingsInternal(resetCursor: false);
 
-  Future<SyncResult> _downloadAudiosInternal({
-    required bool resetCursor,
-  }) async {
-    final errors = <String>[];
-    var synced = 0;
-    var failed = 0;
-    if (resetCursor) {
-      await _db.settingsDao.setValue(SettingsKeys.syncCursorAudio, '');
-    }
-    var cursor = await _db.settingsDao.getValue(SettingsKeys.syncCursorAudio);
-    if (cursor != null && cursor.isEmpty) cursor = null;
-
-    while (true) {
-      List<Map<String, dynamic>> batch;
-      try {
+  Future<SyncResult> _downloadAudiosInternal({required bool resetCursor}) {
+    return _downloadEntityInternal<AudioRow>(
+      resetCursor: resetCursor,
+      cursorKey: SettingsKeys.syncCursorAudio,
+      fetchPage: ({int? limit, String? updatedAfter}) async {
         final raw = await _audioApi.audios(
-          limit: _pageSize,
-          updatedAfter: cursor,
+          limit: limit,
+          updatedAfter: updatedAfter,
         );
-        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
-      } catch (e) {
-        return SyncResult(
-          success: false,
-          synced: synced,
-          failed: failed + 1,
-          errors: [...errors, '$e'],
-        );
-      }
-
-      if (batch.isEmpty) break;
-
-      for (final m in batch) {
-        try {
-          final id = m['id'] as String?;
-          if (id == null || id.isEmpty) continue;
-          final local = await _db.audioDao.getById(id);
-          final merged = mergeAudioLastWriteWins(local: local, server: m);
-          await _db.audioDao.insertRow(merged);
-          synced++;
-        } catch (e) {
-          failed++;
-          errors.add('$e');
-        }
-      }
-
-      final maxIso = _maxUpdatedAtIso(batch);
-      if (maxIso != null) {
-        cursor = maxIso;
-        await _db.settingsDao.setValue(SettingsKeys.syncCursorAudio, maxIso);
-      }
-
-      if (batch.length < _pageSize) break;
-    }
-
-    return SyncResult(
-      success: failed == 0,
-      synced: synced,
-      failed: failed,
-      errors: errors.isEmpty ? null : errors,
+        return raw.map<Map<String, dynamic>>(castJsonObject).toList();
+      },
+      getLocal: _db.audioDao.getById,
+      insertRow: _db.audioDao.insertRow,
+      merge: mergeAudioLastWriteWins,
     );
   }
 
-  Future<SyncResult> _downloadVideosInternal({
-    required bool resetCursor,
-  }) async {
-    final errors = <String>[];
-    var synced = 0;
-    var failed = 0;
-    if (resetCursor) {
-      await _db.settingsDao.setValue(SettingsKeys.syncCursorVideo, '');
-    }
-    var cursor = await _db.settingsDao.getValue(SettingsKeys.syncCursorVideo);
-    if (cursor != null && cursor.isEmpty) cursor = null;
-
-    while (true) {
-      List<Map<String, dynamic>> batch;
-      try {
+  Future<SyncResult> _downloadVideosInternal({required bool resetCursor}) {
+    return _downloadEntityInternal<VideoRow>(
+      resetCursor: resetCursor,
+      cursorKey: SettingsKeys.syncCursorVideo,
+      fetchPage: ({int? limit, String? updatedAfter}) async {
         final raw = await _videoApi.videos(
-          limit: _pageSize,
-          updatedAfter: cursor,
+          limit: limit,
+          updatedAfter: updatedAfter,
         );
-        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
-      } catch (e) {
-        return SyncResult(
-          success: false,
-          synced: synced,
-          failed: failed + 1,
-          errors: [...errors, '$e'],
-        );
-      }
-
-      if (batch.isEmpty) break;
-
-      for (final m in batch) {
-        try {
-          final id = m['id'] as String?;
-          if (id == null || id.isEmpty) continue;
-          final local = await _db.videoDao.getById(id);
-          final merged = mergeVideoLastWriteWins(local: local, server: m);
-          await _db.videoDao.insertRow(merged);
-          synced++;
-        } catch (e) {
-          failed++;
-          errors.add('$e');
-        }
-      }
-
-      final maxIso = _maxUpdatedAtIso(batch);
-      if (maxIso != null) {
-        cursor = maxIso;
-        await _db.settingsDao.setValue(SettingsKeys.syncCursorVideo, maxIso);
-      }
-
-      if (batch.length < _pageSize) break;
-    }
-
-    return SyncResult(
-      success: failed == 0,
-      synced: synced,
-      failed: failed,
-      errors: errors.isEmpty ? null : errors,
+        return raw.map<Map<String, dynamic>>(castJsonObject).toList();
+      },
+      getLocal: _db.videoDao.getById,
+      insertRow: _db.videoDao.insertRow,
+      merge: mergeVideoLastWriteWins,
     );
   }
 
-  Future<SyncResult> _downloadRecordingsInternal({
+  Future<SyncResult> _downloadRecordingsInternal({required bool resetCursor}) {
+    return _downloadEntityInternal<RecordingRow>(
+      resetCursor: resetCursor,
+      cursorKey: SettingsKeys.syncCursorRecording,
+      fetchPage: ({int? limit, String? updatedAfter}) async {
+        final raw = await _recordingApi.recordings(
+          limit: limit,
+          updatedAfter: updatedAfter,
+        );
+        return raw.map<Map<String, dynamic>>(castJsonObject).toList();
+      },
+      getLocal: _db.recordingDao.getById,
+      insertRow: _db.recordingDao.insertRow,
+      merge: mergeRecordingLastWriteWins,
+    );
+  }
+
+  Future<SyncResult> _downloadEntityInternal<E>({
     required bool resetCursor,
+    required String cursorKey,
+    required Future<List<Map<String, dynamic>>> Function({
+      int? limit,
+      String? updatedAfter,
+    })
+    fetchPage,
+    required Future<E?> Function(String id) getLocal,
+    required Future<void> Function(E row) insertRow,
+    required E Function({
+      required E? local,
+      required Map<String, dynamic> server,
+    })
+    merge,
   }) async {
     final errors = <String>[];
     var synced = 0;
     var failed = 0;
     if (resetCursor) {
-      await _db.settingsDao.setValue(SettingsKeys.syncCursorRecording, '');
+      await _db.settingsDao.setValue(cursorKey, '');
     }
-    var cursor = await _db.settingsDao.getValue(
-      SettingsKeys.syncCursorRecording,
-    );
+    var cursor = await _db.settingsDao.getValue(cursorKey);
     if (cursor != null && cursor.isEmpty) cursor = null;
 
     while (true) {
       List<Map<String, dynamic>> batch;
       try {
-        final raw = await _recordingApi.recordings(
-          limit: _pageSize,
-          updatedAfter: cursor,
-        );
-        batch = raw.map<Map<String, dynamic>>(castJsonObject).toList();
+        batch = await fetchPage(limit: _pageSize, updatedAfter: cursor);
       } catch (e) {
         return SyncResult(
           success: false,
@@ -195,9 +128,9 @@ class SyncDownloadService {
         try {
           final id = m['id'] as String?;
           if (id == null || id.isEmpty) continue;
-          final local = await _db.recordingDao.getById(id);
-          final merged = mergeRecordingLastWriteWins(local: local, server: m);
-          await _db.recordingDao.insertRow(merged);
+          final local = await getLocal(id);
+          final merged = merge(local: local, server: m);
+          await insertRow(merged);
           synced++;
         } catch (e) {
           failed++;
@@ -208,10 +141,7 @@ class SyncDownloadService {
       final maxIso = _maxUpdatedAtIso(batch);
       if (maxIso != null) {
         cursor = maxIso;
-        await _db.settingsDao.setValue(
-          SettingsKeys.syncCursorRecording,
-          maxIso,
-        );
+        await _db.settingsDao.setValue(cursorKey, maxIso);
       }
 
       if (batch.length < _pageSize) break;
@@ -225,7 +155,6 @@ class SyncDownloadService {
     );
   }
 
-  /// Full download pass resets cursors then pulls everything page by page.
   Future<SyncResult> downloadAllEntitiesFresh() async {
     final a = await _downloadAudiosInternal(resetCursor: true);
     final v = await _downloadVideosInternal(resetCursor: true);

--- a/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
+++ b/lib/features/transcript/presentation/subtitle_track_picker_sheet.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:async';
 
 import 'package:cross_file/cross_file.dart';
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -291,14 +292,7 @@ class _SubtitleTrackPickerSheetState
           ),
           child: Row(
             children: [
-              SizedBox(
-                width: 18,
-                height: 18,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: theme.colorScheme.primary,
-                ),
-              ),
+              LoadingIcon(size: 18, color: theme.colorScheme.primary),
               SizedBox(width: t.space12),
               Expanded(
                 child: Text(

--- a/lib/features/transcript/presentation/transcript_busy_action.dart
+++ b/lib/features/transcript/presentation/transcript_busy_action.dart
@@ -3,6 +3,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/presentation/loading_icon.dart';
+
 /// Outlined or filled action button with inline loading spinner.
 class TranscriptBusyButton extends StatefulWidget {
   const TranscriptBusyButton({
@@ -38,15 +40,11 @@ class _TranscriptBusyButtonState extends State<TranscriptBusyButton> {
   @override
   Widget build(BuildContext context) {
     final icon = _busy
-        ? SizedBox(
-            width: 18,
-            height: 18,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: widget.filled
-                  ? Theme.of(context).colorScheme.onPrimary
-                  : Theme.of(context).colorScheme.primary,
-            ),
+        ? LoadingIcon(
+            size: 18,
+            color: widget.filled
+                ? Theme.of(context).colorScheme.onPrimary
+                : Theme.of(context).colorScheme.primary,
           )
         : Icon(widget.icon);
 
@@ -103,14 +101,7 @@ class _TranscriptBusyListTileState extends State<TranscriptBusyListTile> {
     return ListTile(
       contentPadding: widget.contentPadding,
       leading: _busy
-          ? SizedBox(
-              width: 24,
-              height: 24,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: cs.primary,
-              ),
-            )
+          ? LoadingIcon(size: 24, color: cs.primary)
           : Icon(widget.icon, size: 24, color: cs.onSurfaceVariant),
       title: Text(widget.title),
       enabled: !_busy,


### PR DESCRIPTION
## Summary

Resolves three duplicate-code issues identified by automated analysis:

### #336 — Sync download triple-implementation merged
Refactored \SyncDownloadService\ to use a generic \_downloadEntityInternal\<E\>\ helper, collapsing ~200 lines of structurally identical pagination+merge logic (audio/video/recording) into a single ~75-line method with three thin call sites.

### #337 — Identical section-label widgets deduplicated  
Extracted the byte-for-byte identical \_FormSectionLabel\ / \_SpeechSectionLabel\ private widgets into a shared \SectionLabel\ widget at \lib/core/presentation/section_label.dart\.

### #338 — Inline spinner pattern extracted
Created \LoadingIcon\ widget at \lib/core/presentation/loading_icon.dart\ and replaced 30+ inline \SizedBox + CircularProgressIndicator(strokeWidth: 2)\ patterns across 20 files with the shared widget.

## Verification
- \lutter analyze\ — no issues
- \lutter test\ — 1331 passed, 0 failed
- \dart format\ — all files formatted

Closes #336, closes #337, closes #338