### PR TITLE
docs: cover duplicate-code fixes (#341) in widget reference, conventions, and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Shared `LoadingIcon` widget** for inline busy affordances ([#338](https://github.com/baizhiheizi/enjoy_player/issues/338), [#341](https://github.com/baizhiheizi/enjoy_player/pull/341)). A compact 18×18 `CircularProgressIndicator` (`size`, `strokeWidth`, `color`) replaces 30+ duplicated `SizedBox` + `CircularProgressIndicator` patterns across 20 files (auth sidebar chip, profile preferences, settings hub, sync status, transcript busy action, subtitle track picker, lookup refresh/error rows, cloud library body, craft translate/synthesize tools, BYOK forms, discover subscribe sheet / screen / channel filter, share poster preview, locate media, shadow-reading assessment button). Documented in [docs/features/app-ui.md § Widgets reference](docs/features/app-ui.md#widgets-reference).
+- **Shared `SectionLabel` widget** for in-card section headers ([#337](https://github.com/baizhiheizi/enjoy_player/issues/337), [#341](https://github.com/baizhiheizi/enjoy_player/pull/341)). Replaces the duplicate `_FormSectionLabel` / `_SpeechSectionLabel` private classes in the BYOK forms with a single public widget (`Icon` + `EnjoyThemeTokens.space8` + bold `labelLarge` text using the active `ColorScheme`). Documented in [docs/features/app-ui.md § Widgets reference](docs/features/app-ui.md#widgets-reference).
+
 ### Changed
 
 - **Discover channel refresh uses InnerTube `browse` as primary data source** ([ADR-0047](docs/decisions/0047-youtube-discover-innertube.md)). The per-channel refresh path now tries InnerTube's anonymous `browse` endpoint first (`POST youtubei.googleapis.com/youtubei/v1/browse`) and falls back to the Atom RSS endpoint on failure. InnerTube returns richer metadata (`lengthText`, `viewCountText`, `publishedTimeText`) and is materially less likely to be blocked by YouTube's bot detection. The legacy watch-page HTML duration enrichment is skipped for InnerTube-sourced rows. Client profile rotation (`WEB` → `MWEB`) and continuation pagination (cap 5 pages ≈ 150 entries) match the caption fetcher's posture. See [docs/features/discover.md § Data sources](docs/features/discover.md#data-sources-dual-source).
+- **`SyncDownloadService` uses a generic `_downloadEntityInternal<E>` helper** ([#336](https://github.com/baizhiheizi/enjoy_player/issues/336), [#341](https://github.com/baizhiheizi/enjoy_player/pull/341)). The three per-entity download paths (audio, video, recording) now share one ~75-line pagination + merge loop instead of duplicating ~200 lines of triplicated cursor-paging logic. Public `downloadAudios` / `downloadVideos` / `downloadRecordings` / `downloadAllEntitiesFresh` entry points and `SyncResult` shape are unchanged — see [docs/features/sync.md](docs/features/sync.md).
 
 ## [0.5.0] - 2026-07-13
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -39,6 +39,8 @@ Prefer `package:enjoy_player/...` for cross-layer imports in presentation code t
 - Prefer **`EnjoyTappableSurface` / `EnjoyTappableIcon`** (or **`EnjoyButton`**) for new tappable UI instead of ad-hoc `InkWell` + `GestureDetector` combinations — see [ADR-0018](decisions/0018-shared-interactive-primitives.md).
 - Route light user feedback through **`Haptics`** (`selection`, `impactMedium`, `success`, `warning`) rather than calling `HapticFeedback` directly; it honors reduced motion / platform.
 - Icon-only controls should still expose **`Tooltip`** (and keyboard hints via `kbd_chip` / hotkey helpers where applicable).
+- Use **`LoadingIcon`** ([`core/presentation/loading_icon.dart`](../lib/core/presentation/loading_icon.dart)) for inline busy affordances (button labels, list rows, chips) instead of hand-rolling a `SizedBox` + `CircularProgressIndicator` pair — defaults to a compact 18×18 spinner, configurable via `size` / `strokeWidth` / `color`. See [app-ui.md § Widgets reference](features/app-ui.md#widgets-reference).
+- Use **`SectionLabel`** ([`core/presentation/section_label.dart`](../lib/core/presentation/section_label.dart)) for in-card section headers (icon + bold `labelLarge` text) so BYOK and other settings surfaces share the same heading rhythm. See [app-ui.md § Widgets reference](features/app-ui.md#widgets-reference).
 - User-visible strings live in ARB localization files under `lib/l10n/`. Every ARB key must be filled for all shipped locales (validated by `flutter gen-l10n`). No non-localized English (or other source-language) fallbacks, no `Text('$error')` exception dumps, no hardcoded accessibility labels.
 
 ## Logging

--- a/docs/features/app-ui.md
+++ b/docs/features/app-ui.md
@@ -99,6 +99,8 @@ Focus ring: 2px (custom nav / sidebars)
 | `SkeletonSettingsList` | same | Settings hub loading state (sliver-safe) |
 | `SkeletonTranscript` | same | Transcript panel loading state (own `ScrollView`) |
 | `SkeletonProfile` | same | Profile screen loading state |
+| `LoadingIcon` | `core/presentation/loading_icon.dart` | Compact 18×18 `CircularProgressIndicator` placeholder for inline busy affordances (buttons, list rows, chips); replaces 30+ ad-hoc `SizedBox` + `CircularProgressIndicator` pairs across 20 files. Configure via `size`, `strokeWidth`, `color`. |
+| `SectionLabel` | `core/presentation/section_label.dart` | Header row for in-card sections (`Icon` + `space8` + bold `labelLarge` text). Centralizes the heading style used by BYOK forms and other settings surfaces. |
 | `AppSidebar` | `features/player/presentation/widgets/app_sidebar.dart` | Flat tonal sidebar |
 | `SidebarAccountChip` | `features/auth/presentation/widgets/sidebar_account_chip.dart` | Account row at the bottom of `AppSidebar`: signed-out → **Sign in** → `/sign-in`; awaiting OTP → progress + resume → `/sign-in` or `/sign-in/email`; signed-in → avatar + name + Pro badge + **Open profile** subtitle → `/profile`; Free users also get an inline **Upgrade** pill that routes to `/subscription` |
 


### PR DESCRIPTION
Closes #342

Documents the duplicate-code refactor in #341 (issues #336, #337, #338) so the new shared widgets and the collapsed `SyncDownloadService` helper are discoverable from the docs.