### PR TITLE
docs: document superpowers pattern and update architecture for ADR-0057/0059

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Maintainers and agents should keep these files **accurate** when behavior or arc
 | [ci-self-hosted-runners.md](ci-self-hosted-runners.md) | Release / CI | Self-hosted runner setup for all workflows |
 | [testing.md](testing.md) | Contributors | Test strategy or CI commands change |
 | [decisions/](decisions/) | Architects | Irreversible technical choices |
+| [superpowers/](superpowers/) | Contributors + agents | Large mechanical refactor specs & implementation plans |
 | [features/](features/) | Product + dev | Feature behavior changes |
 | [features/app-ui.md](features/app-ui.md) | Product + dev | Shell, navigation chrome, or design tokens change |
 | [features/skeleton-loading.md](features/skeleton-loading.md) | Product + dev | Skeleton widget API, prebuilt placeholders, or sliver-safe placement rules change |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,16 @@ The sync / audit columns (`syncStatus`, `serverUpdatedAt`, `createdAt`, `updated
 
 [`GoRouter`](../lib/core/routing/app_router.dart) + [`ShellRoute`](../lib/features/player/presentation/root_shell.dart): routes render beside an extended sidebar at wide breakpoints; [`GlobalTransportBar`](../lib/features/player/presentation/widgets/global_transport_bar.dart) spans the bottom when a playback session exists. An **`errorBuilder`** at the router root renders [`NotFoundScreen`](../lib/core/routing/not_found_screen.dart) (localized en / zh / zh-CN) for unknown locations; the screen surfaces the attempted URI and offers a single primary action to return to `/`.
 
+### Player surface host (ADR-0057)
+
+[`RootShell`](../lib/features/player/presentation/root_shell.dart) mounts one permanent [`PlayerSurfaceHost`](../lib/features/player/presentation/widgets/player_surface_host.dart) — the sole owner of `buildVideoStage()` for the active engine, keyed by engine identity so an engine swap disposes the old surface before mounting the new one. Viewports (vocabulary review clip, expanded player, loading stage) register [`PlayerSurfaceTarget`](../lib/features/player/presentation/widgets/player_surface_target.dart) geometry via [`playerSurfaceRegistryProvider`](../lib/features/player/application/player_surface_registry.dart); the host moves one permanent `Positioned` stage to the global target bounds and parks it off-corner when no target is attached (no follower transforms, which keeps WebView2 bounds correct under Windows display scaling). Open-in-player is a single `context.replace` with a typed [`PlayerLaunchRequest`](../lib/features/player/domain/player_launch_request.dart). Feature code must not build `media_kit` `Video` / `InAppWebView` surfaces outside the host — see [ADR-0057](decisions/0057-permanent-player-surface-host.md).
+
+## Form factor & orientation (ADR-0059)
+
+Android/iOS devices are classified by logical shortest side — **≥ 600 → tablet, else phone** ([`kTabletShortestSideLogical`](../lib/core/platform/device_form_factor.dart)). Phones prefer portrait only (`SystemChrome` on Android, `Info.plist` on iPhone); tablets allow all orientations; desktop never calls `setPreferredOrientations`.
+
+Player **content** layout (stacked vs side-by-side video + transcript) is driven by the player layout constraints' aspect — `width > height` → side-by-side — via [`player_content_layout.dart`](../lib/core/platform/player_content_layout.dart), not by the 720-width breakpoint. The 720 breakpoint (`breakpointTranscriptSideBySide`) is retained for width-driven chrome such as transport-bar packing. Net effect: portrait tablets stack video over transcript even when wider than 720, and narrow landscape windows can lay out side-by-side below 720 — see [ADR-0059](decisions/0059-phone-tablet-orientation-and-player-aspect-layout.md).
+
 ## Manual providers
 
 [`libraryMediaProvider`](../lib/features/library/application/library_media_provider.dart) is a hand-written `StreamProvider` because `riverpod_generator` + Drift row types hit an `InvalidTypeException` in codegen — keep this pattern documented if more stream providers need the same workaround.

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,77 @@
+# Superpowers: refactor specs & implementation plans
+
+`docs/superpowers/` holds **design specs** and **implementation plans** for
+large, mechanically-verifiable refactors — the working documents produced
+*before* the code moves, so humans and agents can agree on scope, constraints,
+and file layout up front.
+
+## Layout
+
+```
+docs/superpowers/
+├── specs/   # design documents: what & why, constraints, audit, approach
+│   └── YYYY-MM-DD-<slug>-design.md
+└── plans/   # step-by-step implementation plans: how, in what order
+    └── YYYY-MM-DD-<slug>.md
+```
+
+Existing entry: the subtitle-track-picker split
+([spec](specs/2026-07-07-subtitle-track-picker-split-design.md),
+[plan](plans/2026-07-07-subtitle-track-picker-split.md), resolved issue #206).
+
+## When to create an entry
+
+Create a spec + plan pair when a refactor is:
+
+- **Large** — touches a 1000+ LOC file or spans several files, and
+- **Mechanical** — pure code motion / rename / regrouping with no intended
+  behavior or API change, and
+- **Risky to review as a raw diff** — a written audit and file map make the
+  "nothing changed but locations" claim checkable.
+
+Small fixes, behavior changes, and new features do **not** belong here: they
+follow the normal flow (feature spec in [`docs/features/`](../features/),
+irreversible choices as [ADRs](../decisions/README.md)).
+
+## Spec format (`specs/YYYY-MM-DD-<slug>-design.md`)
+
+Required sections, in order:
+
+1. **Header** — date, linked issue, branch name, refactor type (e.g. "Pure
+   mechanical refactor (no behavior or API change)").
+2. **Goal** — one paragraph: what is split/moved and what "done" means.
+3. **Constraints (non-negotiable)** — public API surface that must not change,
+   external callers that require zero edits, the codebase idiom to follow
+   (check [`docs/conventions.md`](../conventions.md) § Imports and existing
+   precedents before choosing between separate libraries and `part` files).
+4. **Audit findings** — what the originating (often automated) issue got
+   wrong: mis-grouped symbols, inverted dependency direction, stale line
+   counts. This section is mandatory because automated structural analyses
+   drift from the real tree.
+5. **Approach** — dependency-layer diagram plus a file table
+   (`File | Contents | ~LOC`) for the target layout.
+
+## Plan format (`plans/YYYY-MM-DD-<slug>.md`)
+
+1. **Agentic execution header** — names the sub-skill / execution mode an
+   agent must use, and states that steps use checkbox (`- [ ]`) syntax.
+2. **Goal / Architecture / Tech Stack** — one line each, linking back to the
+   spec.
+3. **File Structure** — responsibility table for every touched file, plus the
+   **rename map** when underscore-private symbols must cross file boundaries
+   (Dart `_` is library-scoped: a symbol shared across separate libraries must
+   be renamed to a plain feature-internal name).
+4. **Tasks** — numbered, checkboxed, one per file/step, each independently
+   green (`flutter analyze` + `flutter test`), ordered so every intermediate
+   commit compiles.
+5. **New tests** — any smoke test added to lock the refactor (e.g. a widget
+   test proving the split sheet still renders).
+
+## Relationship to other docs
+
+| Doc | Role vs superpowers |
+|-----|---------------------|
+| [`docs/decisions/`](../decisions/README.md) | ADRs record **irreversible choices**; a superpowers spec assumes them (e.g. "no `part of` outside generated code" was a constraint in the picker split — note `app_database.dart` DAOs are the exception to that rule). |
+| [`docs/features/`](../features/) | Feature behavior docs; a mechanical refactor must not require feature-doc edits. |
+| [`docs/conventions.md`](../conventions.md) | Style / import rules the plan must obey. |
+| [`AGENTS.md`](../../AGENTS.md) | Hard gates (green tree, codegen, no `print()`) apply to every plan task. |


### PR DESCRIPTION
## Summary

Resolves #417. Three documentation gaps, each verified against the actual tree rather than applying the bot patch:

1. **`docs/superpowers/README.md`** (new) — documents the refactor spec/plan pattern from the existing entry (`2026-07-07-subtitle-track-picker-split`): directory layout, `YYYY-MM-DD-<slug>` naming, required spec sections (Goal / Constraints / Audit findings / Approach) and plan sections (agentic header, File Structure, rename map, checkbox tasks), when to create an entry, and the relationship to ADRs / feature docs / conventions.
2. **`docs/architecture.md`** — two additions, every linked symbol verified to exist:
   - Routing § **Player surface host (ADR-0057)**: permanent `PlayerSurfaceHost` in `RootShell`, engine-identity keying, `PlayerSurfaceTarget` geometry via `playerSurfaceRegistryProvider`, off-corner park, typed `PlayerLaunchRequest`.
   - New § **Form factor & orientation (ADR-0059)**: `kTabletShortestSideLogical = 600` classification, phone portrait lock, aspect-driven (`width > height`) content layout vs the retained 720 chrome breakpoint.
3. **`docs/README.md`** — `superpowers/` index row after `decisions/`.

## Audit notes

- The superpowers README notes that the picker-split spec's "no `part of` outside generated code" claim has an exception: `app_database.dart`'s 15 hand-written DAO parts (relevant to the in-flight #412 refactor).
- ADR-0059 names `player_content_layout.dart` without a path; the actual location is `lib/core/platform/` (verified), which the architecture doc now links correctly.

## Test plan

- [ ] Verify all new links resolve (6 lib files, 2 ADRs, superpowers spec/plan)
- [ ] Docs-only change — no Dart files touched, CI code gates unaffected