### PR TITLE
docs(community): update code map and fix stale initials ref for card refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Community activity card** split into focused part files (`avatars`, `bodies`, `metrics`, `stats`) sharing one library scope.
+- **Global transport bar** extracts `_LineNavButton` as the shared prev/next/replay control.
+
 ## [0.7.2] - 2026-07-22
 
 ### Added

--- a/docs/features/community.md
+++ b/docs/features/community.md
@@ -12,7 +12,7 @@ The community activity card surfaces **active learners** on the signed-in **Home
 - **Timeout**: the request uses an **8-second client timeout**; on timeout (or any other error), the card hides / shows no data rather than a retry affordance (matches web parity).
 - **Variants**: `CommunityActivityCardVariant.card` (full stats + up to 8 avatars; tablet/desktop) and `CommunityActivityCardVariant.summary` (compact headline + up to 4 avatars; mobile insight strip).
 - **Today stats**: when the server returns `recordingsCountToday` / `recordingsDurationToday`, the card shows the aggregated practice volume; otherwise the stat row is hidden.
-- **Avatars**: rendered with `CachedNetworkImage` from `avatarUrl` (Dicebear SVG URLs are rewritten to PNG via `rasterAvatarUrl` in `lib/core/utils/avatar_url.dart` because Flutter cannot decode SVG with raster image widgets); missing avatars fall back to **initials** derived from the user's name (`_initials` in `community_activity_card.dart`).
+- **Avatars**: rendered with `CachedNetworkImage` from `avatarUrl` (Dicebear SVG URLs are rewritten to PNG via `rasterAvatarUrl` in `lib/core/utils/avatar_url.dart` because Flutter cannot decode SVG with raster image widgets); missing avatars fall back to **initials** derived from the user's name (`initials` helper in `community_activity_avatars.dart`).
 - **Layout**: on wide viewports (≈720px+) Today's Goal and Community Activity cards share a responsive two-column row above the recent media grid; on narrow screens they stack.
 
 ## Signed-in gating
@@ -27,6 +27,10 @@ The card is only mounted on Home when `authCtrlProvider` reports `AuthSignedIn`.
 | Riverpod provider | [`lib/features/community/application/active_users_provider.dart`](../../lib/features/community/application/active_users_provider.dart) |
 | Client IANA timezone | [`lib/core/utils/client_timezone.dart`](../../lib/core/utils/client_timezone.dart) |
 | Card UI (card + summary variants) | [`lib/features/community/presentation/community_activity_card.dart`](../../lib/features/community/presentation/community_activity_card.dart) |
+| └ avatars (initials, wrap grid, overlapping stack) | [`community_activity_avatars.dart`](../../lib/features/community/presentation/community_activity_avatars.dart) |
+| └ bodies (card + summary content) | [`community_activity_bodies.dart`](../../lib/features/community/presentation/community_activity_bodies.dart) |
+| └ metrics (today's practice stat row) | [`community_activity_metrics.dart`](../../lib/features/community/presentation/community_activity_metrics.dart) |
+| └ stats (headline summary content) | [`community_activity_stats.dart`](../../lib/features/community/presentation/community_activity_stats.dart) |
 
 ## Related
 


### PR DESCRIPTION
Closes #437.

Fills the documentation gaps left after the community activity card refactor (PR #434 — note: #437's body referenced #436, but that PR was actually "consolidate repository error handling and pay-URL launch"; the card split shipped in #434).

### Changes

**`docs/features/community.md`**
- **Code map**: the card UI row now lists the focused part files produced by the split — `community_activity_avatars.dart`, `community_activity_bodies.dart`, `community_activity_metrics.dart`, `community_activity_stats.dart` — alongside the top-level `community_activity_card.dart`.
- **Stale reference fix**: `_initials` in `community_activity_card.dart` → `initials` helper in `community_activity_avatars.dart` (the function was renamed to public `initials` and relocated during the split).

**`CHANGELOG.md`**
- `[Unreleased]` → `Changed`: community activity card split into focused part files; global transport bar `_LineNavButton` extraction (PR #435).

### Verification

Documentation-only change — no `lib/`, `test/`, or `packages/` edits, so no `flutter analyze` / `flutter test` / codegen impact.

Confirmed against the current tree:
- `lib/features/community/presentation/` contains `community_activity_{card,avatars,bodies,metrics,stats}.dart`.
- `initials` is defined at `community_activity_avatars.dart:16` (public); no `_initials` remains in `community_activity_card.dart`.
- `_LineNavButton` exists at `lib/features/player/presentation/widgets/global_transport_bar.dart:670`.
- No remaining references to the old private widget names (`_CardBody`, `_SummaryBody`, `_UserAvatar`, `_initials`) in `docs/`.