### PR TITLE
refactor(sync): extract 404-guard helper for delete methods

### DIFF
--- a/lib/features/sync/data/sync_upload_service.dart
+++ b/lib/features/sync/data/sync_upload_service.dart
@@ -275,45 +275,27 @@ class SyncUploadService {
     return parsed;
   }
 
-  Future<void> deleteAudio(String id) async {
-    try {
-      await _audioApi.deleteAudio(id);
-    } on ApiException catch (e) {
-      if (e.statusCode == 404) return;
-      rethrow;
-    }
-  }
+  Future<void> deleteAudio(String id) =>
+      _deleteWith404Guard(() => _audioApi.deleteAudio(id));
 
-  Future<void> deleteVideo(String id) async {
-    try {
-      await _videoApi.deleteVideo(id);
-    } on ApiException catch (e) {
-      if (e.statusCode == 404) return;
-      rethrow;
-    }
-  }
+  Future<void> deleteVideo(String id) =>
+      _deleteWith404Guard(() => _videoApi.deleteVideo(id));
 
-  Future<void> deleteRecording(String id) async {
-    try {
-      await _recordingApi.deleteRecording(id);
-    } on ApiException catch (e) {
-      if (e.statusCode == 404) return;
-      rethrow;
-    }
-  }
+  Future<void> deleteRecording(String id) =>
+      _deleteWith404Guard(() => _recordingApi.deleteRecording(id));
 
-  Future<void> deleteVocabularyItem(String id) async {
-    try {
-      await _vocabularyApi.deleteVocabularyItem(id);
-    } on ApiException catch (e) {
-      if (e.statusCode == 404) return;
-      rethrow;
-    }
-  }
+  Future<void> deleteVocabularyItem(String id) =>
+      _deleteWith404Guard(() => _vocabularyApi.deleteVocabularyItem(id));
 
-  Future<void> deleteVocabularyContext(String id) async {
+  Future<void> deleteVocabularyContext(String id) =>
+      _deleteWith404Guard(() => _vocabularyApi.deleteVocabularyContext(id));
+
+  /// Runs a server delete, treating a `404` response as success (the entity
+  /// was already gone on the server). Any other [ApiException] is rethrown so
+  /// the sync queue can retry or fail the row.
+  Future<void> _deleteWith404Guard(Future<void> Function() delete) async {
     try {
-      await _vocabularyApi.deleteVocabularyContext(id);
+      await delete();
     } on ApiException catch (e) {
       if (e.statusCode == 404) return;
       rethrow;


### PR DESCRIPTION
Closes #448.

### Summary

The five `SyncUploadService` delete methods (`deleteAudio`, `deleteVideo`, `deleteRecording`, `deleteVocabularyItem`, `deleteVocabularyContext`) each wrapped their API call in a **byte-for-byte identical** try/catch:

```dart
try {
  await _xxApi.deleteXx(id);
} on ApiException catch (e) {
  if (e.statusCode == 404) return;  // entity already gone on the server
  rethrow;
}
```

The only thing that differed between the five blocks was *which* API sub-service was called — there was no per-method log context or distinct control flow to preserve. This is the clean case for extraction (unlike #447, where each catch block carried distinct `kind=`/`key=` log context).

### Change

Extract a single private helper and reduce each public delete method to a one-liner:

```dart
Future<void> deleteAudio(String id) =>
    _deleteWith404Guard(() => _audioApi.deleteAudio(id));
// …one line each for video / recording / vocabularyItem / vocabularyContext…

Future<void> _deleteWith404Guard(Future<void> Function() delete) async {
  try {
    await delete();
  } on ApiException catch (e) {
    if (e.statusCode == 404) return;
    rethrow;
  }
}
```

Net: **−18 lines** (`16 insertions, 34 deletions`), one policy point for the 404-already-deleted behavior.

### Verification

- `flutter analyze lib/features/sync/data/sync_upload_service.dart` → **No issues found.**
- `flutter test test/features/sync/sync_upload_service_coverage_test.dart` → **All 42 tests passed**, including all 15 delete tests (3 per entity: `succeeds on 200` / `swallows 404` / `rethrows non-404 ApiException`).
- `dart format` → no changes.
- Behavior is unchanged; the refactor is purely structural. No public API signature changed.