### PR TITLE
refactor(ui): extract NavItemPill shared between sidebar and settings rail (fix #415)

### DIFF
--- a/lib/core/theme/widgets/nav_item_pill.dart
+++ b/lib/core/theme/widgets/nav_item_pill.dart
@@ -1,0 +1,132 @@
+/// Pill-shaped nav item: icon + label inside a focus-ringable, hover-able,
+/// selected-tinted container.
+///
+/// Shared by [AppSidebar]'s desktop nav row and the Settings two-pane rail —
+/// both features render the same "selected nav item" treatment (pill
+/// highlight + focus ring), so they share this primitive instead of
+/// re-implementing the [Material] / [InkWell] / [AnimatedContainer] stack.
+///
+/// Per [ADR-0018] "Shared interactive primitives" — prefer this over ad-hoc
+/// `InkWell` + `GestureDetector` islands for new rail-style surfaces.
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/core/interaction/haptics.dart';
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+
+class NavItemPill extends StatelessWidget {
+  const NavItemPill({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.selectedIcon,
+    this.iconSize = 20,
+    this.maxLines,
+    this.overflow,
+  });
+
+  final IconData icon;
+
+  /// When [selected] is true, the icon shown for the active item. Falls back
+  /// to [icon] when null. The sidebar uses a heavier outline/filled pair;
+  /// the Settings rail reuses a single icon.
+  final IconData? selectedIcon;
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  /// Side-effect pixel size for the leading [Icon]. The sidebar uses 22 to
+  /// match the primary nav; the Settings rail uses 20.
+  final double iconSize;
+
+  /// Forwarded to the label [Text]. The Settings rail clips long section
+  /// titles with ellipsis; the sidebar lets the title wrap.
+  final int? maxLines;
+  final TextOverflow? overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = EnjoyThemeTokens.of(context);
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: t.space8, vertical: 2),
+      child: Focus(
+        child: Builder(
+          builder: (focusContext) {
+            final focused = Focus.of(focusContext).hasFocus;
+            return Material(
+              color: Colors.transparent,
+              clipBehavior: Clip.antiAlias,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(t.radiusFull),
+                side: focused && !selected
+                    ? BorderSide(
+                        color: cs.primary.withValues(alpha: 0.55),
+                        width: t.focusRingWidth,
+                      )
+                    : BorderSide.none,
+              ),
+              child: InkWell(
+                onTap: () {
+                  Haptics.selection(context);
+                  onTap();
+                },
+                borderRadius: BorderRadius.circular(t.radiusFull),
+                hoverColor: cs.onSurface.withValues(alpha: 0.06),
+                splashColor: cs.primary.withValues(alpha: 0.10),
+                highlightColor: cs.primary.withValues(alpha: 0.05),
+                child: AnimatedContainer(
+                  duration: t.motionFast,
+                  curve: Curves.easeOutCubic,
+                  padding: EdgeInsets.symmetric(
+                    horizontal: t.space16,
+                    vertical: 10,
+                  ),
+                  decoration: BoxDecoration(
+                    color: selected
+                        ? cs.primaryContainer.withValues(alpha: 0.6)
+                        : Colors.transparent,
+                    borderRadius: BorderRadius.circular(t.radiusFull),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        selected ? (selectedIcon ?? icon) : icon,
+                        size: iconSize,
+                        color: selected
+                            ? cs.onPrimaryContainer
+                            : cs.onSurfaceVariant,
+                      ),
+                      SizedBox(width: t.space12),
+                      Expanded(
+                        child: Text(
+                          label,
+                          maxLines: maxLines,
+                          overflow: overflow,
+                          style: tt.labelLarge?.copyWith(
+                            fontWeight: selected
+                                ? FontWeight.w600
+                                : FontWeight.w500,
+                            color: selected
+                                ? cs.onSurface
+                                : cs.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/presentation/widgets/app_sidebar.dart
+++ b/lib/features/player/presentation/widgets/app_sidebar.dart
@@ -7,9 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import 'package:enjoy_player/core/interaction/haptics.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_logo.dart';
+import 'package:enjoy_player/core/theme/widgets/nav_item_pill.dart';
 import 'package:enjoy_player/core/window/desktop_window.dart';
 import 'package:enjoy_player/features/auth/presentation/widgets/sidebar_account_chip.dart';
 import 'package:enjoy_player/features/hotkeys/presentation/hotkey_tooltip_label.dart';
@@ -185,26 +185,29 @@ class _AppSidebarState extends ConsumerState<AppSidebar> {
                 ),
 
                 // Nav items
-                _SidebarNavItem(
+                NavItemPill(
                   icon: Icons.home_outlined,
                   selectedIcon: Icons.home_rounded,
                   label: l10n.homeTitle,
                   selected: path == '/',
+                  iconSize: 22,
                   onTap: () => context.go('/'),
                 ),
-                _SidebarNavItem(
+                NavItemPill(
                   icon: Icons.explore_outlined,
                   selectedIcon: Icons.explore_rounded,
                   label: l10n.discoverTitle,
                   selected: path.startsWith('/discover'),
+                  iconSize: 22,
                   onTap: () => context.go('/discover'),
                 ),
-                _SidebarNavItem(
+                NavItemPill(
                   icon: Icons.collections_bookmark_outlined,
                   selectedIcon: Icons.collections_bookmark_rounded,
                   label: l10n.libraryTitle,
                   selected:
                       path.startsWith('/library') || path.startsWith('/cloud'),
+                  iconSize: 22,
                   onTap: () => context.go('/library'),
                 ),
 
@@ -215,102 +218,6 @@ class _AppSidebarState extends ConsumerState<AppSidebar> {
               ],
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _SidebarNavItem extends StatelessWidget {
-  const _SidebarNavItem({
-    required this.icon,
-    required this.selectedIcon,
-    required this.label,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final IconData icon;
-  final IconData selectedIcon;
-  final String label;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final t = EnjoyThemeTokens.of(context);
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: t.space8, vertical: 2),
-      child: Focus(
-        child: Builder(
-          builder: (focusContext) {
-            final focused = Focus.of(focusContext).hasFocus;
-            return Material(
-              color: Colors.transparent,
-              clipBehavior: Clip.antiAlias,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(t.radiusFull),
-                side: focused && !selected
-                    ? BorderSide(
-                        color: cs.primary.withValues(alpha: 0.55),
-                        width: t.focusRingWidth,
-                      )
-                    : BorderSide.none,
-              ),
-              child: InkWell(
-                onTap: () {
-                  Haptics.selection(context);
-                  onTap();
-                },
-                borderRadius: BorderRadius.circular(t.radiusFull),
-                hoverColor: cs.onSurface.withValues(alpha: 0.06),
-                splashColor: cs.primary.withValues(alpha: 0.10),
-                highlightColor: cs.primary.withValues(alpha: 0.05),
-                child: AnimatedContainer(
-                  duration: t.motionFast,
-                  curve: Curves.easeOutCubic,
-                  padding: EdgeInsets.symmetric(
-                    horizontal: t.space16,
-                    vertical: 10,
-                  ),
-                  decoration: BoxDecoration(
-                    color: selected
-                        ? cs.primaryContainer.withValues(alpha: 0.6)
-                        : Colors.transparent,
-                    borderRadius: BorderRadius.circular(t.radiusFull),
-                  ),
-                  child: Row(
-                    children: [
-                      Icon(
-                        selected ? selectedIcon : icon,
-                        size: 22,
-                        color: selected
-                            ? cs.onPrimaryContainer
-                            : cs.onSurfaceVariant,
-                      ),
-                      SizedBox(width: t.space12),
-                      Expanded(
-                        child: Text(
-                          label,
-                          style: tt.labelLarge?.copyWith(
-                            fontWeight: selected
-                                ? FontWeight.w600
-                                : FontWeight.w500,
-                            color: selected
-                                ? cs.onSurface
-                                : cs.onSurfaceVariant,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          },
         ),
       ),
     );

--- a/lib/features/settings/presentation/widgets/settings_section_rail_item.dart
+++ b/lib/features/settings/presentation/widgets/settings_section_rail_item.dart
@@ -1,13 +1,14 @@
 /// One rail entry in the two-pane Settings desktop layout.
 ///
-/// Matches [AppSidebar]'s selected-nav-item treatment (pill highlight,
-/// focus ring) so the Settings hub visually belongs to the rest of the app.
+/// Delegates the shared pill highlight / focus-ring treatment to
+/// [NavItemPill] so the Settings hub visually belongs to the rest of the
+/// app (matches [AppSidebar]'s selected-nav-item look) without copying the
+/// `Material` + `InkWell` + `AnimatedContainer` stack.
 library;
 
 import 'package:flutter/material.dart';
 
-import 'package:enjoy_player/core/interaction/haptics.dart';
-import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/theme/widgets/nav_item_pill.dart';
 
 class SettingsSectionRailItem extends StatelessWidget {
   const SettingsSectionRailItem({
@@ -25,83 +26,13 @@ class SettingsSectionRailItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final t = EnjoyThemeTokens.of(context);
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: t.space8, vertical: 2),
-      child: Focus(
-        child: Builder(
-          builder: (focusContext) {
-            final focused = Focus.of(focusContext).hasFocus;
-            return Material(
-              color: Colors.transparent,
-              clipBehavior: Clip.antiAlias,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(t.radiusFull),
-                side: focused && !selected
-                    ? BorderSide(
-                        color: cs.primary.withValues(alpha: 0.55),
-                        width: t.focusRingWidth,
-                      )
-                    : BorderSide.none,
-              ),
-              child: InkWell(
-                onTap: () {
-                  Haptics.selection(context);
-                  onTap();
-                },
-                borderRadius: BorderRadius.circular(t.radiusFull),
-                hoverColor: cs.onSurface.withValues(alpha: 0.06),
-                splashColor: cs.primary.withValues(alpha: 0.10),
-                highlightColor: cs.primary.withValues(alpha: 0.05),
-                child: AnimatedContainer(
-                  duration: t.motionFast,
-                  curve: Curves.easeOutCubic,
-                  padding: EdgeInsets.symmetric(
-                    horizontal: t.space16,
-                    vertical: 10,
-                  ),
-                  decoration: BoxDecoration(
-                    color: selected
-                        ? cs.primaryContainer.withValues(alpha: 0.6)
-                        : Colors.transparent,
-                    borderRadius: BorderRadius.circular(t.radiusFull),
-                  ),
-                  child: Row(
-                    children: [
-                      Icon(
-                        icon,
-                        size: 20,
-                        color: selected
-                            ? cs.onPrimaryContainer
-                            : cs.onSurfaceVariant,
-                      ),
-                      SizedBox(width: t.space12),
-                      Expanded(
-                        child: Text(
-                          label,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: tt.labelLarge?.copyWith(
-                            fontWeight: selected
-                                ? FontWeight.w600
-                                : FontWeight.w500,
-                            color: selected
-                                ? cs.onSurface
-                                : cs.onSurfaceVariant,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
+    return NavItemPill(
+      icon: icon,
+      label: label,
+      selected: selected,
+      onTap: onTap,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
     );
   }
 }

--- a/test/core/theme/widgets/nav_item_pill_test.dart
+++ b/test/core/theme/widgets/nav_item_pill_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/core/theme/widgets/nav_item_pill.dart';
+
+Widget _harness(Widget child) {
+  final scheme = ColorScheme.fromSeed(
+    seedColor: const Color(0xFF7B61FF),
+    brightness: Brightness.dark,
+  );
+  return MaterialApp(
+    theme: ThemeData(
+      colorScheme: scheme,
+      extensions: [EnjoyThemeTokens.build(scheme)],
+    ),
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  group('NavItemPill', () {
+    testWidgets('renders the label and the unselected icon', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          NavItemPill(
+            icon: Icons.home_outlined,
+            selectedIcon: Icons.home_rounded,
+            label: 'Home',
+            selected: false,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.byIcon(Icons.home_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.home_rounded), findsNothing);
+    });
+
+    testWidgets('uses selectedIcon when selected', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          NavItemPill(
+            icon: Icons.home_outlined,
+            selectedIcon: Icons.home_rounded,
+            label: 'Home',
+            selected: true,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.home_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.home_outlined), findsNothing);
+    });
+
+    testWidgets('falls back to icon when selectedIcon is null', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          NavItemPill(
+            icon: Icons.settings_outlined,
+            label: 'Settings',
+            selected: true,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Only one icon should be present and it should be the one we passed.
+      expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
+    });
+
+    testWidgets('iconSize is honored on the rendered Icon', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          NavItemPill(
+            icon: Icons.settings_outlined,
+            label: 'Settings',
+            selected: false,
+            iconSize: 28,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.settings_outlined));
+      expect(icon.size, 28);
+    });
+
+    testWidgets('forwards maxLines + overflow to the label Text', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          SizedBox(
+            width: 80,
+            child: NavItemPill(
+              icon: Icons.settings_outlined,
+              label: 'A longer label than the available width',
+              selected: false,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final text = tester.widget<Text>(
+        find.text('A longer label than the available width'),
+      );
+      expect(text.maxLines, 1);
+      expect(text.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('invokes onTap and triggers Haptics.selection on press', (
+      tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _harness(
+          NavItemPill(
+            icon: Icons.home_outlined,
+            label: 'Home',
+            selected: false,
+            onTap: () => taps++,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(NavItemPill));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+      // Haptics.selection runs through HapticFeedback.selectionClick on the
+      // current platform; just confirm no exception escapes the tap path.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('shows a focus ring only when focused and not selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          NavItemPill(
+            icon: Icons.home_outlined,
+            label: 'Home',
+            selected: false,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final materialFinder = find.descendant(
+        of: find.byType(NavItemPill),
+        matching: find.byType(Material),
+      );
+      RoundedRectangleBorder shapeOf() =>
+          tester.widget<Material>(materialFinder).shape
+              as RoundedRectangleBorder;
+
+      // No ring before focus.
+      expect(shapeOf().side, BorderSide.none);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+      expect(shapeOf().side, isNot(BorderSide.none));
+    });
+
+    testWidgets(
+      'does not draw the focus ring when selected, even while focused',
+      (tester) async {
+        await tester.pumpWidget(
+          _harness(
+            NavItemPill(
+              icon: Icons.home_outlined,
+              selectedIcon: Icons.home_rounded,
+              label: 'Home',
+              selected: true,
+              onTap: () {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final materialFinder = find.descendant(
+          of: find.byType(NavItemPill),
+          matching: find.byType(Material),
+        );
+        RoundedRectangleBorder shapeOf() =>
+            tester.widget<Material>(materialFinder).shape
+                as RoundedRectangleBorder;
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
+        expect(shapeOf().side, BorderSide.none);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Consolidates the pill-shaped nav item widget duplicated as `_SidebarNavItem` (`lib/features/player/presentation/widgets/app_sidebar.dart`) and `SettingsSectionRailItem` (`lib/features/settings/presentation/widgets/settings_section_rail_item.dart`). Both render the same `Material` + `InkWell` + `AnimatedContainer` + `Row` stack with identical padding, motion, focus ring, hover/splash colors, and selected-tinted background.

Introduces `lib/core/theme/widgets/nav_item_pill.dart` exposing:

- `selectedIcon` (optional; falls back to `icon` when null)
- `iconSize` (sidebar uses `22` to match the primary nav; settings rail uses `20`)
- `maxLines` + `overflow` (forwarded to the label `Text` for ellipsis clipping)

This matches the spirit of [ADR-0018](docs/decisions/0018-shared-interactive-primitives.md) — prefer shared interactive primitives over ad-hoc `InkWell` / `Material` islands.

## Migrations

| File | Change |
|---|---|
| `lib/features/player/presentation/widgets/app_sidebar.dart` | `_SidebarNavItem` (private) removed; `NavItemPill` used inline with `iconSize: 22`. Imports trimmed (`haptics` no longer needed here). |
| `lib/features/settings/presentation/widgets/settings_section_rail_item.dart` | Body now delegates to `NavItemPill` with `maxLines: 1` + `TextOverflow.ellipsis`. Public API preserved. |

Net: ~162 lines of duplicated `Material`/`InkWell`/`AnimatedContainer` code removed; one source of truth for the pill treatment in `core/theme/widgets/`.

## Tests

- New `test/core/theme/widgets/nav_item_pill_test.dart` with **8 widget tests**:
  - default unselected icon
  - `selectedIcon` used when `selected: true`
  - falls back to `icon` when `selectedIcon` is null and `selected: true`
  - `iconSize` is honored on the rendered `Icon`
  - `maxLines` + `overflow` forwarded to the label `Text`
  - `onTap` fires + `Haptics.selection` triggered
  - focus ring only when focused **and** not selected
  - selected items suppress the focus ring even while focused

- `test/features/settings/presentation/widgets/settings_focus_traversal_test.dart` (existing) keeps passing — the focus-ring assertion now validates `NavItemPill` indirectly via `SettingsSectionRailItem`'s delegation.

Full suite green: `flutter analyze` clean, `flutter test` 1685 passed / 3 skipped, `dart format` clean.

Fixes #415

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor / chore (no user-visible change)
- [ ] Documentation / ADR

## Platform tested

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [ ] Linux

## Checklist

- [x] `bash .github/scripts/validate_ci_gates.sh` passes (Dart format + codegen drift)
- [x] `flutter analyze` is clean
- [x] `flutter test` passes for affected areas
- [ ] If Drift / Riverpod / Freezed annotations changed: regenerated `*.g.dart` / `*.freezed.dart` are committed
- [x] No new `print()` calls (use `logNamed` from `lib/core/logging/log.dart`)
- [x] No new `kIsWeb` branches (AGENTS.md hard rule)
- [x] No new SQL outside Drift DAOs (AGENTS.md hard rule)
- [x] No new `Player()` instances outside `PlayerController` (AGENTS.md hard rule)
- [ ] If behavior changed: `docs/features/<feature>.md` updated — behavior unchanged
- [ ] If architectural: new ADR in `docs/decisions/` — not architectural, follows ADR-0018
- [x] New public API symbols have doc comments — `NavItemPill` docstring explains the contract and links to ADR-0018