### PR TITLE
docs: cross-reference ADR-0056 from sync doc and ADR-0013

### DIFF
--- a/docs/decisions/0013-local-first-sync.md
+++ b/docs/decisions/0013-local-first-sync.md
@@ -15,10 +15,11 @@ The web app uses deterministic IDs for local uploads (`hashBlob` + `sha256(conte
 1. **Stop auto-pulling** remote `audios` / `videos` / global `recordings` into SQLite on `SyncEngine.fullSync`. `fullSync` means **outbound queue drain** only.
 2. **Cloud page**: optional UI to page remote audios/videos and **copy** selected rows into the local DB (`Add to library`).
 3. **Recordings**: when **signed in**, pull metadata **per media target** when the player opens that target (`GET …/recordings?targetId=&targetType=`), with a per-target `updatedAfter` cursor in `settings_kv`.
-4. **IDs**: align with Enjoy web `apps/web/src/db/id-generator.ts` — partial file SHA-256 for `md5` / content hash; signed-in `aid`/`vid` = `SHA-256(contentHash + ":" + userId)`. Signed-out imports and `local-pending-rekey` were removed with login-only access ([ADR-0031](0031-login-only-access.md)).
+4. **IDs**: align with Enjoy web `apps/web/src/db/id-generator.ts` — partial file SHA-256 for `md5` / content hash; signed-in `aid` = `SHA-256(contentHash + ":" + userId)` (audio). Video uploads now use content-addressed ids per [ADR-0056](0056-uservideo-library-membership.md) (`vid = contentHash`, no `userId` salt); the per-user `vid` scheme applies only to legacy video rows. Signed-out imports and `local-pending-rekey` were removed with login-only access ([ADR-0031](0031-login-only-access.md)).
 
 ## Consequences
 
 - ADR-0010 remains the historical record for "metadata sync exists"; this ADR **supersedes** its automatic **download-all-on-sign-in** behavior for Enjoy Player.
+- [ADR-0056](0056-uservideo-library-membership.md) partially supersedes Decision #4: new video uploads are content-addressed (no `userId` salt); audio ids remain user-scoped.
 - Users who relied on the old "everything appears in Library after sign-in" flow must use **Cloud → Add to library** (or re-import local files).
 - Fewer large SQLite merges on sign-in; recording API traffic moves to **on-demand** per played title.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -79,7 +79,7 @@ Trade-offs, follow-up work, risks.
 | [0053](0053-vocabulary-secondary-route.md) | Vocabulary secondary route (Profile entry; not a primary shell tab) |
 | [0054](0054-vocabulary-cloud-sync.md) | Vocabulary cloud sync — SRS-preserving item conflict, LWW contexts, reviews never sync, auto-pull exception to ADR-0013 (extends ADR-0010) |
 | [0055](0055-adaptive-page-layout-system.md) | Adaptive page layout system (`EnjoyPage` / browse·hub·form widths) |
-| [0056](0056-uservideo-library-membership.md) | UserVideo library membership + content-addressed video uploads |
+| [0056](0056-uservideo-library-membership.md) | UserVideo library membership + content-addressed video uploads (partially supersedes 0013 for video upload ids) |
 | [0057](0057-permanent-player-surface-host.md) | Permanent RootShell player surface host (clip portal + launch pipeline) |
 | [0058](0058-enjoy-deepgram-long-form-asr.md) | Enjoy long-form ASR via Worker Deepgram jobs (≥900s upload/submit/poll) |
 | [0059](0059-phone-tablet-orientation-and-player-aspect-layout.md) | Phone portrait lock / tablet rotate; player stack vs side-by-side by window aspect |

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -26,7 +26,10 @@ When the user opens a media item in the player **while signed in**, the app pull
 
 ### Import IDs (web parity)
 
-Local file fingerprints use the same **partial SHA-256** strategy as the Enjoy web `hashBlob` helper in `apps/web/src/db/id-generator.ts` (first / middle / last 4 MiB). Signed-in imports use `aid` / `vid` = `SHA-256(contentHash + ":" + userId)` then UUID v5 (`audio:user:{aid}` / `video:user:{vid}`), matching `generateLocalAudioAid` / `generateLocalVideoVid` on web. Imports require a signed-in session (ADR-0031); there is no signed-out import or re-key path.
+Local file fingerprints use the same **partial SHA-256** strategy as the Enjoy web `hashBlob` helper in `apps/web/src/db/id-generator.ts` (first / middle / last 4 MiB). Imports require a signed-in session (ADR-0031); there is no signed-out import or re-key path.
+
+- **Audio** (user-scoped): `aid = SHA-256(contentHash + ":" + userId)`, `id = uuid_v5(audio:user:{aid})` — matching `generateLocalAudioAid` on web.
+- **Video** (content-addressed, [ADR-0056](../decisions/0056-uservideo-library-membership.md)): `vid = contentHash` (no `userId` salt), `id = uuid_v5(video:user:{vid})`. Legacy per-user video upload ids on the server are left as-is.
 
 ## Sync status (Settings)
 
@@ -54,7 +57,7 @@ When the server accepts an upload but **omits** the `updatedAt` field in its res
 
 ### Library membership (UserVideo)
 
-Mine video APIs mean **library membership**, not exclusive ownership of the catalog `Video` row. Many users can enroll the same YouTube/Netflix (or new content-addressed upload) id. `DELETE /mine/videos/:id` leaves the library (soft-deletes membership); pulls may include `deletedAt` tombstones — the player removes the local row.
+Mine video APIs mean **library membership**, not exclusive ownership of the catalog `Video` row ([ADR-0056](../decisions/0056-uservideo-library-membership.md)). Many users can enroll the same YouTube/Netflix (or new content-addressed upload) id. `DELETE /mine/videos/:id` leaves the library (soft-deletes membership); pulls may include `deletedAt` tombstones — the player removes the local row.
 
 New local uploads use **content-addressed** ids: `vid = contentHash` (no `userId`), `id = uuid_v5(video:user:{vid})`. Legacy per-user upload ids on the server are left as-is.
 
@@ -67,6 +70,7 @@ On rare unique races during `POST /mine/videos`, the client retries with `GET /m
 - [ADR-0010](../decisions/0010-cloud-sync-mvp.md) (historical bidirectional download scope)
 - [ADR-0013](../decisions/0013-local-first-sync.md) (local-first + lazy recordings)
 - [ADR-0054](../decisions/0054-vocabulary-cloud-sync.md) (vocabulary items/contexts, SRS-preserving conflict, auto-pull exception)
+- [ADR-0056](../decisions/0056-uservideo-library-membership.md) (UserVideo library membership + content-addressed video uploads)
 - [Cloud index](cloud.md)
 - [Vocabulary](vocabulary.md)
 - Web reference: `enjoy` monorepo `apps/web/src/db/services/sync-*.ts`, `apps/web/src/db/id-generator.ts`


### PR DESCRIPTION
## Summary

- Split the *Import IDs (web parity)* section in `docs/features/sync.md` into audio (user-scoped) and video (content-addressed per ADR-0056)
- Added ADR-0056 links to the Library membership section, Related list, ADR-0013 Decision #4 / Consequences, and the ADR index

Docs-only change; no code or tests affected. Closes #383.

## Test plan

- [x] Verify relative links resolve (`0056-uservideo-library-membership.md` exists)
- [ ] Review rendered markdown on GitHub