### PR TITLE
docs: fix ai.md dictionary-lookup link and index linux-platform

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ Maintainers and agents should keep these files **accurate** when behavior or arc
 | [features/asr.md](features/asr.md) | Product + dev | Local-file ASR generation pipeline, audio extraction (FFmpegKit / isolate), failure reasons, or `source: ai` upsert behavior changes |
 | [features/echo-mode.md](features/echo-mode.md) | Product + dev | Echo region, shadow-reading, pronunciation assessment, or share practice poster behavior changes |
 | [features/local-database-recovery.md](features/local-database-recovery.md) | Product + dev | Stale/malformed local-DB detection, the recovery surface, or the reset-local-library flow changes |
+| [features/linux-platform.md](features/linux-platform.md) | Product + dev | Linux support matrix, AppImage packaging/release, or per-platform feature availability changes |
 | [features/craft.md](features/craft.md) | Product + dev | Craft from Text import, translate/synthesize modes, voice picker, or failure handling changes |
 
 ## How to add an ADR

--- a/docs/features/ai.md
+++ b/docs/features/ai.md
@@ -108,7 +108,7 @@ Missing BYOK credentials are surfaced **before** the capability runs, by the `By
 
 ## Consumers
 
-Feature screens should depend on `*ServiceProvider` types in `application/`, not on `ApiClient` directly, so modality and provider selection stay in one place. Transcript dictionary lookup uses the same services — see [dictionary-lookup](features/dictionary-lookup.md).
+Feature screens should depend on `*ServiceProvider` types in `application/`, not on `ApiClient` directly, so modality and provider selection stay in one place. Transcript dictionary lookup uses the same services — see [dictionary-lookup](dictionary-lookup.md).
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Resolves #407 and #409 (the two issues overlap: both ask for the missing `linux-platform.md` index entry; #409 additionally fixes a broken link). Changes were re-implemented and verified against the current tree rather than applying the bot patches from the failed workflow runs.

- **`docs/features/ai.md`**: the Consumers section linked `[dictionary-lookup](features/dictionary-lookup.md)`. Since `ai.md` already lives in `docs/features/`, that resolved to `docs/features/features/dictionary-lookup.md` (broken). Now links `dictionary-lookup.md`.
- **`docs/README.md`**: added the missing `features/linux-platform.md` row to the feature index table (the file has existed since the v0.5.0 Linux work but was never indexed).

## Verification

- [x] `docs/features/dictionary-lookup.md` exists relative to `ai.md` — link now resolves
- [x] `docs/features/linux-platform.md` exists and is now listed in the index
- [x] Docs-only change — no Dart files touched, CI code gates unaffected

## Test plan

- [ ] Confirm the rendered `ai.md` link navigates to the dictionary-lookup doc
- [ ] Confirm the docs index renders the new row