### PR TITLE
perf: N+1 elimination, batch writes, sync parallelization (#468 #481)

### DIFF
--- a/lib/data/db/daos/sync_queue_dao.dart
+++ b/lib/data/db/daos/sync_queue_dao.dart
@@ -26,26 +26,33 @@ class SyncQueueDao extends DatabaseAccessor<AppDatabase>
             ..limit(limit))
           .get();
 
+  /// Increments `retry_count` and stamps `last_attempt` + `error` in a
+  /// single set-based UPDATE — no SELECT round-trip (issue #468).
   Future<void> markAttempted(int id, {String? error}) async {
-    final existing = await (select(
-      syncQueue,
-    )..where((t) => t.id.equals(id))).getSingleOrNull();
-    if (existing == null) return;
-    await (update(syncQueue)..where((t) => t.id.equals(id))).write(
-      SyncQueueCompanion(
-        retryCount: Value(existing.retryCount + 1),
-        lastAttempt: Value(DateTime.now()),
-        error: Value(error),
-      ),
-    );
+    if (error == null) {
+      await customUpdate(
+        'UPDATE sync_queue SET retry_count = retry_count + 1, '
+        'last_attempt = ?, error = NULL WHERE id = ?',
+        variables: [Variable.withDateTime(DateTime.now()), Variable.withInt(id)],
+        updates: {syncQueue},
+      );
+    } else {
+      await customUpdate(
+        'UPDATE sync_queue SET retry_count = retry_count + 1, '
+        'last_attempt = ?, error = ? WHERE id = ?',
+        variables: [
+          Variable.withDateTime(DateTime.now()),
+          Variable.withString(error),
+          Variable.withInt(id),
+        ],
+        updates: {syncQueue},
+      );
+    }
   }
 
   /// Sets [retryCount] to 5 so the row is no longer eligible for retry.
+  /// Direct UPDATE — no SELECT round-trip (issue #468).
   Future<void> markPermanentlyFailed(int id, {String? error}) async {
-    final existing = await (select(
-      syncQueue,
-    )..where((t) => t.id.equals(id))).getSingleOrNull();
-    if (existing == null) return;
     await (update(syncQueue)..where((t) => t.id.equals(id))).write(
       SyncQueueCompanion(
         retryCount: const Value(5),

--- a/lib/data/db/daos/vocabulary_context_dao.dart
+++ b/lib/data/db/daos/vocabulary_context_dao.dart
@@ -10,6 +10,16 @@ class VocabularyContextDao extends DatabaseAccessor<AppDatabase>
         vocabularyContexts,
       )..where((t) => t.vocabularyItemId.equals(vocabularyItemId))).get();
 
+  /// Bulk-fetch all contexts for the given item ids in a single query
+  /// (issue #468 — eliminates N+1 in vocabulary export).
+  Future<List<VocabularyContextRow>> getByItemIds(Iterable<String> itemIds) {
+    final ids = itemIds.toList();
+    if (ids.isEmpty) return Future.value([]);
+    return (select(
+      vocabularyContexts,
+    )..where((t) => t.vocabularyItemId.isIn(ids))).get();
+  }
+
   Future<List<VocabularyContextRow>> getByItemAndSource({
     required String vocabularyItemId,
     required String sourceType,

--- a/lib/features/library/data/library_repository.dart
+++ b/lib/features/library/data/library_repository.dart
@@ -580,13 +580,11 @@ class MediaLibraryRepository {
 
       // Drop all prior transcripts for this media — solid rewrite replaces
       // the primary track; blank clears estimated/stale cues entirely.
-      final oldTranscripts = await _db.transcriptDao.listForTarget(
-        'Audio',
-        mediaId,
+      // Single bulk DELETE instead of per-row loop (issue #468).
+      await _db.customStatement(
+        'DELETE FROM transcripts WHERE target_type = ? AND target_id = ?',
+        ['Audio', mediaId],
       );
-      for (final t in oldTranscripts) {
-        await _db.transcriptDao.deleteId(t.id);
-      }
 
       if (primaryTimelineJson != null) {
         await _db.transcriptDao.upsert(

--- a/lib/features/sync/application/sync_engine.dart
+++ b/lib/features/sync/application/sync_engine.dart
@@ -68,16 +68,25 @@ class SyncEngine {
     // library (ADR-0013). Vocabulary is an intentional exception — a
     // cross-device word book, not local-path media — so it pulls on every
     // signed-in sync alongside the outbound queue drain (ADR-0054).
-    final queueResult = await processQueue(options);
-    final vocabResult = await pullVocabulary();
-    return queueResult.merge(vocabResult);
+    //
+    // processQueue and pullVocabulary don't share state — run them
+    // concurrently (issue #481).
+    final results = await Future.wait([
+      processQueue(options),
+      pullVocabulary(),
+    ]);
+    return results[0].merge(results[1]);
   }
 
   /// Pulls vocabulary items + contexts (ADR-0054 auto-pull exception).
+  ///
+  /// Items + contexts are independent — fetched concurrently (issue #481).
   Future<SyncResult> pullVocabulary() async {
-    final items = await _download.downloadVocabularyItems();
-    final contexts = await _download.downloadVocabularyContexts();
-    return items.merge(contexts);
+    final results = await Future.wait([
+      _download.downloadVocabularyItems(),
+      _download.downloadVocabularyContexts(),
+    ]);
+    return results[0].merge(results[1]);
   }
 
   /// Drains the outbound sync queue.

--- a/lib/features/sync/data/sync_queue_repository.dart
+++ b/lib/features/sync/data/sync_queue_repository.dart
@@ -116,22 +116,25 @@ class SyncQueueRepository {
       _db.syncQueueDao.markPermanentlyFailed(id, error: error);
 
   /// Clears error state for permanently failed items so they retry again.
+  ///
+  /// Single bulk UPDATE instead of SELECT+loop-UPDATE (issue #468).
   Future<int> resetFailed() async {
-    final failed = await (_db.select(
+    final failed =
+        await (_db.selectOnly(_db.syncQueue)
+              ..addColumns([_db.syncQueue.id.count()])
+              ..where(_db.syncQueue.retryCount.isBiggerOrEqualValue(5)))
+            .map((row) => row.read<int>(_db.syncQueue.id.count()) ?? 0)
+            .getSingle();
+    if (failed == 0) return 0;
+    await (_db.update(
       _db.syncQueue,
-    )..where((t) => t.retryCount.isBiggerOrEqualValue(5))).get();
-
-    for (final item in failed) {
-      await (_db.update(
-        _db.syncQueue,
-      )..where((t) => t.id.equals(item.id))).write(
-        const SyncQueueCompanion(
-          retryCount: Value(0),
-          error: Value(null),
-          lastAttempt: Value(null),
-        ),
-      );
-    }
-    return failed.length;
+    )..where((t) => t.retryCount.isBiggerOrEqualValue(5))).write(
+      const SyncQueueCompanion(
+        retryCount: Value(0),
+        error: Value(null),
+        lastAttempt: Value(null),
+      ),
+    );
+    return failed;
   }
 }

--- a/lib/features/transcript/data/transcript_repository.dart
+++ b/lib/features/transcript/data/transcript_repository.dart
@@ -14,6 +14,7 @@ import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 import 'package:cross_file/cross_file.dart';
+import 'package:drift/drift.dart' show InsertMode;
 import 'package:logging/logging.dart';
 import 'package:media_kit/media_kit.dart' as mk;
 import 'package:path/path.dart' as p;
@@ -199,13 +200,13 @@ class TranscriptRepository {
       return const TranscriptResolveResult(hasTracks: false);
     }
 
-    await ensurePrimaryTranscript(mediaId);
+    await ensurePrimaryTranscript(mediaId, targetType: tt);
     try {
       await importSidecarSubtitles(mediaId);
     } on Object catch (e, st) {
       _log.warning('importSidecarSubtitles failed for $mediaId', e, st);
     }
-    await ensurePrimaryTranscript(mediaId);
+    await ensurePrimaryTranscript(mediaId, targetType: tt);
 
     TranscriptCloudFetchResult cloud = const TranscriptCloudFetchResult(
       status: TranscriptCloudFetchStatus.skipped,
@@ -217,7 +218,7 @@ class TranscriptRepository {
         nativeLanguage: nativeLanguage,
         learningLanguage: learningLanguage,
       );
-      await ensurePrimaryTranscript(mediaId);
+      await ensurePrimaryTranscript(mediaId, targetType: tt);
     }
 
     final hasTracks = (await _db.transcriptDao.listForTarget(
@@ -240,8 +241,15 @@ class TranscriptRepository {
   }
 
   /// Assigns primary transcript when tracks exist but session has none.
-  Future<bool> ensurePrimaryTranscript(String mediaId) async {
-    final tt = await dexieTargetTypeForId(_db, mediaId);
+  ///
+  /// When [targetType] is provided, skips the `dexieTargetTypeForId`
+  /// lookup (issue #481 — avoids redundant queries when the caller
+  /// already resolved the type).
+  Future<bool> ensurePrimaryTranscript(
+    String mediaId, {
+    String? targetType,
+  }) async {
+    final tt = targetType ?? await dexieTargetTypeForId(_db, mediaId);
     if (tt == null) return false;
 
     final session = await _db.echoSessionDao.getLatestForTarget(tt, mediaId);
@@ -352,13 +360,21 @@ class TranscriptRepository {
     try {
       final list = await api.transcripts(targetId: mediaId, targetType: tt);
       final now = DateTime.now();
-      var storedCount = 0;
+      final rowsToUpsert = <TranscriptRow>[];
       for (final item in list) {
         final row = _transcriptRowFromServerMap(item, fallbackNow: now);
-        if (row == null) continue;
-        await _db.transcriptDao.upsert(row);
-        storedCount++;
+        if (row != null) rowsToUpsert.add(row);
       }
+      if (rowsToUpsert.isNotEmpty) {
+        await _db.batch(
+          (b) => b.insertAll(
+            _db.transcripts,
+            rowsToUpsert,
+            mode: InsertMode.insertOrReplace,
+          ),
+        );
+      }
+      final storedCount = rowsToUpsert.length;
 
       if (list.isNotEmpty && storedCount == 0) {
         return const TranscriptCloudFetchResult(
@@ -368,7 +384,7 @@ class TranscriptRepository {
       }
 
       if (storedCount > 0) {
-        await ensurePrimaryTranscript(mediaId);
+        await ensurePrimaryTranscript(mediaId, targetType: tt);
         return TranscriptCloudFetchResult(
           status: TranscriptCloudFetchStatus.success,
           storedCount: storedCount,

--- a/lib/features/vocabulary/data/vocabulary_repository.dart
+++ b/lib/features/vocabulary/data/vocabulary_repository.dart
@@ -351,6 +351,9 @@ class VocabularyRepository {
   }
 
   /// Items + contexts for Anki export (caller applies filters).
+  ///
+  /// Contexts are fetched in a single `WHERE vocabulary_item_id IN (…)`
+  /// query instead of one query per item (issue #468).
   Future<
     ({
       List<VocabularyItem> items,
@@ -359,9 +362,13 @@ class VocabularyRepository {
   >
   loadExportBundle() async {
     final items = await listAll();
+    final allContexts = await _db.vocabularyContextDao.getByItemIds(
+      items.map((e) => e.id),
+    );
     final contextsByItemId = <String, List<VocabularyContext>>{};
-    for (final item in items) {
-      contextsByItemId[item.id] = await getContextsForItem(item.id);
+    for (final row in allContexts) {
+      final ctx = _contextFromRow(row);
+      (contextsByItemId[row.vocabularyItemId] ??= []).add(ctx);
     }
     return (items: items, contextsByItemId: contextsByItemId);
   }


### PR DESCRIPTION
## Summary

Resolves #468, resolves #481.

### #468 — Eliminate N+1 queries and use Drift batch() for bulk writes
- **Vocabulary export**: single `WHERE vocabulary_item_id IN (…)` query replaces per-item `getContextsForItem` loop (1000-word book = 1 query instead of 1000)
- **Cloud transcript upsert**: `db.batch()` replaces per-row `upsert` loop
- **Craft replace**: single bulk `DELETE … WHERE target_type = ? AND target_id = ?` replaces per-transcript delete loop
- **SyncQueue `markAttempted`**: set-based `UPDATE … SET retry_count = retry_count + 1` replaces SELECT-then-UPDATE round-trip
- **SyncQueue `markPermanentlyFailed`**: direct UPDATE (already set-based, removed redundant SELECT)
- **SyncQueue `resetFailed`**: single bulk `UPDATE … WHERE retry_count >= 5` replaces SELECT-then-loop-UPDATE

### #481 — Parallelize sync and de-duplicate resolveOnOpen queries
- **`fullSync`**: `Future.wait([processQueue, pullVocabulary])` — independent halves run concurrently
- **`pullVocabulary`**: `Future.wait([downloadItems, downloadContexts])` — independent downloads run concurrently
- **`ensurePrimaryTranscript`**: optional `targetType` parameter skips redundant `dexieTargetTypeForId` lookup in `resolveOnOpen` (was called 3× per media open, now 0× — target type resolved once at top)

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 4985 pass
- [x] All existing sync, vocabulary, and transcript tests pass unchanged