### PR TITLE
refactor(api): extract bearer auth acquisition into _ensureAuthenticated (fix #414)

### DIFF
--- a/lib/data/api/api_client.dart
+++ b/lib/data/api/api_client.dart
@@ -136,26 +136,7 @@ class ApiClient {
     final pathUri = Uri.parse(path);
     final merged = uriBase.resolveUri(pathUri);
 
-    String? bearer;
-    if (sendAuthHeader && requireAuth) {
-      final token = await getAccessToken();
-      if (token == null || token.isEmpty) {
-        if (refreshAccessToken != null) {
-          final ok = await refreshAccessToken!();
-          if (ok) {
-            final newToken = await getAccessToken();
-            if (newToken != null && newToken.isNotEmpty) {
-              bearer = newToken;
-            }
-          }
-        }
-      } else {
-        bearer = token;
-      }
-      if (bearer == null) {
-        throw const ApiException(message: 'Not authenticated', statusCode: 401);
-      }
-    }
+    final bearer = await _ensureAuthenticated(requireAuth);
 
     final request = http.Request('PUT', merged)..bodyBytes = bytes;
     request.headers['Accept'] = 'application/json';
@@ -260,26 +241,7 @@ class ApiClient {
     final pathUri = Uri.parse(path);
     final merged = uriBase.resolveUri(pathUri);
 
-    String? bearer;
-    if (sendAuthHeader && requireAuth) {
-      final token = await getAccessToken();
-      if (token == null || token.isEmpty) {
-        if (refreshAccessToken != null) {
-          final ok = await refreshAccessToken!();
-          if (ok) {
-            final newToken = await getAccessToken();
-            if (newToken != null && newToken.isNotEmpty) {
-              bearer = newToken;
-            }
-          }
-        }
-      } else {
-        bearer = token;
-      }
-      if (bearer == null) {
-        throw const ApiException(message: 'Not authenticated', statusCode: 401);
-      }
-    }
+    final bearer = await _ensureAuthenticated(requireAuth);
 
     final request = http.MultipartRequest('POST', merged);
     request.headers['Accept'] = 'application/json';
@@ -346,6 +308,31 @@ class ApiClient {
       return compute(decodeJsonToCamel, raw);
     }
     return decodeJsonToCamel(raw);
+  }
+
+  /// Returns a bearer token to attach to the outgoing request, or `null`
+  /// when auth is disabled / not required for this call.
+  ///
+  /// When the cached token is missing or empty, attempts a single
+  /// [refreshAccessToken] and re-reads the token. If no usable token is
+  /// available after that, throws [ApiException] with status 401 — matching
+  /// the auth posture callers relied on before the three call sites were
+  /// deduplicated.
+  Future<String?> _ensureAuthenticated(bool requireAuth) async {
+    if (!sendAuthHeader || !requireAuth) return null;
+
+    final token = await getAccessToken();
+    if (token != null && token.isNotEmpty) return token;
+
+    if (refreshAccessToken != null) {
+      final ok = await refreshAccessToken!();
+      if (ok) {
+        final newToken = await getAccessToken();
+        if (newToken != null && newToken.isNotEmpty) return newToken;
+      }
+    }
+
+    throw const ApiException(message: 'Not authenticated', statusCode: 401);
   }
 
   Future<Map<String, dynamic>> _sendMap({
@@ -490,24 +477,9 @@ class ApiClient {
       if (body != null) 'Content-Type': 'application/json; charset=UTF-8',
     };
 
-    if (sendAuthHeader && requireAuth) {
-      final token = await getAccessToken();
-      if (token == null || token.isEmpty) {
-        if (refreshAccessToken != null) {
-          final ok = await refreshAccessToken!();
-          if (ok) {
-            final newToken = await getAccessToken();
-            if (newToken != null && newToken.isNotEmpty) {
-              headers['Authorization'] = 'Bearer $newToken';
-            }
-          }
-        }
-      } else {
-        headers['Authorization'] = 'Bearer $token';
-      }
-      if (!headers.containsKey('Authorization')) {
-        throw const ApiException(message: 'Not authenticated', statusCode: 401);
-      }
+    final bearer = await _ensureAuthenticated(requireAuth);
+    if (bearer != null) {
+      headers['Authorization'] = 'Bearer $bearer';
     }
 
     final bodyBytes = body == null

--- a/test/data/api/api_client_auth_test.dart
+++ b/test/data/api/api_client_auth_test.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+
+import 'package:enjoy_player/data/api/api_client.dart';
+import 'package:enjoy_player/data/api/api_exception.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Tests the bearer-token acquisition logic deduplicated into
+/// [ApiClient] from `putBytesJson`, `postMultipartJson`, and `_dispatch`.
+///
+/// Exercises the helper through the public API so the three call sites stay
+/// locked together. The tests cover every branch:
+///   - cached token present → attached as `Authorization: Bearer <tok>`
+///   - cached token empty + refresh succeeds → new token attached
+///   - cached token empty + refresh fails (or missing) → 401 `ApiException`
+///   - `requireAuth: false` → no auth headers (regardless of cached token)
+///   - `sendAuthHeader: false` → no auth headers (regardless of `requireAuth`)
+void main() {
+  group('ApiClient bearer auth', () {
+    test('attaches the cached access token when present', () async {
+      http.Request? captured;
+      final mock = MockClient((request) async {
+        captured = request;
+        return http.Response(jsonEncode({'ok': true}), 200);
+      });
+
+      final client = ApiClient(
+        httpClient: mock,
+        getBaseUrl: () async => 'https://api.example.com',
+        getAccessToken: () async => 'cached-token',
+      );
+
+      await client.getJson('/me');
+
+      expect(captured, isNotNull);
+      expect(captured!.headers['Authorization'], 'Bearer cached-token');
+    });
+
+    test(
+      'refreshes when the cached token is empty and refresh succeeds',
+      () async {
+        http.Request? captured;
+        final mock = MockClient((request) async {
+          captured = request;
+          return http.Response(jsonEncode({'ok': true}), 200);
+        });
+
+        var refreshCalls = 0;
+        final client = ApiClient(
+          httpClient: mock,
+          getBaseUrl: () async => 'https://api.example.com',
+          getAccessToken: () async {
+            // First read returns the cached (empty) token; the second read
+            // (after refresh) returns the newly minted token.
+            if (refreshCalls == 0) return '';
+            return 'fresh-token';
+          },
+          refreshAccessToken: () async {
+            refreshCalls++;
+            return true;
+          },
+        );
+
+        await client.getJson('/me');
+
+        expect(refreshCalls, 1);
+        expect(captured, isNotNull);
+        expect(captured!.headers['Authorization'], 'Bearer fresh-token');
+      },
+    );
+
+    test(
+      'throws 401 when the cached token is empty and refresh fails',
+      () async {
+        final mock = MockClient((_) async {
+          fail('request should not be sent when auth cannot be established');
+        });
+
+        final client = ApiClient(
+          httpClient: mock,
+          getBaseUrl: () async => 'https://api.example.com',
+          getAccessToken: () async => '',
+          refreshAccessToken: () async => false,
+        );
+
+        expect(
+          () => client.getJson('/me'),
+          throwsA(
+            isA<ApiException>()
+                .having((e) => e.statusCode, 'statusCode', 401)
+                .having((e) => e.message, 'message', 'Not authenticated'),
+          ),
+        );
+      },
+    );
+
+    test('throws 401 when no cached token and no refresh callback', () async {
+      final mock = MockClient((_) async {
+        fail('request should not be sent when auth cannot be established');
+      });
+
+      final client = ApiClient(
+        httpClient: mock,
+        getBaseUrl: () async => 'https://api.example.com',
+        getAccessToken: () async => null,
+      );
+
+      expect(
+        () => client.getJson('/me'),
+        throwsA(
+          isA<ApiException>().having((e) => e.statusCode, 'statusCode', 401),
+        ),
+      );
+    });
+
+    test('skips auth when requireAuth is false', () async {
+      http.Request? captured;
+      final mock = MockClient((request) async {
+        captured = request;
+        return http.Response(jsonEncode({'ok': true}), 200);
+      });
+
+      final client = ApiClient(
+        httpClient: mock,
+        getBaseUrl: () async => 'https://api.example.com',
+        getAccessToken: () async => 'should-not-be-sent',
+      );
+
+      await client.getJson('/me', requireAuth: false);
+
+      expect(captured, isNotNull);
+      expect(captured!.headers.containsKey('Authorization'), isFalse);
+    });
+
+    test('skips auth when sendAuthHeader is false', () async {
+      http.Request? captured;
+      final mock = MockClient((request) async {
+        captured = request;
+        return http.Response(jsonEncode({'ok': true}), 200);
+      });
+
+      final client = ApiClient(
+        httpClient: mock,
+        getBaseUrl: () async => 'https://api.example.com',
+        getAccessToken: () async => 'should-not-be-sent',
+        sendAuthHeader: false,
+      );
+
+      await client.getJson('/me');
+
+      expect(captured, isNotNull);
+      expect(captured!.headers.containsKey('Authorization'), isFalse);
+    });
+
+    test(
+      'putBytesJson shares the same auth flow as the JSON dispatch path',
+      () async {
+        http.Request? captured;
+        final mock = MockClient((request) async {
+          captured = request;
+          return http.Response.bytes(
+            utf8.encode('{"ok":true}'),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = ApiClient(
+          httpClient: mock,
+          getBaseUrl: () async => 'https://api.example.com',
+          getAccessToken: () async => 'token',
+        );
+
+        await client.putBytesJson(
+          '/audio/media/abc',
+          bytes: [1, 2, 3],
+          contentType: 'application/octet-stream',
+        );
+
+        expect(captured, isNotNull);
+        expect(captured!.headers['Authorization'], 'Bearer token');
+      },
+    );
+
+    test(
+      'postMultipartJson shares the same auth flow as the JSON dispatch path',
+      () async {
+        http.Request? captured;
+        final mock = MockClient((request) async {
+          captured = request;
+          return http.Response.bytes(
+            utf8.encode('{"ok":true}'),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = ApiClient(
+          httpClient: mock,
+          getBaseUrl: () async => 'https://api.example.com',
+          getAccessToken: () async => 'token',
+        );
+
+        await client.postMultipartJson(
+          '/whisper',
+          fileFieldName: 'audio',
+          fileBytes: [1, 2, 3],
+        );
+
+        expect(captured, isNotNull);
+        expect(captured!.headers['Authorization'], 'Bearer token');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Consolidates three near-identical 19-line bearer-token acquisition and refresh blocks (in `putBytesJson`, `postMultipartJson`, and `_dispatch`) into a single `_ensureAuthenticated` helper. The three call sites were already diverging slightly — one used a local `bearer` string, two wrote `headers['Authorization']` directly — which is exactly the shape of copy-paste drift the detector flagged.

Behavior is unchanged:

- Returns the bearer string when auth is enabled and a token is available (after at most one refresh attempt).
- Returns `null` when auth is disabled or not required for the call.
- Throws a `401 ApiException` when no usable token can be obtained.

## Refactor

| Site | Before | After |
|---|---|---|
| `putBytesJson` | 19 lines inline | `final bearer = await _ensureAuthenticated(requireAuth);` |
| `postMultipartJson` | 19 lines inline | `final bearer = await _ensureAuthenticated(requireAuth);` |
| `_dispatch` | 19 lines inline | `final bearer = await _ensureAuthenticated(requireAuth);` |

Net: 58 lines removed, 30 lines added (including the helper + docstring). 28-line reduction.

## Tests

Adds `test/data/api/api_client_auth_test.dart` with 8 cases that exercise every branch through the public API:

- cached token attached as `Authorization: Bearer <tok>`
- empty cached token + refresh success → new token attached
- empty cached token + refresh failure → 401
- no refresh callback + empty token → 401
- `requireAuth: false` → no `Authorization` header
- `sendAuthHeader: false` → no `Authorization` header
- `putBytesJson` shares the same flow
- `postMultipartJson` shares the same flow

Full suite green: `flutter analyze` clean, `flutter test` 1685 passed / 3 skipped, `dart format` clean.

Fixes #414

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor / chore (no user-visible change)
- [ ] Documentation / ADR

## Platform tested

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [ ] Linux

## Checklist

- [x] `bash .github/scripts/validate_ci_gates.sh` passes (Dart format + codegen drift)
- [x] `flutter analyze` is clean
- [x] `flutter test` passes for affected areas
- [ ] If Drift / Riverpod / Freezed annotations changed: regenerated `*.g.dart` / `*.freezed.dart` are committed
- [x] No new `print()` calls (use `logNamed` from `lib/core/logging/log.dart`)
- [x] No new `kIsWeb` branches (AGENTS.md hard rule)
- [x] No new SQL outside Drift DAOs (AGENTS.md hard rule)
- [x] No new `Player()` instances outside `PlayerController` (AGENTS.md hard rule)
- [ ] If behavior changed: `docs/features/<feature>.md` updated
- [ ] If architectural: new ADR in `docs/decisions/`
- [x] New public API symbols have doc comments (if applicable) — `_ensureAuthenticated` is private with a docstring