### PR TITLE
docs(craft): document Craft history remove feature (ADR-0062)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Craft history remove**: clearing a Craft history record now keeps the library audio and transcript (it clears Craft provenance instead of deleting). See [ADR-0062](docs/decisions/0062-craft-history-remove-keeps-audio.md) and [docs/features/craft.md](docs/features/craft.md#craft-history-crafthistory).
+
 ## [0.7.2] - 2026-07-22
 
 ### Added

--- a/docs/features/craft.md
+++ b/docs/features/craft.md
@@ -242,6 +242,7 @@ No `isWide` width calculations or ad-hoc max widths live in Craft widgets — al
 ## Related
 
 - [ADR-0061: Craft first-class Home entry, history, edit](../decisions/0061-craft-first-class-history.md)
+- [ADR-0062: Remove Craft history record keeps practice audio](../decisions/0062-craft-history-remove-keeps-audio.md)
 - [ADR-0060: Craft Voice-Express dual-mode redesign](../decisions/0060-craft-voice-express-dual-mode.md)
 - [ADR-0043: Craft from Text Import](../decisions/0043-craft-from-text-import.md)
 - [ADR-0055: Adaptive page layout system](../decisions/0055-adaptive-page-layout-system.md)


### PR DESCRIPTION
Closes #451.

Adds the missing documentation cross-references for the Craft history remove feature (ADR-0062).

### Changes

**`docs/features/craft.md`** — Added [ADR-0062](docs/decisions/0062-craft-history-remove-keeps-audio.md) to the "Related" section, alongside the existing ADR-0061 / ADR-0060 references. The remove behavior itself is already documented in the [Craft history section](docs/features/craft.md#craft-history-crafthistory) (line 32: `removeCraftHistoryRecord` clears `Audios.provider` from `'craft'` to `'user'`, keeping the audio file and transcript — not a library delete).

**`CHANGELOG.md`** — Added `[Unreleased]` → `Added` entry for the Craft history remove feature.

### Verification

Documentation-only change — no `lib/`, `test/`, or `packages/` edits.

Confirmed against the current tree:
- `docs/decisions/0062-craft-history-remove-keeps-audio.md` exists and is `Accepted`.
- `MediaLibraryRepository.removeCraftHistoryRecord(mediaId)` exists at `lib/features/library/data/library_repository.dart:631`, wired into `lib/features/craft/presentation/craft_history_screen.dart:114`, and tested at `test/features/library/library_repository_craft_test.dart:468`.
- The Craft history section of `craft.md` already describes the remove behavior; only the ADR cross-reference in "Related" was missing.