### PR TITLE
docs: resolve open documentation issues (#347–#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Practice poster export crash in release mode** — `RenderObject.debugNeedsPaint` throws `LateInitializationError` in release when implemented with `late`+`assert`; use frame settle + retry instead and reset exporting state in `finally`.
+- **Practice poster export crash in release mode** — `RenderObject.debugNeedsPaint` throws `LateInitializationError` in release when implemented with `late`+`assert`; export waits for a settled frame, retries rasterization when needed, and resets exporting state in `finally`. See [docs/features/share-poster.md](docs/features/share-poster.md).
 
 ## [0.5.2] - 2026-07-16
 
@@ -26,29 +26,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Discover channel refresh uses InnerTube `browse` as primary data source** ([ADR-0047](docs/decisions/0047-youtube-discover-innertube.md)). The per-channel refresh path now tries InnerTube's anonymous `browse` endpoint first (`POST youtubei.googleapis.com/youtubei/v1/browse`) and falls back to the Atom RSS endpoint on failure. InnerTube returns richer metadata (`lengthText`, `viewCountText`, `publishedTimeText`) and is materially less likely to be blocked by YouTube's bot detection. The legacy watch-page HTML duration enrichment is skipped for InnerTube-sourced rows. Client profile rotation (`WEB` → `MWEB`) and continuation pagination (cap 5 pages ≈ 150 entries) match the caption fetcher's posture. See [docs/features/discover.md § Data sources](docs/features/discover.md#data-sources-dual-source).
+- **Discover channel refresh uses InnerTube `browse` as primary data source** ([ADR-0047](docs/decisions/0047-youtube-discover-innertube.md)). The per-channel refresh path now tries InnerTube's anonymous `browse` endpoint first (`POST youtubei.googleapis.com/youtubei/v1/browse`) and falls back to the Atom RSS endpoint on failure. InnerTube returns richer metadata (`lengthText`, `viewCountText`, `publishedTimeText`) and is materially less likely to be blocked by YouTube's bot detection. The legacy watch-page HTML duration enrichment is skipped for InnerTube-sourced rows. Client profile rotation (`WEB` → `MWEB`) and continuation pagination (cap 5 pages ≈ 150 entries) match the caption fetcher's posture. See [docs/features/discover.md](docs/features/discover.md). *(Later superseded for feed fetch by [ADR-0051](docs/decisions/0051-youtube-worker-discovery.md) — server-side RSSHub proxy; ADR-0047 remains accurate for that slice of history.)*
 - **Discover avatar URL cache rides the shared `L1Store<K, V>` primitive** ([#335](https://github.com/baizhiheizi/enjoy_player/pull/335)). `DiscoverRepository` no longer carries a hand-rolled `LinkedHashMap` LRU for channel avatars; the cache is now a 256-entry, 6-hour-TTL instance of the same [`L1Store`](lib/core/cache/lru_store.dart) that backs the AI result cache hierarchy ([ADR-0045](docs/decisions/0045-ai-result-cache-hierarchy.md)) and `LookupSheetResultCache`. The 6 h TTL is a strict relaxation of the previous infinite lifetime — avatar URLs change only a few times per year, so the window is far longer than realistic re-fetch cadence while bounding memory of long-running sessions that touch thousands of distinct channels. New cache call sites should use `L1Store` instead of re-implementing LRU bookkeeping; see [docs/conventions.md § Caching](docs/conventions.md#caching) for the behavior contract and current call sites.
 - **`SyncDownloadService` uses a generic `_downloadEntityInternal<E>` helper** ([#336](https://github.com/baizhiheizi/enjoy_player/issues/336), [#341](https://github.com/baizhiheizi/enjoy_player/pull/341)). The three per-entity download paths (audio, video, recording) now share one ~75-line pagination + merge loop instead of duplicating ~200 lines of triplicated cursor-paging logic. Public `downloadAudios` / `downloadVideos` / `downloadRecordings` / `downloadAllEntitiesFresh` entry points and `SyncResult` shape are unchanged — see [docs/features/sync.md](docs/features/sync.md).
-- **Discover feed entry upserts run in a single Drift transaction** for lower write amplification on large channel refreshes.
+- **Discover feed entry upserts run in a single Drift batch transaction per source** for lower write amplification on large channel refreshes — one `watchTimeline` emission for non-empty upserts; empty responses are a no-op. See [docs/features/discover.md § Cache semantics](docs/features/discover.md#cache-semantics-append-only).
 
 ### Fixed
 
 - **Intermittent Windows YouTube play-then-pause startup**: WebView2 ignores `mediaPlaybackRequiresUserGesture`, while the player previously force-unmuted on HTML5's optimistic `play` event. Playback now stays muted until the authoritative `playing` event settles, transport state no longer treats `play` as proof that frames are advancing, and rejected `play()` promises plus command/event/poll transitions are captured by the `YouTube*` diagnostic loggers. The WebView logger names were also corrected from `Youtube*` to the allowlisted, case-sensitive `YouTube*` prefix, fixing pre-existing silent loss of FINE records. See [docs/features/youtube.md](docs/features/youtube.md#limitations).
 - **YouTube InnerTube caption profile ladder hardening** so client-profile rotation and worker cache-only transcript fetches fail closed instead of returning empty or mismatched tracks.
-- **Shadow-reading assessment restored for unknown media language** (assessment no longer skips when language cannot be inferred).
+- **Shadow-reading assessment restored for unknown media language** — unknown / denylisted media tags (`und`, empty) fall back to the learner's `effectiveLearningLanguage` via `resolveAzureAssessmentLocaleForPractice` / `isAzurePronunciationAssessmentSupportedForPractice` instead of disabling Assess while play / take-menu still worked. Genuinely unsupported primaries still disable the control with a tooltip (no silent `en-US` coercion). See [docs/features/shadow-reading.md](docs/features/shadow-reading.md#pronunciation-assessment-azure) and [docs/features/echo-mode.md](docs/features/echo-mode.md).
+- **Discover migration v13 `feed_url` backfill** uses the SQL column name `channel_id` (not the Drift accessor `channelId`), so pre-existing subscriptions get a worker feed URL instead of failing the migration step.
 - **Worker YouTube `client-profiles` wire shape parsing** aligned with the actual response body.
 
 ## [0.5.0] - 2026-07-13
 
 ### Added
 
-- **Linux platform support (AppImage)**. Linux is now a first-class supported desktop platform. (ADR-0044) [#PR]
+- **Linux platform support (AppImage)**. Linux is now a first-class supported desktop platform. ([ADR-0048](docs/decisions/0048-linux-platform-support.md))
   - `linux/` Flutter desktop scaffold, `.github/workflows/build_linux.yml` CI, `release_linux.sh`, AppImage packager
   - Centralized `lib/core/platform/linux_platform_availability.dart` predicates
   - Landing page `#card-linux` with localized strings (en + zh)
   - YouTube engine gracefully opts out on Linux (WebViewGTK not ready for v1)
   - Constitution amendment 1.1.0 → 1.2.0 (Linux added to supported targets)
-  - New `docs/features/linux-platform.md`, `docs/decisions/0044-linux-platform-support.md`
+  - New `docs/features/linux-platform.md`, `docs/decisions/0048-linux-platform-support.md`
   - `AGENTS.md` and `README.md` updated for Linux first-class support
 
 - **Echo enforcement coordinator (`EchoEnforcer`)**: the reactive per-tick

--- a/docs/api/rest-services.md
+++ b/docs/api/rest-services.md
@@ -137,6 +137,10 @@ Reference services that already follow this pattern (each is a thin
 - [`services/ai/`](../../lib/data/api/services/ai/) — `AsrApi`, `ChatApi`,
   `TranslationApi`, `DictionaryApi`, `AzureTokenApi`, `CreditsApi`,
   `YoutubeTranscriptsApi`.
+- [`youtube_feed_api.dart`](../../lib/data/api/services/ai/youtube_feed_api.dart)
+  — `YoutubeFeedClient` (JSON Feed over the worker RSSHub proxy; uses
+  `package:http` + bearer auth via `youtubeFeedClientProvider`, not `RestApi` /
+  `ApiClient`, because the response shape is JSON Feed v1.1).
 
 ## Related references
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,26 +43,39 @@ sequenceDiagram
 
 | Table | Purpose |
 |-------|---------|
-| `videos` | Local video URI, `vid` hash, duration (seconds), sync metadata |
-| `audios` | Local audio URI, `aid` hash, duration, optional TTS fields, sync metadata |
+| `videos` | Local / linked media: `localUri`, `md5` content fingerprint, `size`, `localMtimeMs` (cheap open trust check), `vid` hash, duration (seconds), sync metadata ([ADR-0050](decisions/0050-path-linked-local-media.md)) |
+| `audios` | Same path-linked columns as `videos`, plus optional TTS fields and sync metadata |
 | `transcripts` | `targetType` + `targetId` (weapp-style), JSON `timeline`, sync metadata |
 | `echo_sessions` | Playback + echo window + primary/secondary transcript ids per target |
 | `recordings` | Pronunciation recordings (sync-ready); time fields `duration`, `referenceStart`, `referenceDuration` in ms, aligned with API |
 | `dictations` | Dictation attempts (sync-ready) |
 | `sync_queue` | Offline-first outbound sync queue (`SyncCtrl` + [`features/sync.md`](features/sync.md)) |
 | `settings` | Key/value JSON blobs (player prefs, hotkeys, **main API base URL**, **AI/Worker API base URL**, **auth profile cache**, app locale prefs) |
+| `youtube_channel_subscriptions` | Discover subscriptions (`channelId`, `sourceType`, `feedUrl`, optional catalog `language`, fetch timestamps) |
+| `youtube_feed_entries` | Append-only Discover feed cache keyed by video id ([ADR-0046](decisions/0046-discover-feed-append-only.md)) |
+| `transcript_fetch_states` | Per-target transcript fetch bookkeeping; composite index `idx_transcript_fetch_states_target` on `(target_type, target_id)` |
+| `ai_cache` | L2 AI result cache (`kind` + `key` PK, `payload_json`, `updated_at`) ([ADR-0045](decisions/0045-ai-result-cache-hierarchy.md)) |
+
+`localUri` / `md5` / `size` predate schema v14 and store the playable reference plus SHA-256 fingerprint used for re-import / re-link matching. **v13 → v14** adds `localMtimeMs` for the cheap open trust check ([ADR-0050](decisions/0050-path-linked-local-media.md)).
 
 ### Schema upgrades (release note)
 
-[`AppDatabase`](../lib/data/db/app_database.dart) uses **destructive** `onUpgrade` for schema versions below 6. **v6 → v7** adds Discover tables incrementally without wiping library data. Older upgrades still drop listed tables and recreate them. Plan releases accordingly.
+[`AppDatabase`](../lib/data/db/app_database.dart) is at **`schemaVersion: 14`**. Upgrades from versions **below 6** are **destructive** (JSON backup, drop legacy tables, `createAll`). From **v6 upward**, migrations are **incremental** — no library wipe:
+
+| Step | Change |
+|------|--------|
+| v6 → v7 | Create `youtube_channel_subscriptions` + `youtube_feed_entries` |
+| v7 → v8 | Add `youtube_feed_entries.duration_seconds` |
+| v8 → v9 | `CREATE INDEX IF NOT EXISTS idx_transcript_fetch_states_target` |
+| v9 → v10 | Add `youtube_channel_subscriptions.language` (catalog tag; not used as media content language after YT source-language removal) |
+| v10 → v11 | Add `echo_sessions.blur_active` |
+| v11 → v12 | Create `ai_cache` + `idx_ai_cache_kind_updated_at` ([ADR-0045](decisions/0045-ai-result-cache-hierarchy.md)) |
+| v12 → v13 | Add `source_type` / `feed_url`; backfill `feed_url` using SQL column `channel_id` ([ADR-0051](decisions/0051-youtube-worker-discovery.md)) |
+| v13 → v14 | Add `videos.local_mtime_ms` + `audios.local_mtime_ms` ([ADR-0050](decisions/0050-path-linked-local-media.md)) |
 
 ### Per-user database cache
 
 `app_database_provider.dart` keeps the most recent **two** per-user [`AppDatabase`](../lib/data/db/app_database.dart) instances in a bounded `LinkedHashMap`. On sign-in for a third account, the **oldest** entry is closed (and its Drift connections released) before the new one is inserted — see [ADR-0012](decisions/0012-per-user-sqlite-isolation.md) for the per-user isolation rationale. The cap keeps the file-handle / mmap footprint stable across guest ↔ account churn.
-
-#### `transcript_fetch_states` composite index
-
-The `(target_type, target_id)` lookup on [`TranscriptFetchStates`](../lib/data/db/tables/transcript_fetch_states.dart) is now backed by the composite index `idx_transcript_fetch_states_target`. The index is declared on the table via `@TableIndex` (so new installs get it from `createAll()`) and the **v8 → v9** migration step adds it to existing databases with `CREATE INDEX IF NOT EXISTS` — neither path drops the table or its data.
 
 ## Optional Enjoy account (auth)
 

--- a/docs/decisions/0021-youtube-discover-rss.md
+++ b/docs/decisions/0021-youtube-discover-rss.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-0051
 
 ## Context
 

--- a/docs/decisions/0047-youtube-discover-innertube.md
+++ b/docs/decisions/0047-youtube-discover-innertube.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-0051
 
 ## Context
 

--- a/docs/decisions/0051-youtube-worker-discovery.md
+++ b/docs/decisions/0051-youtube-worker-discovery.md
@@ -1,8 +1,11 @@
-# ADR-0049: YouTube Worker Discovery via RSSHub Proxy
+# ADR-0051: YouTube Worker Discovery via RSSHub Proxy
+
+> **Note:** Originally filed as ADR-0049 (`0049-youtube-worker-discovery.md`). Renumbered to ADR-0051 to resolve an ID collision with `0049-youtube-language-aware-captions.md` (ADR-0050 was already taken by path-linked local media).
 
 **Date**: 2026-07-14  
 **Status**: Accepted  
 **Deciders**: Engineering team  
+**Supersedes**: [ADR-0021](0021-youtube-discover-rss.md), [ADR-0047](0047-youtube-discover-innertube.md)
 
 ## Context
 
@@ -46,7 +49,7 @@ Response: JSON Feed v1.1 (https://www.jsonfeed.org/version/1.1/)
 
 - **Eliminates client-side YouTube scraping completely.** No more InnerTube `browse`, Atom RSS, HTML scraping, or watch-page duration enrichment.
 - **Improved reliability.** RSSHub handles YouTube API communication, rate limiting, and response-shape resilience server-side.
-- **Simplified client architecture.** Replaces 5 data files (YoutubeBrowseClient, YoutubeRssParser, YoutubeChannelResolver, YoutubeFetch, YoutubeVideoDuration) + a legacy ID correction map (~1500 LOC) with 3 new files (YoutubeUrlParser, JsonFeedParser, WorkerFeedClient) (~400 LOC).
+- **Simplified client architecture.** Replaces 5 data files (YoutubeBrowseClient, YoutubeRssParser, YoutubeChannelResolver, YoutubeFetch, YoutubeVideoDuration) + a legacy ID correction map (~1500 LOC) with a small parser/client set (`YoutubeUrlParser`, `JsonFeedParser`, and `YoutubeFeedClient` in `lib/data/api/services/ai/youtube_feed_api.dart`, wired via `youtubeFeedClientProvider` with bearer auth from `SecureTokenStore.readAccessToken`).
 - **Adds playlist subscription support.** Previously deferred as out-of-scope, now a first-class source type alongside channels and handles.
 - **Standard feed format.** JSON Feed v1.1 is a well-defined standard; no custom API schema needed.
 
@@ -60,6 +63,8 @@ Response: JSON Feed v1.1 (https://www.jsonfeed.org/version/1.1/)
 ### Migration
 
 The legacy client-side discovery code is completely removed in this change. No dual-source fallback — the worker feed is the sole source. Existing cached feed entries in the local database remain visible offline.
+
+Schema **v12 → v13** adds `source_type` / `feed_url` on `youtube_channel_subscriptions` and backfills `feed_url` with SQL that uses the snake_case column name `channel_id` (not the Drift accessor `channelId`). A runtime repair step regenerates a missing `feed_url` on refresh when needed.
 
 ## Rejected Alternatives
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -44,7 +44,7 @@ Trade-offs, follow-up work, risks.
 | [0018](0018-shared-interactive-primitives.md) | Shared interactive primitives — EnjoyTappable, Haptics, EnjoyButton |
 | [0019](0019-transcript-dictionary-lookup.md) | Transcript dictionary lookup — selection scope, bottom sheet, worker APIs |
 | [0020](0020-android-windows-release-identity.md) | Android app ID `ai.enjoy.player`, release signing via `key.properties`, Windows release branding + Inno installer |
-| [0021](0021-youtube-discover-rss.md) | YouTube discovery via RSS feeds and local channel subscriptions |
+| [0021](0021-youtube-discover-rss.md) | YouTube discovery via RSS feeds and local channel subscriptions (superseded by 0051) |
 | [0022](0022-unified-library-navigation.md) | Unified Library navigation — local + cloud source switch |
 | [0023](0023-app-update-distribution.md) | App update distribution — store no-op, direct feeds on dl.enjoy.bot |
 | [0024](0024-download-landing-page.md) | Download landing page — static site on Cloudflare Pages at get.enjoy.bot |
@@ -68,9 +68,10 @@ Trade-offs, follow-up work, risks.
 | [0042](0042-multi-language-lookup-catalog.md) | Multi-language lookup catalog — decoupled source / target language pickers for transcript dictionary lookup |
 | [0043](0043-craft-from-text-import.md) | Craft from text import — single entry, two modes, BYOK parity for TTS |
 | [0044](0044-deterministic-end-of-media-completion-loop.md) | Deterministic end-of-media handling with generation-guarded completion loop |
-| [0048](0048-linux-platform-support.md) | Linux as a first-class supported desktop platform (AppImage) (renumbered from 0044) |
 | [0045](0045-ai-result-cache-hierarchy.md) | Unified two-tier AI result cache (L1 LRU+TTL / L2 Drift) and `AiCacheFingerprint` keying |
 | [0046](0046-discover-feed-append-only.md) | Discover feed cache is append-only between unsubscribe events |
-| [0047](0047-youtube-discover-innertube.md) | InnerTube `browse` as primary source for YouTube channel discover |
+| [0047](0047-youtube-discover-innertube.md) | InnerTube `browse` as primary source for YouTube channel discover (superseded by 0051) |
+| [0048](0048-linux-platform-support.md) | Linux as a first-class supported desktop platform (AppImage) |
 | [0049](0049-youtube-language-aware-captions.md) | YouTube language-aware caption discovery & primary selection |
 | [0050](0050-path-linked-local-media.md) | Path-linked local media — prefer lasting link, copy fallback (partial supersession of 0005 import storage) |
+| [0051](0051-youtube-worker-discovery.md) | YouTube discovery via server-side RSSHub proxy (supersedes 0021 and 0047) |

--- a/docs/features/discover.md
+++ b/docs/features/discover.md
@@ -16,8 +16,7 @@ Discover feeds are **not** library items until imported. Subscriptions are **Enj
 
 The Discover tab shows a **merged video feed** only (responsive grid of recent uploads). A horizontal **filter strip** sits below the header:
 
-- **All** — timeline across all subscribed channels (optionally filtered to the focus learning language; see below)
-- **Language scope** — toggle between focus-language filtering and **All languages** (recommended strip and merged feed when **All** channel filter is active)
+- **All** — timeline across all subscribed channels
 - **Channel avatars** — filter the feed to one subscription
 - **Manage channels** — opens subscription management (see below)
 
@@ -30,7 +29,6 @@ Opened from the filter strip (bottom sheet on narrow layouts, centered dialog at
 - **Subscribe** (paste URL / `@handle` / channel ID / playlist ID)
 - **Your channels** — list with **Unsubscribe** (does not navigate away from the modal)
 - **Recommended** — bundled catalog (`assets/discover/recommended_channels.json`) with **Subscribe** / **Subscribed** badges; channels are **language-tagged** (English, Japanese, Korean, Spanish, French in the first wave). The list is filtered to the user's focus learning language by default, with **All languages** to browse everything.
-- **Subscription language** — each subscription stores a channel language (from the catalog or **Unknown** for pasted URLs). Tap the language label on a subscription row to correct it. **Add to library** uses subscription language as the default media content language; unknown-language subscriptions prompt for content language before import.
 
 Empty Discover state (no subscriptions) prompts **Manage channels** so users can add recommended channels first.
 
@@ -52,7 +50,7 @@ Empty Discover state (no subscriptions) prompts **Manage channels** so users can
 
 ### Data source (single-source RSSHub proxy)
 
-The per-source refresh path is **single-source** ([ADR-0049](../decisions/0049-youtube-worker-discovery.md)):
+The per-source refresh path is **single-source** ([ADR-0051](../decisions/0051-youtube-worker-discovery.md)):
 
 All video discovery requests go through a **server-side RSSHub proxy**, never directly to YouTube. The worker exposes three RSSHub YouTube routes:
 
@@ -77,10 +75,11 @@ The client requests JSON Feed v1.1 format (via `?format=json`). See the [worker 
 - `date_published` — published timestamp (ISO 8601)
 - `attachments[].duration_in_seconds` — video duration
 
-The refresh client (`WorkerFeedClient`) handles:
+The refresh client ([`YoutubeFeedClient`](../../lib/data/api/services/ai/youtube_feed_api.dart), provided by `youtubeFeedClientProvider` with bearer auth from `SecureTokenStore.readAccessToken`) handles:
 - HTTP status codes → typed exceptions (404 → notFound, 410 → sourceUnavailable, 429 → rateLimited, 502 → upstreamFailure)
 - Handle-to-ID canonicalization: when subscribing via @handle, the client extracts the canonical channel ID from `home_page_url` and uses `/youtube/channel/{id}` for subsequent refreshes
 - Network errors → networkError exception
+- Runtime repair: if a subscription's `feed_url` is missing, regenerate it before fetch (covers pre-v13 rows that missed the backfill)
 
 ### Cache semantics (append-only)
 
@@ -90,6 +89,7 @@ The `youtube_feed_entries` cache is **append-only between unsubscribe events** (
 - Updates mutable metadata (`title`, `thumbnailUrl`, `publishedAt`) and `fetchedAt` on entries the source re-presented.
 - **Does not delete** cached entries that fell out of the source's most-recent window (~15–50 entries).
 - Uses video ID deduplication — if all returned entries are already cached, no changes are made and `lastFetchedAt` is still updated.
+- Writes each source's upserts in **one Drift `batch` / transaction** (`YoutubeFeedEntryDao.upsertEntries`). Non-empty refreshes therefore emit a **single** `watchTimeline` update; empty responses are a no-op (no watcher churn).
 
 The user-visible way to bound cache growth is to **unsubscribe** from a source — `DiscoverRepository.unsubscribe(channelId)` deletes every cached entry for that channel.
 
@@ -104,6 +104,14 @@ When a user subscribes via @handle (e.g., `https://youtube.com/@TED`):
 4. All subsequent refreshes use `GET /youtube/channel/UCAuUUnT6oDeKwE6v1NGQxug?format=json`
 
 This prevents duplicate subscriptions (handle + channel ID pointing to the same source) and avoids redundant handle resolution on every refresh.
+
+### YT source language removal
+
+Subscription rows may still store a catalog `language` column (schema v10) for recommended-channel bookkeeping, but the **DiscoverChannel** domain model and UI no longer expose a per-subscription language:
+
+- There is no **Language scope** toggle on the filter strip and no language label / editor on subscription rows.
+- **Add to library** does not infer media content language from a subscription; callers pass an explicit `contentLanguage` or default to `und` (`kUnknownMediaLanguageTag`).
+- Recommended-catalog filtering by the learner's focus language remains (catalog tags on bundled channels only).
 
 ### Scheduler gating
 
@@ -142,7 +150,7 @@ The merged feed grid and the channel feed grid both use stable `ValueKey<String>
 
 ## Add to library
 
-Uses the same path as **Import → From YouTube URL**: oEmbed metadata, `videos` row with `provider: youtube`, optional sync enqueue when signed in. Duplicate video ids show **In library** instead of add.
+Uses the same path as **Import → From YouTube URL**: oEmbed metadata, `videos` row with `provider: youtube`, optional sync enqueue when signed in. Duplicate video ids show **In library** instead of add. Media content language comes from an explicit import choice (or `und`), not from the subscription row.
 
 ## Transcripts
 
@@ -158,9 +166,9 @@ No caption availability in the worker feed. After import, transcript loading fol
 
 ## Related
 
-- [ADR-0049](../decisions/0049-youtube-worker-discovery.md) — moved YouTube discovery to server-side RSSHub proxy
-- [ADR-0021](../decisions/0021-youtube-discover-rss.md) — original RSS-only discovery (replaced)
+- [ADR-0051](../decisions/0051-youtube-worker-discovery.md) — moved YouTube discovery to server-side RSSHub proxy
+- [ADR-0021](../decisions/0021-youtube-discover-rss.md) — original RSS-only discovery (superseded by 0051)
 - [ADR-0046](../decisions/0046-discover-feed-append-only.md) — append-only feed cache
-- [ADR-0047](../decisions/0047-youtube-discover-innertube.md) — InnerTube primary source (replaced)
+- [ADR-0047](../decisions/0047-youtube-discover-innertube.md) — InnerTube primary source (superseded by 0051)
 - [Worker feed API contract](../../specs/018-youtube-worker-discovery/contracts/worker-feed-api.md)
 - [youtube.md](youtube.md)

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -343,7 +343,7 @@ bash .github/scripts/rename_release_artifacts.sh apple
 | Sideload APK (`direct` flavor) | Direct download | Yes (`ota_update`) |
 | Windows installer | Direct download | Yes (WinSparkle) |
 | macOS zip | Direct download | Yes (Sparkle) |
-| Linux AppImage | Direct download | No (manual update; AppImageUpdate planned per ADR-0044) |
+| Linux AppImage | Direct download | No (manual update; AppImageUpdate planned per ADR-0048) |
 | iOS IPA | TestFlight / App Store | No |
 
 Direct builds check `https://dl.enjoy.bot/player/latest.json` (ADR-0023). Store builds do not.

--- a/lib/core/platform/linux_platform_availability.dart
+++ b/lib/core/platform/linux_platform_availability.dart
@@ -15,29 +15,29 @@ bool get isLinux => Platform.isLinux;
 ///
 /// The engine depends on `flutter_inappwebview`'s Linux backend, which requires
 /// `webkit2gtk-4.0` — not present on a default Ubuntu 22.04 LTS install.
-/// Re-evaluate in a follow-up ADR (ADR-0044, R1 / R6).
+/// Re-evaluate in a follow-up ADR (ADR-0048, R1 / R6).
 const youtubeEngineAvailableOnLinux = false;
 
 /// Google native sign-in is **available** on Linux.
 ///
 /// `google_sign_in: ^6.3.0` supports Linux via a browser-based OAuth flow.
-/// Flip to `false` if first smoke shows a crash or auth loop (ADR-0044, R10).
+/// Flip to `false` if first smoke shows a crash or auth loop (ADR-0048, R10).
 const googleSignInAvailableOnLinux = true;
 
 /// In-app auto-updater (`auto_updater: 0.2.1`) is **not** available on Linux.
 ///
 /// `auto_updater` is Windows/macOS-only. Linux uses the direct-download update
-/// model (ADR-0044, R7).
+/// model (ADR-0048, R7).
 const autoUpdaterAvailableOnLinux = false;
 
 /// Echo-mode recording (`record: ^7.0.0`) is **enabled** on Linux by default.
 ///
 /// Flip to `false` if first smoke shows a crash; the rest of echo practice
-/// works without recording (ADR-0044, R8).
+/// works without recording (ADR-0048, R8).
 const echoRecordingAvailableOnLinux = true;
 
 /// ASR (Azure speech) audio extraction over FFmpeg is **enabled** on Linux.
 ///
 /// The extraction code falls through to system `ffmpeg` on PATH for non-Windows
-/// platforms. Flip to `false` if smoke shows a regression (ADR-0044).
+/// platforms. Flip to `false` if smoke shows a regression (ADR-0048).
 const nativeLinuxAsrAvailable = true;

--- a/lib/features/auth/domain/auth_platform_support.dart
+++ b/lib/features/auth/domain/auth_platform_support.dart
@@ -14,7 +14,7 @@ import 'package:enjoy_player/features/auth/domain/google_auth_config.dart';
 /// (uncatchable native `NSException`) if `GIDSignIn.signIn()` is invoked before
 /// Info.plist has a real OAuth client configured, so the button must stay
 /// hidden until that setup is done. Linux uses the `googleSignInAvailableOnLinux`
-/// flag from the centralized platform-availability module (ADR-0044).
+/// flag from the centralized platform-availability module (ADR-0048).
 bool get nativeGoogleSignInSupported {
   if (defaultTargetPlatform == TargetPlatform.windows) return false;
   if (defaultTargetPlatform == TargetPlatform.linux) {

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -114,7 +114,7 @@ class YoutubePlayerEngine implements PlayerEngine {
         defaultTargetPlatform == TargetPlatform.linux) {
       throw UnsupportedError(
         'YouTube is not yet available on Linux — coming soon '
-        '(ADR-0044, R1 / R6: webview2gtk-4.0 dependency).',
+        '(ADR-0048, R1 / R6: webview2gtk-4.0 dependency).',
       );
     }
     if (source is! YoutubePlayableSource) {

--- a/lib/features/player/application/player_engine.dart
+++ b/lib/features/player/application/player_engine.dart
@@ -128,7 +128,7 @@ class MediaKitPlayerEngine implements PlayerEngine {
     }
     if (Platform.isLinux) {
       // Same conservative path as macOS: avoid green-screen / EGL_BAD_DISPLAY
-      // on Linux + Wayland with NVIDIA / AMD hybrid GPUs (ADR-0044, R2).
+      // on Linux + Wayland with NVIDIA / AMD hybrid GPUs (ADR-0048, R2).
       return const VideoControllerConfiguration(
         width: kVideoControllerWidth,
         height: kVideoControllerHeight,

--- a/lib/features/transcript/data/client_profile.dart
+++ b/lib/features/transcript/data/client_profile.dart
@@ -186,8 +186,9 @@ const List<ClientProfile> kBuiltInClientProfiles = [
   ),
   ClientProfile(
     // Desktop WEB — last-resort caption fallback (often needs PoToken).
-    // Kept for Discover-era compatibility and rare cases where mobile
-    // clients are throttled. Not preferred for captions in 2026.
+    // Discover feed fetch no longer uses InnerTube browse (ADR-0051);
+    // ClientProfile rotation applies only to the caption `/player` ladder.
+    // Kept for rare cases where mobile clients are throttled.
     name: 'web',
     clientName: 'WEB',
     clientVersion: '2.20250709.00.00',

--- a/specs/015-ai-cache-hierarchy/plan.md
+++ b/specs/015-ai-cache-hierarchy/plan.md
@@ -22,7 +22,7 @@ Replace the four ad-hoc AI result caches in `lib/features/lookup/` and `lib/feat
 
 **Testing**: `flutter test` (host VM) against `NativeDatabase.memory()` (the existing pattern in `auto_translate_request_test.dart`). The cache layer is split so the pure-Dart core is testable without Riverpod, the DAO is testable against an in-memory Drift database, and the integration (via `lookup_section_providers.dart` and `auto_translate_controller.dart`) is testable via `ProviderContainer` with overrides — mirroring the existing transcript test suite.
 
-**Target Platform**: Android, iOS, macOS, Windows, Linux (unchanged; per ADR-0044). The cache has no platform-conditional code.
+**Target Platform**: Android, iOS, macOS, Windows, Linux (unchanged; per ADR-0048). The cache has no platform-conditional code.
 
 **Project Type**: Flutter native mobile/desktop app — no new project type.
 

--- a/specs/016-append-only-discover-feed/plan.md
+++ b/specs/016-append-only-discover-feed/plan.md
@@ -31,7 +31,7 @@ No new dependencies are introduced. No Drift schema change is required (column s
 
 **Testing**: `flutter test` is the primary gate. The change must add unit tests under `test/features/discover/` covering (a) cache grows on new entries, (b) cache preserved when RSS omits entries, (c) refresh idempotency on identical RSS responses, (d) unsubscribe clears the channel's cache, (e) failed refresh leaves cache and `lastFetchedAt` untouched. The existing `discover_repository_test.dart` and `discover_dedupe_test.dart` may need updates if they assert stale-entry deletion (per spec QR-002 + SC-007).
 
-**Target Platform**: Android, iOS, macOS, Windows, Linux (Flutter web is out of scope per ADR-0044 and the constitution). No platform-specific code; the change is in pure Dart.
+**Target Platform**: Android, iOS, macOS, Windows, Linux (Flutter web is out of scope per ADR-0048 and the constitution). No platform-specific code; the change is in pure Dart.
 
 **Project Type**: Flutter native mobile/desktop app.
 

--- a/specs/017-innertube-channel-discover/plan.md
+++ b/specs/017-innertube-channel-discover/plan.md
@@ -36,7 +36,7 @@ No new dependencies are introduced. No Drift schema change is required — `Yout
 
 No widget/integration tests are required; the change is a repository-layer data-source swap with documented observable behavior. Manual verification is described in `quickstart.md`.
 
-**Target Platform**: Android, iOS, macOS, Windows, Linux (Flutter web is out of scope per ADR-0044 and the constitution). No platform-specific code; `package:http` already supports all targets.
+**Target Platform**: Android, iOS, macOS, Windows, Linux (Flutter web is out of scope per ADR-0048 and the constitution). No platform-specific code; `package:http` already supports all targets.
 
 **Project Type**: Flutter native mobile/desktop app.
 

--- a/specs/018-youtube-worker-discovery/plan.md
+++ b/specs/018-youtube-worker-discovery/plan.md
@@ -62,7 +62,7 @@ This is a redesign from zero — the legacy client-side code (`YoutubeRssParser`
 
 ### V. Documentation and Traceability
 
-- [x] New ADR: `0049-youtube-worker-discovery.md` — PASS
+- [x] New ADR: `0051-youtube-worker-discovery.md` — PASS
 - [x] Updated feature doc: `docs/features/discover.md` — PASS
 - [x] Updated agent guidance if needed — CONFIRM at Phase 1 re-check
 
@@ -155,7 +155,7 @@ test/
 
 docs/
 ├── features/discover.md                       # REWRITE
-└── decisions/0049-youtube-worker-discovery.md # NEW
+└── decisions/0051-youtube-worker-discovery.md # NEW
 ```
 
 **Structure Decision**: All new code stays under `lib/features/discover/data/` following the existing feature-first convention. Worker API contracts go in `specs/018-youtube-worker-discovery/contracts/`. The legacy code removal is part of this feature (not a follow-up), since the redesign replaces it completely.

--- a/specs/018-youtube-worker-discovery/quickstart.md
+++ b/specs/018-youtube-worker-discovery/quickstart.md
@@ -113,4 +113,4 @@ bash .github/scripts/validate_ci_gates.sh
 - `lib/features/discover/data/discover_repository.dart` — rewritten refresh pipeline
 - `lib/data/db/tables/youtube_channel_subscriptions.dart` — schema migration (new columns)
 - `docs/features/discover.md` — updated documentation
-- `docs/decisions/0049-youtube-worker-discovery.md` — new ADR
+- `docs/decisions/0051-youtube-worker-discovery.md` — new ADR

--- a/specs/018-youtube-worker-discovery/research.md
+++ b/specs/018-youtube-worker-discovery/research.md
@@ -35,7 +35,7 @@
 
 **Rationale**: The worker is deployed alongside the existing Enjoy worker at `worker.enjoy.bot`. The existing `aiApiClientProvider` already provides an `ApiClient` pointed at the worker base URL. However, the current feed endpoints don't need bearer auth (they're public RSSHub routes proxied through the worker). A new lightweight HTTP client (using `package:http` directly) is simpler than reusing `ApiClient` with all its JSON response conventions.
 
-Alternative considered: Reuse `ApiClient` from `api_client.dart` — rejected because the RSSHub proxy returns JSON Feed (not the Rails-style snake_case JSON `ApiClient` expects), and feed requests may not always need auth tokens (public route proxy). A dedicated `WorkerFeedClient` with `package:http` is more maintainable.
+Alternative considered: Reuse `ApiClient` from `api_client.dart` — rejected because the RSSHub proxy returns JSON Feed (not the Rails-style snake_case JSON `ApiClient` expects), and feed requests may not always need auth tokens (public route proxy). A dedicated feed client (`YoutubeFeedClient`, originally `WorkerFeedClient`) with `package:http` is more maintainable.
 
 **Configuration**:
 ```dart

--- a/specs/018-youtube-worker-discovery/spec.md
+++ b/specs/018-youtube-worker-discovery/spec.md
@@ -121,7 +121,7 @@ The learner uses Enjoy Player on both their desktop and mobile device, signed in
 - **FR-011**: The client MUST NOT trigger background refreshes while the app is in the background state; refreshes MUST be deferred to the next foreground event.
 - **FR-012**: All logging on the client side MUST use the project's `logNamed` / `package:logging` pattern; the new code MUST NOT introduce `print()` calls.
 - **FR-013**: The client MUST NOT make any direct HTTP requests to YouTube domains (`youtube.com`, `youtubei.googleapis.com`) for discovery or video metadata purposes. All discovery HTTP requests go through the worker (RSSHub proxy).
-- **FR-014**: An `ADR-0049-youtube-worker-discovery.md` MUST be created under `docs/decisions/` documenting the decision to move YouTube video discovery to a server-side RSSHub proxy, the three RSSHub YouTube feed routes, and the local-first subscription model.
+- **FR-014**: An `ADR-0051-youtube-worker-discovery.md` MUST be created under `docs/decisions/` documenting the decision to move YouTube video discovery to a server-side RSSHub proxy, the three RSSHub YouTube feed routes, and the local-first subscription model.
 - **FR-015**: `docs/features/discover.md` MUST be updated to describe the new server-side RSSHub proxy architecture, the three subscribable source types, and the local-first subscription model.
 - **FR-016**: Multi-device subscription sync MUST use the existing cloud sync infrastructure (ADR-0010, ADR-0013). The worker is NOT involved in subscription synchronization between devices.
 

--- a/specs/018-youtube-worker-discovery/tasks.md
+++ b/specs/018-youtube-worker-discovery/tasks.md
@@ -20,7 +20,7 @@
 - **Shared code**: `lib/core/`, `lib/data/`
 - **Tests**: `test/features/discover/`, `test/data/`
 - **Feature docs**: `docs/features/discover.md`
-- **ADRs**: `docs/decisions/0049-youtube-worker-discovery.md`
+- **ADRs**: `docs/decisions/0051-youtube-worker-discovery.md`
 
 ---
 
@@ -160,7 +160,7 @@
 
 **Purpose**: Documentation, verification, and cleanup
 
-- [ ] T052 [P] Write ADR `0049-youtube-worker-discovery.md` in `docs/decisions/0049-youtube-worker-discovery.md` — document RSSHub proxy decision, JSON Feed contract, local-first subscriptions, removed legacy code
+- [ ] T052 [P] Write ADR `0051-youtube-worker-discovery.md` in `docs/decisions/0051-youtube-worker-discovery.md` — document RSSHub proxy decision, JSON Feed contract, local-first subscriptions, removed legacy code
 - [ ] T053 [P] Rewrite `docs/features/discover.md` — describe worker RSSHub proxy architecture, three source types, local-first subscriptions, data flow in `docs/features/discover.md`
 - [ ] T054 [P] Remove `YoutubeChannelResolver` and its test — `lib/features/discover/data/youtube_channel_resolver.dart`, `test/features/discover/youtube_channel_resolver_test.dart`
 - [ ] T055 [P] Update `lib/features/discover/data/recommended_channels_loader.dart` — ensure recommended channels use `sourceType: channel` and construct `feedUrl`

--- a/test/core/platform/linux_platform_availability_test.dart
+++ b/test/core/platform/linux_platform_availability_test.dart
@@ -11,7 +11,7 @@ void main() {
     });
 
     test(
-      'youtubeEngineAvailableOnLinux is false (v1 opt-out per ADR-0044)',
+      'youtubeEngineAvailableOnLinux is false (v1 opt-out per ADR-0048)',
       () {
         expect(
           linux_avail.youtubeEngineAvailableOnLinux,
@@ -23,7 +23,7 @@ void main() {
       },
     );
 
-    test('googleSignInAvailableOnLinux is true (v1 default per ADR-0044)', () {
+    test('googleSignInAvailableOnLinux is true (v1 default per ADR-0048)', () {
       expect(
         linux_avail.googleSignInAvailableOnLinux,
         true,
@@ -32,7 +32,7 @@ void main() {
     });
 
     test('autoUpdaterAvailableOnLinux is false (auto_updater is Windows/macOS '
-        'only per ADR-0044)', () {
+        'only per ADR-0048)', () {
       expect(
         linux_avail.autoUpdaterAvailableOnLinux,
         false,
@@ -42,7 +42,7 @@ void main() {
       );
     });
 
-    test('echoRecordingAvailableOnLinux is true (v1 default per ADR-0044)', () {
+    test('echoRecordingAvailableOnLinux is true (v1 default per ADR-0048)', () {
       expect(
         linux_avail.echoRecordingAvailableOnLinux,
         true,
@@ -52,7 +52,7 @@ void main() {
       );
     });
 
-    test('nativeLinuxAsrAvailable is true (v1 default per ADR-0044)', () {
+    test('nativeLinuxAsrAvailable is true (v1 default per ADR-0048)', () {
       expect(
         linux_avail.nativeLinuxAsrAvailable,
         true,

--- a/test/data/api/recording_client_platform_test.dart
+++ b/test/data/api/recording_client_platform_test.dart
@@ -24,7 +24,7 @@ void main() {
 
   test('recordingClientPlatformValue returns linux when Platform.isLinux', () {
     // When running on a Linux test host, the client_platform string must be
-    // 'linux' so the backend classifies it correctly (ADR-0044, FR-020).
+    // 'linux' so the backend classifies it correctly (ADR-0048, FR-020).
     if (!Platform.isLinux) {
       // The test host is not Linux, so we only verify the IO value is one
       // of the supported platforms (already covered above). This test

--- a/test/features/auth/domain/auth_platform_support_test.dart
+++ b/test/features/auth/domain/auth_platform_support_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   group('nativeGoogleSignInSupported on Linux', () {
     test('returns true on Linux (google_sign_in is enabled by default per '
-        'ADR-0044)', () {
+        'ADR-0048)', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.linux;
       expect(
         nativeGoogleSignInSupported,

--- a/test/features/player/application/engines/youtube/youtube_engine_availability_linux_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_engine_availability_linux_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   group('YoutubePlayerEngine on Linux', () {
     test('open throws UnsupportedError on Linux (YouTube not yet available '
-        'per ADR-0044)', () async {
+        'per ADR-0048)', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.linux;
       final engine = YoutubePlayerEngine();
 
@@ -33,7 +33,7 @@ void main() {
         youtubeEngineAvailableOnLinux,
         false,
         reason:
-            'YouTube engine is not available on Linux for v1 per ADR-0044 '
+            'YouTube engine is not available on Linux for v1 per ADR-0048 '
             '(webview2gtk-4.0 dependency).',
       );
     });


### PR DESCRIPTION
## Summary

Consolidates the blocked Update Docs agent issues that could not push because they touch protected files (`CHANGELOG.md` / `README.md`).

- **ADR collision**: renumber worker-discovery `0049` → **`0051`** (language-aware captions keeps `0049`; path-linked media already owns `0050`); mark ADR-0021 / ADR-0047 superseded
- **Linux refs**: finish ADR-0044 → **ADR-0048** migration in CHANGELOG, packaging, specs, and Linux platform comments/tests (preserve completion-loop ADR-0044)
- **Architecture**: Drift tables + schema history through **v14** (Discover, `ai_cache`, path-linked `localMtimeMs`)
- **Discover**: `YoutubeFeedClient` + auth wiring, YT source-language removal, batched `upsertEntries` semantics
- **CHANGELOG**: migration `channel_id` fix, richer shadow-reading / poster / batch notes; InnerTube entry notes later ADR-0051 supersession

Closes #347, #348, #352, #353, #358, #359, #364, #365, #368, #371

## Test plan

- [x] `flutter analyze` on touched Dart files
- [x] `flutter test` on Linux platform / auth / recording client tests with updated ADR strings
- [x] Confirm `docs/decisions/0051-youtube-worker-discovery.md` exists and no `0049-youtube-worker-discovery.md`
- [x] Confirm Linux AppImage / CHANGELOG 0.5.0 links point at ADR-0048
- [ ] Spot-check Discover feature doc against current filter strip + manage-channels UI


Made with [Cursor](https://cursor.com)