### PR TITLE
refactor: resolve duplicate-code #356 and #363

### DIFF
--- a/lib/core/utils/time_format.dart
+++ b/lib/core/utils/time_format.dart
@@ -13,6 +13,17 @@ String formatDurationHms(Duration d) {
 /// Alias for [formatDurationHms] (legacy name).
 String formatDuration(Duration d) => formatDurationHms(d);
 
+/// Player-style `mm:ss` / `h:mm:ss` from a millisecond duration.
+String formatDurationHmsMs(int milliseconds) =>
+    formatDurationHms(Duration(milliseconds: milliseconds));
+
+/// Player-style `mm:ss` / `h:mm:ss` from a (possibly fractional) second count.
+///
+/// Fractional seconds are rounded to the nearest millisecond before formatting
+/// so transport chrome and library tiles stay consistent.
+String formatDurationHmsSeconds(num seconds) =>
+    formatDurationHmsMs((seconds * 1000).round());
+
 /// Compact human-readable practice duration (`15m 30s`, `2h 5m`, `45s`).
 String formatPracticeDurationMs(int ms) {
   if (ms <= 0) return '0m';

--- a/lib/data/api/services/ai/youtube_transcripts_api.dart
+++ b/lib/data/api/services/ai/youtube_transcripts_api.dart
@@ -73,21 +73,32 @@ class YoutubeTranscriptsApi extends RestApi
   static const _transcriptsPath = '/youtube/transcripts';
   static const _profilesPath = '/youtube/client-profiles';
 
+  /// Fire-and-forget: log at WARNING and return [fallback] on any failure.
+  Future<T> _swallow<T>(
+    String description,
+    Future<T> Function() call, {
+    required T fallback,
+  }) async {
+    try {
+      return await call();
+    } on Object catch (e, st) {
+      _log.warning(description, e, st);
+      return fallback;
+    }
+  }
+
   @override
   Future<Map<String, dynamic>?> getCachedTranscript({
     required String videoId,
     required String language,
-  }) async {
-    try {
-      return await client.getJson(
-        _transcriptsPath,
-        queryParameters: {'videoId': videoId, 'language': language},
-      );
-    } on Object catch (e, st) {
-      _log.warning('worker cache GET failed for $videoId/$language', e, st);
-      return null;
-    }
-  }
+  }) => _swallow(
+    'worker cache GET failed for $videoId/$language',
+    () => client.getJson(
+      _transcriptsPath,
+      queryParameters: {'videoId': videoId, 'language': language},
+    ),
+    fallback: null,
+  );
 
   @override
   Future<bool> uploadTranscript({
@@ -96,8 +107,15 @@ class YoutubeTranscriptsApi extends RestApi
     required String source,
     required List<Map<String, dynamic>> timeline,
     Map<String, dynamic>? metadata,
-  }) async {
-    try {
+  }) => _swallow(
+    // Fire-and-forget from the caller's perspective, but do NOT silently
+    // disappear here: a failed upload means the next client on a
+    // different machine will re-fetch via InnerTube instead of using
+    // the worker cache (issue: Windows → no worker upload → Android
+    // cache miss). Operators need to see this in production logs.
+    'worker upload failed for $videoId/$language '
+    '(source=$source, ${timeline.length} lines)',
+    () async {
       final captionFetch = _captionFetchForSource(source);
       await client.postJson(
         _transcriptsPath,
@@ -115,41 +133,25 @@ class YoutubeTranscriptsApi extends RestApi
         },
       );
       return true;
-    } on Object catch (e, st) {
-      // Fire-and-forget from the caller's perspective, but do NOT silently
-      // disappear here: a failed upload means the next client on a
-      // different machine will re-fetch via InnerTube instead of using
-      // the worker cache (issue: Windows → no worker upload → Android
-      // cache miss). Operators need to see this in production logs.
-      _log.warning(
-        'worker upload failed for $videoId/$language '
-        '(source=$source, ${timeline.length} lines)',
-        e,
-        st,
-      );
-      return false;
-    }
-  }
+    },
+    fallback: false,
+  );
 
   @override
-  Future<List<Map<String, dynamic>>> fetchClientProfiles() async {
-    try {
-      final response = await client.getJson(_profilesPath);
-      final list = response['profiles'];
-      if (list is List) {
-        return list
-            .map(castJsonObjectOrNull)
-            .whereType<Map<String, dynamic>>()
-            .toList(growable: false);
-      }
-      _log.warning(
-        'worker profile fetch returned a body without a profiles list; '
-        'falling back to built-in defaults',
-      );
-      return <Map<String, dynamic>>[];
-    } on Object catch (e, st) {
-      _log.warning('worker profile fetch failed', e, st);
-      return <Map<String, dynamic>>[];
-    }
-  }
+  Future<List<Map<String, dynamic>>> fetchClientProfiles() =>
+      _swallow('worker profile fetch failed', () async {
+        final response = await client.getJson(_profilesPath);
+        final list = response['profiles'];
+        if (list is List) {
+          return list
+              .map(castJsonObjectOrNull)
+              .whereType<Map<String, dynamic>>()
+              .toList(growable: false);
+        }
+        _log.warning(
+          'worker profile fetch returned a body without a profiles list; '
+          'falling back to built-in defaults',
+        );
+        return <Map<String, dynamic>>[];
+      }, fallback: const <Map<String, dynamic>>[]);
 }

--- a/lib/features/cloud/presentation/cloud_library_body.dart
+++ b/lib/features/cloud/presentation/cloud_library_body.dart
@@ -312,9 +312,7 @@ class _CloudAudioRowState extends ConsumerState<_CloudAudioRow> {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final add = ref.watch(cloudAddToLibraryProvider);
-    final dur = formatDurationHms(
-      Duration(seconds: widget.item.durationSeconds),
-    );
+    final dur = formatDurationHmsSeconds(widget.item.durationSeconds);
     final item = widget.item;
     final seed = _coverSeed(item);
     final accent = generativeAccentForSeed(seed);
@@ -517,9 +515,7 @@ class _CloudVideoTileState extends ConsumerState<_CloudVideoTile> {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final add = ref.watch(cloudAddToLibraryProvider);
-    final dur = formatDurationHms(
-      Duration(seconds: widget.item.durationSeconds),
-    );
+    final dur = formatDurationHmsSeconds(widget.item.durationSeconds);
     final item = widget.item;
     final seed = _coverSeed(item);
     final accent = generativeAccentForSeed(seed);

--- a/lib/features/discover/presentation/discover_feed_tile.dart
+++ b/lib/features/discover/presentation/discover_feed_tile.dart
@@ -106,7 +106,7 @@ class _DiscoverFeedTileState extends ConsumerState<DiscoverFeedTile> {
   String? _durationLabel(FeedEntry entry) {
     final seconds = entry.durationSeconds;
     if (seconds == null || seconds <= 0) return null;
-    return formatDurationHms(Duration(seconds: seconds));
+    return formatDurationHmsSeconds(seconds);
   }
 
   @override

--- a/lib/features/library/presentation/home_screen.dart
+++ b/lib/features/library/presentation/home_screen.dart
@@ -399,7 +399,7 @@ class _HomeMediaTile extends ConsumerWidget {
     final isVideo = media.kind == MediaKind.video;
     final thumb = localThumbnailFileForMedia(media);
     final netThumb = networkThumbnailForMedia(media);
-    final dur = formatDurationHms(Duration(milliseconds: media.durationMs));
+    final dur = formatDurationHmsMs(media.durationMs);
     // Grid tiles use the deterministic generative accent — running
     // `PaletteGenerator.fromImageProvider` per tile decodes + analyses pixels
     // on the main isolate (palette_generator 0.3.x predates isolate

--- a/lib/features/library/presentation/widgets/local_library_tab_view.dart
+++ b/lib/features/library/presentation/widgets/local_library_tab_view.dart
@@ -155,7 +155,7 @@ class LocalAudioRow extends ConsumerWidget {
     );
     final thumb = localThumbnailFileForCard(media.thumbnailPath);
     final netThumb = remoteThumbnailForCard(media.thumbnailPath);
-    final dur = formatDurationHms(Duration(milliseconds: media.durationMs));
+    final dur = formatDurationHmsMs(media.durationMs);
     final accent = generativeAccentForSeed(media.coverSeed);
 
     return MediaCardRow(
@@ -259,7 +259,7 @@ class LocalVideoTile extends ConsumerWidget {
     );
     final thumb = localThumbnailFileForMedia(media);
     final netThumb = networkThumbnailForMedia(media);
-    final dur = formatDurationHms(Duration(milliseconds: media.durationMs));
+    final dur = formatDurationHmsMs(media.durationMs);
     final accent = generativeAccentForSeed(media.coverSeed);
 
     return MediaCardTile(

--- a/lib/features/player/presentation/widgets/transport/transport_meta_row.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_meta_row.dart
@@ -52,7 +52,7 @@ class TransportMetaRow extends ConsumerWidget {
             style: tt.titleSmall?.copyWith(fontWeight: FontWeight.w600),
           ),
           Text(
-            '${formatDurationHms(pos)} / ${formatDurationHms(Duration(milliseconds: (chrome.durationSeconds * 1000).round()))}',
+            '${formatDurationHms(pos)} / ${formatDurationHmsSeconds(chrome.durationSeconds)}',
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: tt.bodySmall?.copyWith(

--- a/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
@@ -144,12 +144,7 @@ class _TransportProgressStripState
             ),
           ),
           const SizedBox(width: 8),
-          Text(
-            formatDurationHms(
-              Duration(milliseconds: (durationSec * 1000).round()),
-            ),
-            style: timeStyle,
-          ),
+          Text(formatDurationHmsSeconds(durationSec), style: timeStyle),
         ],
       ),
     );

--- a/test/core/utils/time_format_test.dart
+++ b/test/core/utils/time_format_test.dart
@@ -62,6 +62,36 @@ void main() {
     });
   });
 
+  group('formatDurationHmsMs', () {
+    test('matches formatDurationHms for the same millisecond value', () {
+      expect(formatDurationHmsMs(0), '00:00');
+      expect(formatDurationHmsMs(5 * 1000), '00:05');
+      expect(formatDurationHmsMs(75 * 60 * 1000), '01:15:00');
+      expect(
+        formatDurationHmsMs(2 * 60 * 60 * 1000 + 3 * 60 * 1000 + 4 * 1000),
+        formatDurationHms(const Duration(hours: 2, minutes: 3, seconds: 4)),
+      );
+    });
+  });
+
+  group('formatDurationHmsSeconds', () {
+    test('matches integer-second Duration formatting', () {
+      expect(formatDurationHmsSeconds(0), '00:00');
+      expect(formatDurationHmsSeconds(5), '00:05');
+      expect(formatDurationHmsSeconds(62), '01:02');
+      expect(formatDurationHmsSeconds(3600), '01:00:00');
+    });
+
+    test('rounds fractional seconds to the nearest millisecond', () {
+      // Sub-second values still format as 00:00 — Duration.inSeconds truncates.
+      expect(formatDurationHmsSeconds(0.4), '00:00');
+      expect(formatDurationHmsSeconds(0.6), '00:00');
+      // Near a whole second, ms rounding can tip into the next second.
+      expect(formatDurationHmsSeconds(0.9996), '00:01');
+      expect(formatDurationHmsSeconds(1.5), '00:01');
+    });
+  });
+
   group('formatPracticeDurationMs', () {
     test('zero and negative milliseconds render as 0m', () {
       expect(formatPracticeDurationMs(0), '0m');


### PR DESCRIPTION
## Summary
- **#356**: Extract `_swallow` on `YoutubeTranscriptsApi` so the three fire-and-forget methods share one try/catch/log/fallback path (upload context preserved in the description string).
- **#363**: Add `formatDurationHmsMs` / `formatDurationHmsSeconds` and migrate library/transport/discover call sites so fractional-second rounding lives in one place.
- **#361 / #362**: Closed as won't-fix after review (see issue comments) — RestApi facades and Drift `(targetType, targetId)` filters are intentional patterns, not DRY debt.

## Test plan
- [x] `flutter analyze`
- [x] `flutter test` (full suite green)
- [x] `test/core/utils/time_format_test.dart` covers new helpers
- [x] `test/data/api/services/ai/youtube_transcripts_api_test.dart` still passes

Closes #356
Closes #363

Made with [Cursor](https://cursor.com)