### PR TITLE
perf: DB indexes + EXISTS optimization + AI cache batch deletes (#467 #469 #478)

### DIFF
--- a/lib/data/db/app_database.dart
+++ b/lib/data/db/app_database.dart
@@ -104,7 +104,7 @@ class AppDatabase extends _$AppDatabase {
   bool get isDeviceGlobalDatabase => _dbName == deviceGlobalDatabaseName;
 
   @override
-  int get schemaVersion => 15;
+  int get schemaVersion => 16;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -217,6 +217,52 @@ class AppDatabase extends _$AppDatabase {
         await m.database.customStatement(
           'CREATE INDEX IF NOT EXISTS idx_vocabulary_reviews_item_at '
           'ON vocabulary_reviews (vocabulary_item_id, at)',
+        );
+      } else if (next == 16) {
+        // Hot-read-path covering indexes (issue #467).
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_transcripts_target '
+          'ON transcripts (target_type, target_id)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_recordings_target '
+          'ON recordings (target_type, target_id)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_echo_sessions_target_active '
+          'ON echo_sessions (target_type, target_id, last_active_at)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_videos_provider_vid '
+          'ON videos (provider, vid)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_videos_local_uri '
+          'ON videos (local_uri)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_audios_local_uri '
+          'ON audios (local_uri)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_audios_md5 '
+          'ON audios (md5)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_dictations_target '
+          'ON dictations (target_type, target_id)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_youtube_feed_entries_channel_published '
+          'ON youtube_feed_entries (channel_id, published_at)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_youtube_feed_entries_published '
+          'ON youtube_feed_entries (published_at DESC)',
+        );
+        await m.database.customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_sync_queue_retry_created '
+          'ON sync_queue (retry_count, created_at)',
         );
       }
       current = next;

--- a/lib/data/db/app_database.g.dart
+++ b/lib/data/db/app_database.g.dart
@@ -11432,9 +11432,53 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $VocabularyContextsTable(this);
   late final $VocabularyReviewsTable vocabularyReviews =
       $VocabularyReviewsTable(this);
+  late final Index idxVideosProviderVid = Index(
+    'idx_videos_provider_vid',
+    'CREATE INDEX idx_videos_provider_vid ON videos (provider, vid)',
+  );
+  late final Index idxVideosLocalUri = Index(
+    'idx_videos_local_uri',
+    'CREATE INDEX idx_videos_local_uri ON videos (local_uri)',
+  );
+  late final Index idxAudiosLocalUri = Index(
+    'idx_audios_local_uri',
+    'CREATE INDEX idx_audios_local_uri ON audios (local_uri)',
+  );
+  late final Index idxAudiosMd5 = Index(
+    'idx_audios_md5',
+    'CREATE INDEX idx_audios_md5 ON audios (md5)',
+  );
+  late final Index idxTranscriptsTarget = Index(
+    'idx_transcripts_target',
+    'CREATE INDEX idx_transcripts_target ON transcripts (target_type, target_id)',
+  );
   late final Index idxTranscriptFetchStatesTarget = Index(
     'idx_transcript_fetch_states_target',
     'CREATE INDEX idx_transcript_fetch_states_target ON transcript_fetch_states (target_type, target_id)',
+  );
+  late final Index idxEchoSessionsTargetActive = Index(
+    'idx_echo_sessions_target_active',
+    'CREATE INDEX idx_echo_sessions_target_active ON echo_sessions (target_type, target_id, last_active_at)',
+  );
+  late final Index idxRecordingsTarget = Index(
+    'idx_recordings_target',
+    'CREATE INDEX idx_recordings_target ON recordings (target_type, target_id)',
+  );
+  late final Index idxDictationsTarget = Index(
+    'idx_dictations_target',
+    'CREATE INDEX idx_dictations_target ON dictations (target_type, target_id)',
+  );
+  late final Index idxSyncQueueRetryCreated = Index(
+    'idx_sync_queue_retry_created',
+    'CREATE INDEX idx_sync_queue_retry_created ON sync_queue (retry_count, created_at)',
+  );
+  late final Index idxYoutubeFeedEntriesChannelPublished = Index(
+    'idx_youtube_feed_entries_channel_published',
+    'CREATE INDEX idx_youtube_feed_entries_channel_published ON youtube_feed_entries (channel_id, published_at)',
+  );
+  late final Index idxYoutubeFeedEntriesPublished = Index(
+    'idx_youtube_feed_entries_published',
+    'CREATE INDEX idx_youtube_feed_entries_published ON youtube_feed_entries (published_at)',
   );
   late final Index idxVocabularyItemsWordLanguage = Index(
     'idx_vocabulary_items_word_language',
@@ -11507,7 +11551,18 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     vocabularyItems,
     vocabularyContexts,
     vocabularyReviews,
+    idxVideosProviderVid,
+    idxVideosLocalUri,
+    idxAudiosLocalUri,
+    idxAudiosMd5,
+    idxTranscriptsTarget,
     idxTranscriptFetchStatesTarget,
+    idxEchoSessionsTargetActive,
+    idxRecordingsTarget,
+    idxDictationsTarget,
+    idxSyncQueueRetryCreated,
+    idxYoutubeFeedEntriesChannelPublished,
+    idxYoutubeFeedEntriesPublished,
     idxVocabularyItemsWordLanguage,
     idxVocabularyItemsNextReviewAt,
     idxVocabularyItemsStatus,

--- a/lib/data/db/daos/ai_cache_dao.dart
+++ b/lib/data/db/daos/ai_cache_dao.dart
@@ -59,18 +59,14 @@ class AiCacheDao extends DatabaseAccessor<AppDatabase> with _$AiCacheDaoMixin {
               .getSingle();
       if (total <= keep) return 0;
       final toDelete = total - keep;
-      final beforeKeys = await customSelect(
-        'SELECT key FROM ai_cache WHERE kind = ? '
-        'ORDER BY updated_at ASC LIMIT ?',
-        variables: [Variable.withString(kind), Variable.withInt(toDelete)],
-        readsFrom: {aiCache},
-      ).map((row) => row.read<String>('key')).get();
-      for (final k in beforeKeys) {
-        await (delete(
-          aiCache,
-        )..where((t) => t.kind.equals(kind) & t.key.equals(k))).go();
-      }
-      return beforeKeys.length;
+      // Single-statement bulk DELETE (issue #478): avoids N round-trips
+      // and N fsyncs when evicting many keys.
+      await customStatement(
+        'DELETE FROM ai_cache WHERE kind = ? AND key IN '
+        '(SELECT key FROM ai_cache WHERE kind = ? ORDER BY updated_at ASC LIMIT ?)',
+        [kind, kind, toDelete],
+      );
+      return toDelete;
     } on Object catch (e, st) {
       _log.warning('ai_cache evictOldestExcept failed kind=$kind', e, st);
       return -1;
@@ -108,6 +104,31 @@ class AiCacheDao extends DatabaseAccessor<AppDatabase> with _$AiCacheDaoMixin {
       await (delete(aiCache)..where((t) => t.kind.equals(kind))).go();
     } on Object catch (e, st) {
       _log.warning('ai_cache deleteForKind failed kind=$kind', e, st);
+    }
+  }
+
+  /// Bulk-deletes every row whose `payload_json` matches both LIKE patterns
+  /// in a single SQL statement (issue #478). Returns the number of deleted
+  /// rows.
+  Future<int> deleteByPayloadLike(String pattern1, String pattern2) async {
+    try {
+      final count =
+          await (selectOnly(aiCache)
+                ..addColumns([aiCache.key.count()])
+                ..where(
+                  aiCache.payloadJson.like(pattern1) &
+                      aiCache.payloadJson.like(pattern2),
+                ))
+              .map((row) => row.read<int>(aiCache.key.count()) ?? 0)
+              .getSingle();
+      await customStatement(
+        'DELETE FROM ai_cache WHERE payload_json LIKE ? AND payload_json LIKE ?',
+        [pattern1, pattern2],
+      );
+      return count;
+    } on Object catch (e, st) {
+      _log.warning('ai_cache deleteByPayloadLike failed', e, st);
+      return -1;
     }
   }
 

--- a/lib/data/db/daos/audio_dao.dart
+++ b/lib/data/db/daos/audio_dao.dart
@@ -39,11 +39,19 @@ class AudioDao extends DatabaseAccessor<AppDatabase> with _$AudioDaoMixin {
   Future<void> deleteId(String id) =>
       (delete(audios)..where((t) => t.id.equals(id))).go();
 
-  /// Rows whose [Audios.localUri] equals [localUri] (exact string match).
-  Future<int> countByLocalUri(String localUri) async {
-    final rows = await (select(
-      audios,
-    )..where((t) => t.localUri.equals(localUri))).get();
-    return rows.length;
+  /// Whether any row's [Audios.localUri] equals [localUri] (exact match).
+  ///
+  /// Uses `SELECT 1 … LIMIT 1` (EXISTS) instead of materialising full rows
+  /// just to count them — paired with the `idx_audios_local_uri` index added
+  /// in migration 16 (issue #469).
+  Future<bool> existsByLocalUri(String localUri) async {
+    final row =
+        await (selectOnly(audios)
+              ..addColumns([audios.id])
+              ..where(audios.localUri.equals(localUri))
+              ..limit(1))
+            .map((r) => r.read(audios.id))
+            .getSingleOrNull();
+    return row != null;
   }
 }

--- a/lib/data/db/daos/video_dao.dart
+++ b/lib/data/db/daos/video_dao.dart
@@ -69,11 +69,19 @@ class VideoDao extends DatabaseAccessor<AppDatabase> with _$VideoDaoMixin {
   Future<void> deleteId(String id) =>
       (delete(videos)..where((t) => t.id.equals(id))).go();
 
-  /// Rows whose [Videos.localUri] equals [localUri] (exact string match).
-  Future<int> countByLocalUri(String localUri) async {
-    final rows = await (select(
-      videos,
-    )..where((t) => t.localUri.equals(localUri))).get();
-    return rows.length;
+  /// Whether any row's [Videos.localUri] equals [localUri] (exact match).
+  ///
+  /// Uses `SELECT 1 … LIMIT 1` (EXISTS) instead of materialising full rows
+  /// just to count them — paired with the `idx_videos_local_uri` index added
+  /// in migration 16 (issue #469).
+  Future<bool> existsByLocalUri(String localUri) async {
+    final row =
+        await (selectOnly(videos)
+              ..addColumns([videos.id])
+              ..where(videos.localUri.equals(localUri))
+              ..limit(1))
+            .map((r) => r.read(videos.id))
+            .getSingleOrNull();
+    return row != null;
   }
 }

--- a/lib/data/db/tables/audios.dart
+++ b/lib/data/db/tables/audios.dart
@@ -5,6 +5,8 @@ import 'package:drift/drift.dart';
 
 import 'sync_metadata.dart';
 
+@TableIndex(name: 'idx_audios_local_uri', columns: {#localUri})
+@TableIndex(name: 'idx_audios_md5', columns: {#md5})
 @DataClassName('AudioRow')
 class Audios extends Table with SyncMetadataColumns {
   @override

--- a/lib/data/db/tables/dictations.dart
+++ b/lib/data/db/tables/dictations.dart
@@ -5,6 +5,7 @@ import 'package:drift/drift.dart';
 
 import 'sync_metadata.dart';
 
+@TableIndex(name: 'idx_dictations_target', columns: {#targetType, #targetId})
 @DataClassName('DictationRow')
 class Dictations extends Table with SyncMetadataColumns {
   @override

--- a/lib/data/db/tables/echo_sessions.dart
+++ b/lib/data/db/tables/echo_sessions.dart
@@ -5,6 +5,10 @@ import 'package:drift/drift.dart';
 
 import 'sync_metadata.dart';
 
+@TableIndex(
+  name: 'idx_echo_sessions_target_active',
+  columns: {#targetType, #targetId, #lastActiveAt},
+)
 @DataClassName('EchoSessionRow')
 class EchoSessions extends Table with SyncMetadataColumns {
   @override

--- a/lib/data/db/tables/recordings.dart
+++ b/lib/data/db/tables/recordings.dart
@@ -5,6 +5,7 @@ import 'package:drift/drift.dart';
 
 import 'sync_metadata.dart';
 
+@TableIndex(name: 'idx_recordings_target', columns: {#targetType, #targetId})
 @DataClassName('RecordingRow')
 class Recordings extends Table with SyncMetadataColumns {
   @override

--- a/lib/data/db/tables/sync_queue.dart
+++ b/lib/data/db/tables/sync_queue.dart
@@ -3,6 +3,10 @@ library;
 
 import 'package:drift/drift.dart';
 
+@TableIndex(
+  name: 'idx_sync_queue_retry_created',
+  columns: {#retryCount, #createdAt},
+)
 @DataClassName('SyncQueueRow')
 class SyncQueue extends Table {
   @override

--- a/lib/data/db/tables/transcripts.dart
+++ b/lib/data/db/tables/transcripts.dart
@@ -5,6 +5,7 @@ import 'package:drift/drift.dart';
 
 import 'sync_metadata.dart';
 
+@TableIndex(name: 'idx_transcripts_target', columns: {#targetType, #targetId})
 @DataClassName('TranscriptRow')
 class Transcripts extends Table with SyncMetadataColumns {
   @override

--- a/lib/data/db/tables/videos.dart
+++ b/lib/data/db/tables/videos.dart
@@ -5,6 +5,8 @@ import 'package:drift/drift.dart';
 
 import 'sync_metadata.dart';
 
+@TableIndex(name: 'idx_videos_provider_vid', columns: {#provider, #vid})
+@TableIndex(name: 'idx_videos_local_uri', columns: {#localUri})
 @DataClassName('VideoRow')
 class Videos extends Table with SyncMetadataColumns {
   @override

--- a/lib/data/db/tables/youtube_feed_entries.dart
+++ b/lib/data/db/tables/youtube_feed_entries.dart
@@ -3,6 +3,11 @@ library;
 
 import 'package:drift/drift.dart';
 
+@TableIndex(
+  name: 'idx_youtube_feed_entries_channel_published',
+  columns: {#channelId, #publishedAt},
+)
+@TableIndex(name: 'idx_youtube_feed_entries_published', columns: {#publishedAt})
 @DataClassName('YoutubeFeedEntryRow')
 class YoutubeFeedEntries extends Table {
   @override

--- a/lib/data/files/app_managed_media_gc.dart
+++ b/lib/data/files/app_managed_media_gc.dart
@@ -25,9 +25,9 @@ Future<bool> isAppManagedMediaStillReferenced({
   if (!await isAppManagedMediaPath(fileUri)) return false;
 
   final inCurrent =
-      await db.audioDao.countByLocalUri(fileUri) +
-      await db.videoDao.countByLocalUri(fileUri);
-  if (inCurrent > 0) return true;
+      await db.audioDao.existsByLocalUri(fileUri) ||
+      await db.videoDao.existsByLocalUri(fileUri);
+  if (inCurrent) return true;
 
   return _otherPerUserDbReferencesLocalUri(
     currentDbBaseName: db.databaseFileBaseName,

--- a/lib/features/ai/application/ai_result_cache.dart
+++ b/lib/features/ai/application/ai_result_cache.dart
@@ -18,8 +18,6 @@ import 'dart:convert';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'package:drift/drift.dart' show Variable;
-
 import 'package:enjoy_player/core/cache/lru_store.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
@@ -169,28 +167,14 @@ abstract class AiResultCache<V extends Object> {
     required String sourceLanguage,
     required String targetLanguage,
   }) async {
-    // L2: LIKE scan, then DELETE per row.
+    // L2: single-statement bulk DELETE (issue #478) — replaces the previous
+    // SELECT-then-per-row-DELETE loop.
     final srcPattern = '%"sourceLanguage":"$sourceLanguage"%';
     final tgtPattern = '%"targetLanguage":"$targetLanguage"%';
-    final rows = await _dao
-        .customSelect(
-          'SELECT kind, key FROM ai_cache '
-          'WHERE payload_json LIKE ? AND payload_json LIKE ?',
-          variables: [
-            Variable.withString(srcPattern),
-            Variable.withString(tgtPattern),
-          ],
-          readsFrom: {_dao.aiCache},
-        )
-        .get();
-    for (final row in rows) {
-      final kind = row.read<String>('kind');
-      final key = row.read<String>('key');
-      await _dao.deleteRow(kind, key);
-    }
+    final deleted = await _dao.deleteByPayloadLike(srcPattern, tgtPattern);
     _log.info(
       'ai_cache evict_for_pair src=$sourceLanguage tgt=$targetLanguage '
-      'l2=${rows.length}',
+      'l2=$deleted',
     );
   }
 
@@ -323,6 +307,33 @@ class AiContextualTranslationCache
 // Riverpod providers
 // ---------------------------------------------------------------------------
 
+/// Coalesces the startup prune pass for all AI cache kinds (issue #478).
+///
+/// Previously each of the four cache providers called `unawaited(cache.prune())`
+/// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
+/// table racing on the same Drift executor. This provider runs the prune once
+/// per database instance; each cache provider watches it to ensure it has
+/// fired before the cache is used.
+@Riverpod(keepAlive: true)
+void aiCacheStartupPrune(Ref ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final policies = defaultAiKindPolicies;
+  unawaited(() async {
+    final now = DateTime.now();
+    for (final entry in policies.entries) {
+      final kind = entry.key;
+      final policy = entry.value;
+      if (policy.l2RowCap > 0) {
+        await db.aiCacheDao.evictOldestExcept(kind.wire, policy.l2RowCap);
+      }
+      if (policy.l2AgeCutoff > Duration.zero) {
+        final cutoff = now.subtract(policy.l2AgeCutoff);
+        await db.aiCacheDao.pruneOlderThan(kind.wire, cutoff);
+      }
+    }
+  }());
+}
+
 /// Per-user `AiMapCache` (JSON-typed payload). Cleared on sign-out /
 /// user-id change.
 ///
@@ -359,9 +370,7 @@ AiMapCache aiResultCache(Ref ref) {
     }
   });
 
-  // Best-effort maintenance at startup.
-  unawaited(cache.prune());
-
+  ref.watch(aiCacheStartupPruneProvider);
   return cache;
 }
 
@@ -391,7 +400,7 @@ AiTranslationCache aiTranslationCache(Ref ref) {
       unawaited(cache.clear());
     }
   });
-  unawaited(cache.prune());
+  ref.watch(aiCacheStartupPruneProvider);
   return cache;
 }
 
@@ -420,7 +429,7 @@ AiDictionaryCache aiDictionaryCache(Ref ref) {
       unawaited(cache.clear());
     }
   });
-  unawaited(cache.prune());
+  ref.watch(aiCacheStartupPruneProvider);
   return cache;
 }
 
@@ -449,6 +458,6 @@ AiContextualTranslationCache aiContextualTranslationCache(Ref ref) {
       unawaited(cache.clear());
     }
   });
-  unawaited(cache.prune());
+  ref.watch(aiCacheStartupPruneProvider);
   return cache;
 }

--- a/lib/features/ai/application/ai_result_cache.g.dart
+++ b/lib/features/ai/application/ai_result_cache.g.dart
@@ -8,6 +8,71 @@ part of 'ai_result_cache.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Coalesces the startup prune pass for all AI cache kinds (issue #478).
+///
+/// Previously each of the four cache providers called `unawaited(cache.prune())`
+/// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
+/// table racing on the same Drift executor. This provider runs the prune once
+/// per database instance; each cache provider watches it to ensure it has
+/// fired before the cache is used.
+
+@ProviderFor(aiCacheStartupPrune)
+final aiCacheStartupPruneProvider = AiCacheStartupPruneProvider._();
+
+/// Coalesces the startup prune pass for all AI cache kinds (issue #478).
+///
+/// Previously each of the four cache providers called `unawaited(cache.prune())`
+/// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
+/// table racing on the same Drift executor. This provider runs the prune once
+/// per database instance; each cache provider watches it to ensure it has
+/// fired before the cache is used.
+
+final class AiCacheStartupPruneProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Coalesces the startup prune pass for all AI cache kinds (issue #478).
+  ///
+  /// Previously each of the four cache providers called `unawaited(cache.prune())`
+  /// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
+  /// table racing on the same Drift executor. This provider runs the prune once
+  /// per database instance; each cache provider watches it to ensure it has
+  /// fired before the cache is used.
+  AiCacheStartupPruneProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'aiCacheStartupPruneProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$aiCacheStartupPruneHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return aiCacheStartupPrune(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$aiCacheStartupPruneHash() =>
+    r'5811f5235124494ebaf5495fc005e3c96f40199a';
+
 /// Per-user `AiMapCache` (JSON-typed payload). Cleared on sign-out /
 /// user-id change.
 ///
@@ -67,7 +132,7 @@ final class AiResultCacheProvider
   }
 }
 
-String _$aiResultCacheHash() => r'1174c0e7699ae9017884ae7d4a602658ccc30ac1';
+String _$aiResultCacheHash() => r'a091f85bdab587328537b1aa67a201f36011c981';
 
 /// Per-user `AiTranslationCache` (typed `TranslationResult`). Shares the
 /// L2 Drift table with `aiResultCache` (different `AiKind.wire`).
@@ -123,7 +188,7 @@ final class AiTranslationCacheProvider
 }
 
 String _$aiTranslationCacheHash() =>
-    r'2d0c04ebd0e3399a66fecf1b0ca485f84fd39ffe';
+    r'255329c8a3653ebc1da72377c4104f25e794e5c0';
 
 /// Per-user `AiDictionaryCache`.
 
@@ -175,7 +240,7 @@ final class AiDictionaryCacheProvider
   }
 }
 
-String _$aiDictionaryCacheHash() => r'217497e734742cd533a39726ebbe94371710e782';
+String _$aiDictionaryCacheHash() => r'3faf13ed889a1d005279546fa66e64256ca91d75';
 
 /// Per-user `AiContextualTranslationCache`.
 
@@ -229,4 +294,4 @@ final class AiContextualTranslationCacheProvider
 }
 
 String _$aiContextualTranslationCacheHash() =>
-    r'4718d09d436cc5c94da273658fbcec3f1ae9d5dc';
+    r'5429bf6ef754e46ceee108a9cb27d0c8004da09c';

--- a/test/data/db/daos/ai_cache_dao_test.dart
+++ b/test/data/db/daos/ai_cache_dao_test.dart
@@ -139,5 +139,52 @@ void main() {
       final all = await db.aiCacheDao.readAllForKind('dictionary').first;
       expect(all.map((r) => r.key).toSet(), {'a', 'b'});
     });
+
+    test(
+      'deleteByPayloadLike bulk-deletes matching rows in one statement',
+      () async {
+        await db.aiCacheDao.upsert(
+          'translation',
+          'k1',
+          '{"sourceLanguage":"en","targetLanguage":"es"}',
+          DateTime.utc(2026),
+        );
+        await db.aiCacheDao.upsert(
+          'translation',
+          'k2',
+          '{"sourceLanguage":"en","targetLanguage":"ja"}',
+          DateTime.utc(2026),
+        );
+        await db.aiCacheDao.upsert(
+          'translation',
+          'k3',
+          '{"sourceLanguage":"fr","targetLanguage":"de"}',
+          DateTime.utc(2026),
+        );
+
+        final deleted = await db.aiCacheDao.deleteByPayloadLike(
+          '%"sourceLanguage":"en"%',
+          '%"targetLanguage":"es"%',
+        );
+        expect(deleted, 1);
+        expect(await db.aiCacheDao.read('translation', 'k1'), isNull);
+        expect(await db.aiCacheDao.read('translation', 'k2'), isNotNull);
+        expect(await db.aiCacheDao.read('translation', 'k3'), isNotNull);
+      },
+    );
+
+    test('deleteByPayloadLike returns 0 when no rows match', () async {
+      await db.aiCacheDao.upsert(
+        'translation',
+        'k1',
+        '{"sourceLanguage":"en"}',
+        DateTime.utc(2026),
+      );
+      final deleted = await db.aiCacheDao.deleteByPayloadLike(
+        '%"sourceLanguage":"xx"%',
+        '%"targetLanguage":"yy"%',
+      );
+      expect(deleted, 0);
+    });
   });
 }

--- a/test/data/db/daos/audio_dao_test.dart
+++ b/test/data/db/daos/audio_dao_test.dart
@@ -112,13 +112,13 @@ void main() {
       expect(await db.audioDao.getById('keep'), isNotNull);
     });
 
-    test('countByLocalUri counts matching rows', () async {
+    test('existsByLocalUri returns true for matching rows', () async {
       await db.audioDao.insertRow(_audioRow(id: '1', localUri: 'file://1'));
       await db.audioDao.insertRow(_audioRow(id: '2', localUri: 'file://1'));
       await db.audioDao.insertRow(_audioRow(id: '3', localUri: 'file://2'));
-      expect(await db.audioDao.countByLocalUri('file://1'), 2);
-      expect(await db.audioDao.countByLocalUri('file://2'), 1);
-      expect(await db.audioDao.countByLocalUri('file://3'), 0);
+      expect(await db.audioDao.existsByLocalUri('file://1'), isTrue);
+      expect(await db.audioDao.existsByLocalUri('file://2'), isTrue);
+      expect(await db.audioDao.existsByLocalUri('file://3'), isFalse);
     });
 
     test('watchAll emits rows ordered by createdAt descending', () async {

--- a/test/data/db/daos/video_dao_test.dart
+++ b/test/data/db/daos/video_dao_test.dart
@@ -169,13 +169,18 @@ void main() {
       expect(await db.videoDao.getById('v-1'), isNull);
     });
 
-    test('countByLocalUri returns matching rows count', () async {
+    test('existsByLocalUri returns true for matching rows', () async {
       await db.videoDao.insertRow(_video(id: 'a', localUri: '/tmp/a.mp4'));
       await db.videoDao.insertRow(_video(id: 'b', localUri: '/tmp/a.mp4'));
       await db.videoDao.insertRow(_video(id: 'c', localUri: '/tmp/b.mp4'));
-      final n = await db.videoDao.countByLocalUri('/tmp/a.mp4');
-      expect(n, 2);
-      expect(await db.videoDao.countByLocalUri('/tmp/missing'), 0);
+      expect(await db.videoDao.existsByLocalUri('/tmp/a.mp4'), isTrue);
+      expect(await db.videoDao.existsByLocalUri('/tmp/b.mp4'), isTrue);
+      expect(await db.videoDao.existsByLocalUri('/tmp/missing'), isFalse);
+    });
+
+    test('existsByLocalUri returns false for null localUri rows', () async {
+      await db.videoDao.insertRow(_video(id: 'a'));
+      expect(await db.videoDao.existsByLocalUri('/tmp/a.mp4'), isFalse);
     });
   });
 }

--- a/test/data/db/migration_16_indexes_test.dart
+++ b/test/data/db/migration_16_indexes_test.dart
@@ -1,0 +1,80 @@
+import 'package:drift/drift.dart' show Variable;
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('migration 16 — hot-read-path indexes', () {
+    late AppDatabase db;
+
+    setUp(() {
+      db = AppDatabase(executor: NativeDatabase.memory());
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('schemaVersion is 16', () {
+      expect(db.schemaVersion, 16);
+    });
+
+    test('all covering indexes exist after fresh create', () async {
+      final indexes = await db
+          .customSelect(
+            "SELECT name FROM sqlite_master WHERE type = 'index' "
+            "AND name LIKE 'idx_%' ORDER BY name",
+          )
+          .get();
+      final names = indexes.map((r) => r.read<String>('name')).toSet();
+
+      // Migration 16 indexes (issue #467) — declared as @TableIndex on the
+      // table classes so createAll() creates them on fresh databases, and
+      // also in migration step 16 for upgrades.
+      expect(
+        names,
+        containsAll([
+          'idx_transcripts_target',
+          'idx_recordings_target',
+          'idx_echo_sessions_target_active',
+          'idx_videos_provider_vid',
+          'idx_videos_local_uri',
+          'idx_audios_local_uri',
+          'idx_audios_md5',
+          'idx_dictations_target',
+          'idx_youtube_feed_entries_channel_published',
+          'idx_youtube_feed_entries_published',
+          'idx_sync_queue_retry_created',
+        ]),
+      );
+    });
+
+    test('transcripts index is usable by EXPLAIN QUERY PLAN', () async {
+      final plan = await db
+          .customSelect(
+            'EXPLAIN QUERY PLAN '
+            'SELECT 1 FROM transcripts WHERE target_type = ? AND target_id = ? '
+            'LIMIT 1',
+            variables: [
+              Variable.withString('Video'),
+              Variable.withString('v-1'),
+            ],
+          )
+          .get();
+      final planText = plan.map((r) => r.read<String>('detail')).join('\n');
+      expect(planText, contains('idx_transcripts_target'));
+    });
+
+    test('videos local_uri index is usable by EXISTS query', () async {
+      final plan = await db
+          .customSelect(
+            'EXPLAIN QUERY PLAN '
+            'SELECT 1 FROM videos WHERE local_uri = ? LIMIT 1',
+            variables: [Variable.withString('/tmp/test.mp4')],
+          )
+          .get();
+      final planText = plan.map((r) => r.read<String>('detail')).join('\n');
+      expect(planText, contains('idx_videos_local_uri'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Resolves #467,  resolves #469, resolves #478.

### #467 — Missing SQLite indexes on hot read paths
- Bumped `schemaVersion` 15 → 16
- Added `@TableIndex` annotations + migration step 16 for 11 covering indexes:
  - `transcripts (target_type, target_id)`
  - `recordings (target_type, target_id)`
  - `echo_sessions (target_type, target_id, last_active_at)`
  - `videos (provider, vid)` + `videos (local_uri)`
  - `audios (local_uri)` + `audios (md5)`
  - `dictations (target_type, target_id)`
  - `youtube_feed_entries (channel_id, published_at)` + `youtube_feed_entries (published_at)`
  - `sync_queue (retry_count, created_at)`

### #469 — Replace countByLocalUri with EXISTS
- Replaced `countByLocalUri` (full-row materialization → `.length`) with `existsByLocalUri` (`SELECT 1 … LIMIT 1`) in `VideoDao` and `AudioDao`
- Updated `app_managed_media_gc.dart` callers

### #478 — Batch AI cache eviction + coalesce startup prune
- `evictOldestExcept`: single bulk `DELETE … WHERE key IN (subquery)` instead of per-key loop
- Added `deleteByPayloadLike` for `evictForPair`: single `DELETE … WHERE payload_json LIKE ? AND … LIKE ?`
- Coalesced four startup `prune()` calls into a single `aiCacheStartupPruneProvider`

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 4992 pass
- [x] Schema migration test asserts all 11 indexes exist after fresh create
- [x] EXPLAIN QUERY PLAN confirms index usage
- [x] DAO tests for `existsByLocalUri` and `deleteByPayloadLike`