### PR TITLE
docs(craft): add Craft Voice-Express changelog entry and README index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Craft Voice-Express dual-mode** redesign: a voice-first Express mode (speak → ASR → AI rewrite → TTS) is now the default, alongside the existing Advanced translate/synthesize tools. See [ADR-0060](docs/decisions/0060-craft-voice-express-dual-mode.md) and [docs/features/craft.md](docs/features/craft.md).
+
 ## [0.7.2] - 2026-07-22
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Maintainers and agents should keep these files **accurate** when behavior or arc
 | [features/echo-mode.md](features/echo-mode.md) | Product + dev | Echo region, shadow-reading, pronunciation assessment, or share practice poster behavior changes |
 | [features/local-database-recovery.md](features/local-database-recovery.md) | Product + dev | Stale/malformed local-DB detection, the recovery surface, or the reset-local-library flow changes |
 | [features/linux-platform.md](features/linux-platform.md) | Product + dev | Linux support matrix, AppImage packaging/release, or per-platform feature availability changes |
-| [features/craft.md](features/craft.md) | Product + dev | Craft from Text import, translate/synthesize modes, voice picker, or failure handling changes |
+| [features/craft.md](features/craft.md) | Product + dev | Craft dual-mode (voice-first Express + Advanced translate/synthesize), from Text import, voice picker, history, or failure handling changes |
 
 ## How to add an ADR
 


### PR DESCRIPTION
Closes #443.

Fills the two documentation gaps left after the Craft Voice-Express feature shipped (ADR-0060).

### Changes

**`CHANGELOG.md`** — Added `[Unreleased]` → `Added` entry for the Craft Voice-Express dual-mode redesign, cross-referencing [ADR-0060](docs/decisions/0060-craft-voice-express-dual-mode.md) and [docs/features/craft.md](docs/features/craft.md).

**`docs/README.md`** — Updated the `craft.md` index entry to describe the voice-first **Express** mode alongside the existing **Advanced** translate/synthesize tools (the old summary only mentioned "Craft from Text import, translate/synthesize modes, voice picker").

### Verification

Documentation-only change — no `lib/`, `test/`, or `packages/` edits.

Confirmed against the current tree:
- `docs/decisions/0060-craft-voice-express-dual-mode.md` exists.
- `docs/features/craft.md` already documents the dual-mode screen layout, Express capture/rewrite/audio pipeline, and Auto translation style — no further feature-doc changes needed (the body was already populated when the feature landed).
- `[Unreleased]` was previously empty.