### PR TITLE
refactor(json): dedupe numeric JSON cast helpers; fix round/toInt inconsistency

### DIFF
--- a/lib/core/json/json_cast.dart
+++ b/lib/core/json/json_cast.dart
@@ -30,3 +30,46 @@ Map<String, dynamic> castJsonObject(Object? value) {
   }
   return map;
 }
+
+/// Coerces a JSON value to a nullable `int`.
+///
+/// Accepts an [int] directly, truncates a [num] (e.g. a `double` that slipped
+/// in from a lenient backend) toward zero via [num.toInt], and parses a
+/// [String]. Returns `null` for `null` or an unparseable value.
+///
+/// Truncation (not rounding) is used deliberately: these fields are counts,
+/// timestamps, and durations that are semantically integers, and
+/// `num.toInt()` is the conventional Dart coercion. Use [intOrZero] when a
+/// non-null default is wanted.
+int? intFromJson(Object? value) {
+  if (value == null) return null;
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value.toString());
+}
+
+/// Coerces a JSON value to a non-null `int`, defaulting to `0`.
+///
+/// Like [intFromJson] but never returns `null` — `null`, a non-numeric type,
+/// or an unparseable string all become `0`.
+int intOrZero(Object? value) => intFromJson(value) ?? 0;
+
+/// Coerces a JSON value to a non-null [num], defaulting to `0`.
+///
+/// Accepts a [num] directly and parses a [String]; anything else (including
+/// `null`) becomes `0`.
+num numOrZero(Object? value) {
+  if (value is num) return value;
+  if (value is String) return num.tryParse(value) ?? 0;
+  return 0;
+}
+
+/// Coerces a JSON value to a nullable [num].
+///
+/// Accepts a [num] directly and parses a [String]; `null` or an unparseable
+/// value yields `null`. Use [numOrZero] when a non-null default is wanted.
+num? numOrNull(Object? value) {
+  if (value is num) return value;
+  if (value is String) return num.tryParse(value);
+  return null;
+}

--- a/lib/features/auth/domain/user_profile.dart
+++ b/lib/features/auth/domain/user_profile.dart
@@ -1,6 +1,7 @@
 /// User profile returned by `GET/PATCH /api/v1/profile` (camelCase JSON).
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/core/utils/avatar_url.dart';
 
 enum SubscriptionTier { free, pro }
@@ -27,7 +28,7 @@ class UserProfile {
       locale: json['locale'] as String?,
       learningLanguage: json['learningLanguage'] as String?,
       nativeLanguage: json['nativeLanguage'] as String?,
-      goal: _intFromJson(json['goal']),
+      goal: intFromJson(json['goal']),
       createdAt: json['createdAt'] as String?,
     );
   }
@@ -125,11 +126,4 @@ double? _doubleFromJson(Object? value) {
   if (value == null) return null;
   if (value is num) return value.toDouble();
   return double.tryParse(value.toString());
-}
-
-int? _intFromJson(Object? value) {
-  if (value == null) return null;
-  if (value is int) return value;
-  if (value is num) return value.toInt();
-  return int.tryParse(value.toString());
 }

--- a/lib/features/community/domain/active_user.dart
+++ b/lib/features/community/domain/active_user.dart
@@ -4,13 +4,6 @@ library;
 import 'package:enjoy_player/core/json/json_cast.dart';
 import 'package:enjoy_player/core/utils/avatar_url.dart';
 
-int? _intFromJson(Object? value) {
-  if (value == null) return null;
-  if (value is int) return value;
-  if (value is double) return value.round();
-  return int.tryParse(value.toString());
-}
-
 class ActiveUser {
   factory ActiveUser.fromJson(Map<String, dynamic> json) {
     return ActiveUser(
@@ -40,9 +33,9 @@ class ActiveUsersResponse {
     }
     return ActiveUsersResponse(
       users: users,
-      count: _intFromJson(json['count']) ?? users.length,
-      recordingsCountToday: _intFromJson(json['recordingsCountToday']),
-      recordingsDurationToday: _intFromJson(json['recordingsDurationToday']),
+      count: intFromJson(json['count']) ?? users.length,
+      recordingsCountToday: intFromJson(json['recordingsCountToday']),
+      recordingsDurationToday: intFromJson(json['recordingsDurationToday']),
     );
   }
   const ActiveUsersResponse({

--- a/lib/features/credits/domain/credits_package.dart
+++ b/lib/features/credits/domain/credits_package.dart
@@ -1,13 +1,15 @@
 /// One-time permanent-credit package from Rails `/api/v1/credits/packages`.
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
+
 class CreditsTransferRate {
   const CreditsTransferRate({required this.usd, required this.credits});
 
   factory CreditsTransferRate.fromJson(Map<String, dynamic> json) {
     return CreditsTransferRate(
-      usd: _num(json['usd']),
-      credits: _int(json['credits']),
+      usd: numOrZero(json['usd']),
+      credits: intOrZero(json['credits']),
     );
   }
 
@@ -33,7 +35,7 @@ class CreditsPackage {
       id: json['id']?.toString() ?? '',
       amount: json['amount']?.toString() ?? '',
       currency: json['currency']?.toString() ?? 'USD',
-      credits: _int(json['credits']),
+      credits: intOrZero(json['credits']),
       rate: CreditsTransferRate.fromJson(rateMap),
     );
   }
@@ -81,17 +83,4 @@ class CreditsPackagePurchaseSession {
   final String amount;
   final String? payUrl;
   final CreditsPackage package;
-}
-
-num _num(Object? value) {
-  if (value is num) return value;
-  if (value is String) return num.tryParse(value) ?? 0;
-  return 0;
-}
-
-int _int(Object? value) {
-  if (value is int) return value;
-  if (value is num) return value.toInt();
-  if (value is String) return int.tryParse(value) ?? 0;
-  return 0;
 }

--- a/lib/features/credits/domain/credits_summary.dart
+++ b/lib/features/credits/domain/credits_summary.dart
@@ -1,6 +1,8 @@
 /// Worker `GET /credits/summary` wallet standing.
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
+
 class CreditsSummary {
   const CreditsSummary({
     required this.tier,
@@ -14,11 +16,11 @@ class CreditsSummary {
   factory CreditsSummary.fromJson(Map<String, dynamic> json) {
     return CreditsSummary(
       tier: json['tier']?.toString() ?? '',
-      dailyUsed: _int(json['dailyUsed']),
-      dailyLimit: _int(json['dailyLimit']),
-      dailyRemaining: _int(json['dailyRemaining']),
-      permanentAvailable: _int(json['permanentAvailable']),
-      resetAt: _int(json['resetAt']),
+      dailyUsed: intOrZero(json['dailyUsed']),
+      dailyLimit: intOrZero(json['dailyLimit']),
+      dailyRemaining: intOrZero(json['dailyRemaining']),
+      permanentAvailable: intOrZero(json['permanentAvailable']),
+      resetAt: intOrZero(json['resetAt']),
     );
   }
 
@@ -37,11 +39,4 @@ class CreditsSummary {
     'permanentAvailable': permanentAvailable,
     'resetAt': resetAt,
   };
-}
-
-int _int(Object? value) {
-  if (value is int) return value;
-  if (value is num) return value.toInt();
-  if (value is String) return int.tryParse(value) ?? 0;
-  return 0;
 }

--- a/lib/features/credits/domain/credits_usage_log.dart
+++ b/lib/features/credits/domain/credits_usage_log.dart
@@ -1,6 +1,8 @@
 /// One row from Worker `GET /credits/usages` (`logs[]`).
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
+
 class CreditsUsageLog {
   factory CreditsUsageLog.fromJson(Map<String, dynamic> json) {
     final metaRaw = json['meta'];
@@ -13,12 +15,12 @@ class CreditsUsageLog {
       id: json['id']?.toString() ?? '',
       userId: json['userId']?.toString() ?? '',
       date: json['date']?.toString() ?? '',
-      timestampMs: _intFromJson(json['timestamp']) ?? 0,
+      timestampMs: intFromJson(json['timestamp']) ?? 0,
       serviceType: json['serviceType']?.toString() ?? '',
       tier: json['tier']?.toString() ?? '',
-      creditsRequired: _intFromJson(json['required']) ?? 0,
-      usedBefore: _intFromJson(json['usedBefore']) ?? 0,
-      usedAfter: _intFromJson(json['usedAfter']) ?? 0,
+      creditsRequired: intFromJson(json['required']) ?? 0,
+      usedBefore: intFromJson(json['usedBefore']) ?? 0,
+      usedAfter: intFromJson(json['usedAfter']) ?? 0,
       allowed: _boolFromJson(json['allowed']) ?? false,
       meta: meta,
     );
@@ -50,13 +52,6 @@ class CreditsUsageLog {
   final int usedAfter;
   final bool allowed;
   final Map<String, Object?>? meta;
-}
-
-int? _intFromJson(Object? value) {
-  if (value == null) return null;
-  if (value is int) return value;
-  if (value is num) return value.toInt();
-  return int.tryParse(value.toString());
 }
 
 bool? _boolFromJson(Object? value) {

--- a/lib/features/subscription/domain/auto_renew_billing.dart
+++ b/lib/features/subscription/domain/auto_renew_billing.dart
@@ -1,6 +1,8 @@
 /// Nested auto-renew snapshot from `GET /api/v1/subscriptions`.
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
+
 class AutoRenewBilling {
   const AutoRenewBilling({
     required this.active,
@@ -28,7 +30,7 @@ class AutoRenewBilling {
       planId: json['planId']?.toString(),
       tier: json['tier']?.toString() ?? 'pro',
       interval: json['interval']?.toString() ?? '',
-      amount: _numOrNull(json['amount']),
+      amount: numOrNull(json['amount']),
     );
   }
 
@@ -77,10 +79,4 @@ class AutoRenewBilling {
     'interval': interval,
     if (amount != null) 'amount': amount,
   };
-}
-
-num? _numOrNull(Object? value) {
-  if (value is num) return value;
-  if (value is String) return num.tryParse(value);
-  return null;
 }

--- a/lib/features/subscription/domain/auto_renew_start_result.dart
+++ b/lib/features/subscription/domain/auto_renew_start_result.dart
@@ -1,6 +1,8 @@
 /// Result of `POST /api/v1/subscriptions/auto_renew`.
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
+
 class AutoRenewStartResult {
   const AutoRenewStartResult({
     required this.id,
@@ -33,7 +35,7 @@ class AutoRenewStartResult {
       planId: json['planId']?.toString(),
       tier: json['tier']?.toString() ?? 'pro',
       interval: json['interval']?.toString() ?? '',
-      priceAmount: _numOrNull(priceMap?['amount'] ?? json['amount']),
+      priceAmount: numOrNull(priceMap?['amount'] ?? json['amount']),
       priceInterval: priceMap?['interval']?.toString(),
       currencyNote: priceMap?['currencyNote']?.toString(),
     );
@@ -51,10 +53,4 @@ class AutoRenewStartResult {
   final num? priceAmount;
   final String? priceInterval;
   final String? currencyNote;
-}
-
-num? _numOrNull(Object? value) {
-  if (value is num) return value;
-  if (value is String) return num.tryParse(value);
-  return null;
 }

--- a/lib/features/subscription/domain/subscription_plan.dart
+++ b/lib/features/subscription/domain/subscription_plan.dart
@@ -1,6 +1,8 @@
 /// Catalog row from `GET /api/v1/subscriptions/plans`.
 library;
 
+import 'package:enjoy_player/core/json/json_cast.dart';
+
 class SubscriptionPlan {
   const SubscriptionPlan({
     required this.id,
@@ -15,7 +17,7 @@ class SubscriptionPlan {
       id: json['id']?.toString() ?? '',
       tier: json['tier']?.toString() ?? 'pro',
       interval: json['interval']?.toString() ?? '',
-      amount: _num(json['amount']),
+      amount: numOrZero(json['amount']),
       currencyNote: json['currencyNote']?.toString(),
     );
   }
@@ -36,10 +38,4 @@ class SubscriptionPlan {
     'amount': amount,
     if (currencyNote != null) 'currencyNote': currencyNote,
   };
-}
-
-num _num(Object? value) {
-  if (value is num) return value;
-  if (value is String) return num.tryParse(value) ?? 0;
-  return 0;
 }

--- a/test/core/json/json_cast_test.dart
+++ b/test/core/json/json_cast_test.dart
@@ -44,4 +44,77 @@ void main() {
       expect(() => castJsonObject('nope'), throwsFormatException);
     });
   });
+
+  group('intFromJson', () {
+    test('accepts an int directly', () {
+      expect(intFromJson(7), 7);
+    });
+
+    test('truncates a num toward zero (not round)', () {
+      // Truncation is deliberate: these fields are counts / timestamps /
+      // durations that are semantically integers. 3.9 -> 3, not 4.
+      expect(intFromJson(3.9), 3);
+      expect(intFromJson(-3.9), -3);
+    });
+
+    test('parses a numeric string', () {
+      expect(intFromJson('42'), 42);
+    });
+
+    test('returns null for null', () {
+      expect(intFromJson(null), isNull);
+    });
+
+    test('returns null for an unparseable value', () {
+      expect(intFromJson('nonsense'), isNull);
+      expect(intFromJson(true), isNull);
+    });
+  });
+
+  group('intOrZero', () {
+    test('returns the int when parseable', () {
+      expect(intOrZero(5), 5);
+      expect(intOrZero('9'), 9);
+    });
+
+    test('defaults to 0 for null or unparseable', () {
+      expect(intOrZero(null), 0);
+      expect(intOrZero('x'), 0);
+      expect(intOrZero(<String, dynamic>{}), 0);
+    });
+  });
+
+  group('numOrZero', () {
+    test('accepts a num directly', () {
+      expect(numOrZero(3), 3);
+      expect(numOrZero(2.5), 2.5);
+    });
+
+    test('parses a numeric string', () {
+      expect(numOrZero('1.5'), 1.5);
+    });
+
+    test('defaults to 0 for null, unparseable string, or other types', () {
+      expect(numOrZero(null), 0);
+      expect(numOrZero('x'), 0);
+      expect(numOrZero(true), 0);
+    });
+  });
+
+  group('numOrNull', () {
+    test('accepts a num directly', () {
+      expect(numOrNull(3), 3);
+      expect(numOrNull(2.5), 2.5);
+    });
+
+    test('parses a numeric string', () {
+      expect(numOrNull('1.5'), 1.5);
+    });
+
+    test('returns null for null, unparseable string, or other types', () {
+      expect(numOrNull(null), isNull);
+      expect(numOrNull('x'), isNull);
+      expect(numOrNull(false), isNull);
+    });
+  });
 }


### PR DESCRIPTION
Closes #446.

### Summary

The private numeric JSON helpers `_num`, `_int`, `_numOrNull`, and `_intFromJson` were copy-pasted across 7 domain files in `credits/`, `subscription/`, `auth/`, and `community/`. This extracts them as public helpers in the existing `lib/core/json/json_cast.dart` and replaces every duplicate — **and** fixes a genuine behavioral inconsistency the detector flagged.

### The real bug: `round()` vs `toInt()`

`active_user.dart`'s `_intFromJson` used `value.round()` for a `double`, while `user_profile.dart` and `credits_usage_log.dart` used `value.toInt()` (truncation). For a value like `3.9`, `round()` → `4` and `toInt()` → `3` — a silent data-integrity difference.

Standardized on **`toInt()` (truncation)**:
- These fields are all counts, timestamps, and durations that are semantically integers — a fractional value from the server is malformed, and truncation is the conventional Dart `num.toInt()` coercion.
- It matches the codebase majority (2 of 3 sites).
- The choice is documented in the helper doc comment and pinned by a unit test (`intFromJson truncates a num toward zero (not round)`).

### Changes

**New shared helpers in `lib/core/json/json_cast.dart`:**
| Helper | Returns | Replaces |
|--------|---------|----------|
| `intFromJson(Object?)` | `int?` (nullable) | `_intFromJson` (3 sites) |
| `intOrZero(Object?)` | `int` (default 0) | `_int` (2 sites) |
| `numOrZero(Object?)` | `num` (default 0) | `_num` (2 sites) |
| `numOrNull(Object?)` | `num?` (nullable) | `_numOrNull` (2 sites) |

**Updated consumers** (7 files): `active_user.dart`, `user_profile.dart`, `credits_usage_log.dart`, `credits_package.dart`, `credits_summary.dart`, `subscription_plan.dart`, `auto_renew_billing.dart`, `auto_renew_start_result.dart`.

**`_subscriptionTierFromJson` is intentionally left in place** — it is enum-specific (coupled to `SubscriptionTier`, only 2 occurrences) and does not belong in a generic primitives file.

### Verification

- `flutter analyze` (9 changed lib files) → **No issues found.**
- `flutter test test/core/json/ test/features/auth/ test/features/credits/ test/features/subscription/` → **All 313 tests passed.**
- Added focused tests for the 4 new helpers in `test/core/json/json_cast_test.dart` (including the truncation-pinning test).
- `bash .github/scripts/check_dart_format.sh` → `ok` (1187 files, 0 changed).
- No codegen-affected annotations touched — no `*.g.dart` regeneration needed.

The only behavior change is `active_user.dart` `\`recordingsCountToday\`/\`recordingsDurationToday\`/\`count\`` coercion moving from `round()` to `toInt()`, which only differs for malformed fractional server input; for well-formed integer JSON (the actual contract) the result is identical.