### PR TITLE
refactor(data): consolidate repository error handling and pay-URL launch

### DIFF
--- a/lib/core/utils/launch_pay_url.dart
+++ b/lib/core/utils/launch_pay_url.dart
@@ -1,0 +1,23 @@
+/// External checkout URL launch for purchase flows (credits + subscription).
+library;
+
+import 'package:url_launcher/url_launcher.dart';
+
+/// Validates [url] and opens it in the external browser.
+///
+/// Throws [StateError] (`missing_pay_url`, `invalid_pay_url`,
+/// `launch_failed`) when the checkout URL is absent, unparseable, or the
+/// platform refuses to launch it.
+Future<void> launchPayUrl(String? url) async {
+  if (url == null || url.isEmpty) {
+    throw StateError('missing_pay_url');
+  }
+  final uri = Uri.tryParse(url);
+  if (uri == null) {
+    throw StateError('invalid_pay_url');
+  }
+  final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+  if (!launched) {
+    throw StateError('launch_failed');
+  }
+}

--- a/lib/data/api/rest_repository.dart
+++ b/lib/data/api/rest_repository.dart
@@ -1,0 +1,46 @@
+/// Shared error-handling template for REST repositories.
+library;
+
+import 'package:meta/meta.dart';
+
+import 'package:enjoy_player/core/errors/app_failure.dart';
+import 'package:enjoy_player/core/json/json_cast.dart';
+import 'package:enjoy_player/data/api/api_exception.dart';
+
+/// Mixin for repositories that wrap `*Api` services and translate transport
+/// errors into [AppFailure]s. Consolidates the `try / on ApiException /
+/// on FormatException` template so error-mapping changes happen in one place.
+mixin RestRepository {
+  /// Maps an [ApiException] to the feature-specific [AppFailure].
+  @protected
+  AppFailure mapApiException(ApiException e);
+
+  /// Runs [call], rethrowing [ApiException] through [mapApiException] and
+  /// JSON-decode [FormatException]s as [NetworkFailure].
+  Future<T> apiCall<T>(Future<T> Function() call) async {
+    try {
+      return await call();
+    } on ApiException catch (e) {
+      throw mapApiException(e);
+    } on FormatException catch (e) {
+      throw NetworkFailure(e.message);
+    }
+  }
+
+  /// Parses the list at [field] in an API response, skipping entries that are
+  /// not JSON objects. Returns an empty list when the field is absent.
+  List<T> parseJsonListField<T>(
+    Map<String, dynamic> json,
+    String field,
+    T Function(Map<String, dynamic>) fromJson,
+  ) {
+    final raw = json[field];
+    if (raw is! List) return const [];
+    final items = <T>[];
+    for (final e in raw) {
+      final map = castJsonObjectOrNull(e);
+      if (map != null) items.add(fromJson(map));
+    }
+    return items;
+  }
+}

--- a/lib/features/credits/application/credits_packages_provider.dart
+++ b/lib/features/credits/application/credits_packages_provider.dart
@@ -2,8 +2,8 @@
 library;
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:url_launcher/url_launcher.dart';
 
+import 'package:enjoy_player/core/utils/launch_pay_url.dart';
 import 'package:enjoy_player/features/credits/application/credits_summary_provider.dart';
 import 'package:enjoy_player/features/credits/data/credits_packages_repository.dart';
 import 'package:enjoy_player/features/credits/domain/credits_package.dart';
@@ -55,21 +55,7 @@ class CreditsPackagePurchaseCtrl extends _$CreditsPackagePurchaseCtrl {
       final session = await repo.startPurchase(packageId: packageId);
       state = const AsyncData(null);
 
-      final url = session.payUrl;
-      if (url == null || url.isEmpty) {
-        throw StateError('missing_pay_url');
-      }
-      final uri = Uri.tryParse(url);
-      if (uri == null) {
-        throw StateError('invalid_pay_url');
-      }
-      final launched = await launchUrl(
-        uri,
-        mode: LaunchMode.externalApplication,
-      );
-      if (!launched) {
-        throw StateError('launch_failed');
-      }
+      await launchPayUrl(session.payUrl);
       ref
           .read(tierReconcileCtrlProvider.notifier)
           .markPackagePurchasePending(

--- a/lib/features/credits/application/credits_packages_provider.g.dart
+++ b/lib/features/credits/application/credits_packages_provider.g.dart
@@ -84,7 +84,7 @@ final class CreditsPackagePurchaseCtrlProvider
 }
 
 String _$creditsPackagePurchaseCtrlHash() =>
-    r'6ea43fb3309b09c31915d248f04d624203834d06';
+    r'0ecc1f00d6a84977121b05335e0236acbef0490a';
 
 abstract class _$CreditsPackagePurchaseCtrl
     extends $Notifier<AsyncValue<void>> {

--- a/lib/features/credits/data/credits_packages_repository.dart
+++ b/lib/features/credits/data/credits_packages_repository.dart
@@ -4,8 +4,8 @@ library;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
-import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
+import 'package:enjoy_player/data/api/rest_repository.dart';
 import 'package:enjoy_player/data/api/services/api_providers.dart';
 import 'package:enjoy_player/data/api/services/credits_packages_api.dart';
 import 'package:enjoy_player/features/credits/domain/credits_package.dart';
@@ -17,43 +17,29 @@ CreditsPackagesRepository creditsPackagesRepository(Ref ref) {
   return CreditsPackagesRepository(ref.watch(creditsPackagesApiProvider));
 }
 
-class CreditsPackagesRepository {
+class CreditsPackagesRepository with RestRepository {
   CreditsPackagesRepository(this._api);
 
   final CreditsPackagesApi _api;
 
-  Future<List<CreditsPackage>> listPackages() async {
-    try {
-      final json = await _api.listPackages();
-      final raw = json['packages'];
-      if (raw is! List) return const [];
-      final packages = <CreditsPackage>[];
-      for (final e in raw) {
-        final map = castJsonObjectOrNull(e);
-        if (map != null) packages.add(CreditsPackage.fromJson(map));
-      }
-      return packages;
-    } on ApiException catch (e) {
-      throw _map(e);
-    } on FormatException catch (e) {
-      throw NetworkFailure(e.message);
-    }
-  }
+  Future<List<CreditsPackage>> listPackages() => apiCall(
+    () async => parseJsonListField(
+      await _api.listPackages(),
+      'packages',
+      CreditsPackage.fromJson,
+    ),
+  );
 
   Future<CreditsPackagePurchaseSession> startPurchase({
     required String packageId,
-  }) async {
-    try {
-      final json = await _api.startPackagePurchase(packageId: packageId);
-      return CreditsPackagePurchaseSession.fromJson(json);
-    } on ApiException catch (e) {
-      throw _map(e);
-    } on FormatException catch (e) {
-      throw NetworkFailure(e.message);
-    }
-  }
+  }) => apiCall(
+    () async => CreditsPackagePurchaseSession.fromJson(
+      await _api.startPackagePurchase(packageId: packageId),
+    ),
+  );
 
-  AppFailure _map(ApiException e) {
+  @override
+  AppFailure mapApiException(ApiException e) {
     if (e.statusCode == 402) return CreditsFailure(e.message);
     return NetworkFailure(e.message, statusCode: e.statusCode);
   }

--- a/lib/features/subscription/application/subscription_purchase_provider.dart
+++ b/lib/features/subscription/application/subscription_purchase_provider.dart
@@ -2,8 +2,8 @@
 library;
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:url_launcher/url_launcher.dart';
 
+import 'package:enjoy_player/core/utils/launch_pay_url.dart';
 import 'package:enjoy_player/features/subscription/application/tier_reconcile_provider.dart';
 import 'package:enjoy_player/features/subscription/data/subscription_repository.dart';
 import 'package:enjoy_player/features/subscription/domain/auto_renew_start_result.dart';
@@ -29,7 +29,7 @@ class SubscriptionPurchaseCtrl extends _$SubscriptionPurchaseCtrl {
         PurchaseRequest(months: months, processor: processor),
       );
       state = const AsyncData(null);
-      await _launchPayUrl(session.payUrl);
+      await launchPayUrl(session.payUrl);
       ref.read(tierReconcileCtrlProvider.notifier).markPurchasePending();
       return session;
     } catch (e, st) {
@@ -46,7 +46,7 @@ class SubscriptionPurchaseCtrl extends _$SubscriptionPurchaseCtrl {
       final repo = ref.read(subscriptionRepositoryProvider);
       final result = await repo.startAutoRenew(planId: planId);
       state = const AsyncData(null);
-      await _launchPayUrl(result.payUrl);
+      await launchPayUrl(result.payUrl);
       ref.read(tierReconcileCtrlProvider.notifier).markPurchasePending();
       return result;
     } catch (e, st) {
@@ -64,20 +64,6 @@ class SubscriptionPurchaseCtrl extends _$SubscriptionPurchaseCtrl {
     } catch (e, st) {
       state = AsyncError(e, st);
       rethrow;
-    }
-  }
-
-  Future<void> _launchPayUrl(String? url) async {
-    if (url == null || url.isEmpty) {
-      throw StateError('missing_pay_url');
-    }
-    final uri = Uri.tryParse(url);
-    if (uri == null) {
-      throw StateError('invalid_pay_url');
-    }
-    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
-    if (!launched) {
-      throw StateError('launch_failed');
     }
   }
 }

--- a/lib/features/subscription/application/subscription_purchase_provider.g.dart
+++ b/lib/features/subscription/application/subscription_purchase_provider.g.dart
@@ -42,7 +42,7 @@ final class SubscriptionPurchaseCtrlProvider
 }
 
 String _$subscriptionPurchaseCtrlHash() =>
-    r'c62f4971e7e7e71e60ebd8755f580e23ce282375';
+    r'8a1b0b2f68e2a4ae42c8d560da71d880f0725af5';
 
 abstract class _$SubscriptionPurchaseCtrl extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/lib/features/subscription/data/subscription_repository.dart
+++ b/lib/features/subscription/data/subscription_repository.dart
@@ -4,8 +4,8 @@ library;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
-import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
+import 'package:enjoy_player/data/api/rest_repository.dart';
 import 'package:enjoy_player/data/api/services/subscription_api.dart';
 import 'package:enjoy_player/data/api/services/api_providers.dart';
 import 'package:enjoy_player/features/subscription/domain/auto_renew_billing.dart';
@@ -22,82 +22,47 @@ SubscriptionRepository subscriptionRepository(Ref ref) {
   return SubscriptionRepository(ref.watch(subscriptionApiProvider));
 }
 
-class SubscriptionRepository {
+class SubscriptionRepository with RestRepository {
   SubscriptionRepository(this._api);
 
   final SubscriptionApi _api;
 
-  Future<SubscriptionStatus> getStatus() async {
-    try {
-      final json = await _api.getStatus();
-      return SubscriptionStatus.fromJson(json);
-    } on ApiException catch (e) {
-      throw _mapApiException(e);
-    } on FormatException catch (e) {
-      throw NetworkFailure(e.message);
-    }
-  }
+  Future<SubscriptionStatus> getStatus() =>
+      apiCall(() async => SubscriptionStatus.fromJson(await _api.getStatus()));
 
-  Future<List<SubscriptionPlan>> listPlans() async {
-    try {
-      final json = await _api.listPlans();
-      final raw = json['plans'];
-      if (raw is! List) return const [];
-      final plans = <SubscriptionPlan>[];
-      for (final e in raw) {
-        final map = castJsonObjectOrNull(e);
-        if (map != null) plans.add(SubscriptionPlan.fromJson(map));
-      }
-      return plans;
-    } on ApiException catch (e) {
-      throw _mapApiException(e);
-    } on FormatException catch (e) {
-      throw NetworkFailure(e.message);
-    }
-  }
+  Future<List<SubscriptionPlan>> listPlans() => apiCall(
+    () async => parseJsonListField(
+      await _api.listPlans(),
+      'plans',
+      SubscriptionPlan.fromJson,
+    ),
+  );
 
-  Future<PaymentSession> purchase(PurchaseRequest request) async {
-    try {
-      final json = await _api.purchase(
-        months: request.months,
-        processor: request.processor,
+  Future<PaymentSession> purchase(PurchaseRequest request) => apiCall(
+    () async => PaymentSession.fromJson(
+      await _api.purchase(months: request.months, processor: request.processor),
+    ),
+  );
+
+  Future<AutoRenewStartResult> startAutoRenew({required String planId}) =>
+      apiCall(
+        () async => AutoRenewStartResult.fromJson(
+          await _api.startAutoRenew(planId: planId),
+        ),
       );
-      return PaymentSession.fromJson(json);
-    } on ApiException catch (e) {
-      throw _mapApiException(e);
-    } on FormatException catch (e) {
-      throw NetworkFailure(e.message);
-    }
-  }
 
-  Future<AutoRenewStartResult> startAutoRenew({required String planId}) async {
-    try {
-      final json = await _api.startAutoRenew(planId: planId);
-      return AutoRenewStartResult.fromJson(json);
-    } on ApiException catch (e) {
-      throw _mapApiException(e);
-    } on FormatException catch (e) {
-      throw NetworkFailure(e.message);
+  Future<AutoRenewBilling> cancelAutoRenew() => apiCall(() async {
+    final json = await _api.cancelAutoRenew();
+    // Cancel may return billing fields at top level or nested.
+    final nested = json['autoRenew'];
+    if (nested is Map) {
+      return AutoRenewBilling.fromJson(Map<String, dynamic>.from(nested));
     }
-  }
+    return AutoRenewBilling.fromJson(json);
+  });
 
-  Future<AutoRenewBilling> cancelAutoRenew() async {
-    try {
-      final json = await _api.cancelAutoRenew();
-      // Cancel may return billing fields at top level or nested.
-      final nested = json['autoRenew'];
-      if (nested is Map) {
-        return AutoRenewBilling.fromJson(Map<String, dynamic>.from(nested));
-      }
-      return AutoRenewBilling.fromJson(json);
-    } on ApiException catch (e) {
-      throw _mapApiException(e);
-    } on FormatException catch (e) {
-      throw NetworkFailure(e.message);
-    }
-  }
-
-  AppFailure _mapApiException(ApiException e) {
+  @override
+  AppFailure mapApiException(ApiException e) {
     if (e.statusCode == 402) {
       return CreditsFailure(e.message);
     }


### PR DESCRIPTION
## Summary
- Extract the duplicated `try / on ApiException / on FormatException` template (7 method bodies across `subscription_repository.dart` and `credits_packages_repository.dart`) into a `RestRepository` mixin in `lib/data/api/rest_repository.dart` (closes #431)
  - `apiCall<T>()` — the shared error-handling template
  - `parseJsonListField<T>()` — the shared JSON list parsing pattern
  - Each repository now only declares its status-code → `AppFailure` mapping (subscription keeps its extra 409 → `SubscriptionConflictFailure` case)
- Extract the duplicated checkout-URL validation/launch logic from both purchase controllers into `launchPayUrl()` in `lib/core/utils/launch_pay_url.dart` with the identical `StateError` contract (`missing_pay_url` / `invalid_pay_url` / `launch_failed`)

Error-mapping changes (new status codes, retry logic) now happen in one place per repository instead of 5–7 coordinated edits.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 3145 tests pass, including `subscription_repository_test.dart` and `credits_packages_provider_test.dart` which exercise the refactored paths directly
- [x] `dart format` clean
- [x] Behavior-preserving: same exceptions, same failure types, same StateError messages