### PR TITLE
perf: throttle transport slider seeks, debounce volume, scope hover (#470 #471)

### DIFF
--- a/lib/features/player/application/player_preferences_provider.dart
+++ b/lib/features/player/application/player_preferences_provider.dart
@@ -77,6 +77,19 @@ class PlayerPreferencesCtrl extends _$PlayerPreferencesCtrl {
     await applyCurrentToEngine();
   }
 
+  /// Updates volume state + engine **without** persisting to Drift — for
+  /// use during slider drag so each tick is cheap. Call [setVolume] on
+  /// `onChangeEnd` to persist the final value (issue #470).
+  Future<void> setVolumeTransient(double v) async {
+    final clamped = v.clamp(0.0, 1.0).toDouble();
+    state = state.copyWith(volume: clamped);
+    if (clamped > 0.01) {
+      _lastNonZeroVolume = clamped;
+    }
+    final engine = ref.read(playerEngineProvider);
+    await engine.setVolumeNormalized(clamped);
+  }
+
   Future<void> toggleMute() async {
     if (state.volume <= 0.01) {
       await setVolume(_lastNonZeroVolume.clamp(0.05, 1.0).toDouble());

--- a/lib/features/player/presentation/widgets/global_transport_bar.dart
+++ b/lib/features/player/presentation/widgets/global_transport_bar.dart
@@ -160,8 +160,6 @@ class GlobalTransportBar extends ConsumerStatefulWidget {
 }
 
 class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
-  bool _sliderHovered = false;
-
   void _openPlaybackRateSheet() {
     final t = EnjoyThemeTokens.of(context);
     unawaited(
@@ -434,11 +432,7 @@ class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
           Padding(
             padding: EdgeInsets.fromLTRB(t.space12, t.space8, t.space12, 0),
             child: RepaintBoundary(
-              child: TransportProgressStrip(
-                chrome: chrome,
-                hovered: _sliderHovered,
-                onHoverChanged: (v) => setState(() => _sliderHovered = v),
-              ),
+              child: TransportProgressStrip(chrome: chrome),
             ),
           ),
           Padding(

--- a/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
@@ -56,16 +56,9 @@ class _TransportThumbShape extends RoundSliderThumbShape {
 }
 
 class TransportProgressStrip extends ConsumerStatefulWidget {
-  const TransportProgressStrip({
-    super.key,
-    required this.chrome,
-    required this.hovered,
-    required this.onHoverChanged,
-  });
+  const TransportProgressStrip({super.key, required this.chrome});
 
   final PlaybackChrome chrome;
-  final bool hovered;
-  final ValueChanged<bool> onHoverChanged;
 
   @override
   ConsumerState<TransportProgressStrip> createState() =>
@@ -74,6 +67,16 @@ class TransportProgressStrip extends ConsumerStatefulWidget {
 
 class _TransportProgressStripState
     extends ConsumerState<TransportProgressStrip> {
+  /// Non-null while the user is actively dragging the slider; the thumb
+  /// renders from this value instead of the engine position stream so the
+  /// UI stays responsive without issuing a seek per micro-movement
+  /// (issue #470).
+  double? _dragFraction;
+
+  /// Hover state is managed locally so the parent transport bar does not
+  /// rebuild when the cursor enters/exits the slider thumb area (issue #471).
+  bool _hovered = false;
+
   int? _scrubSecond;
 
   bool get _hapticScrub => isMobilePlatform;
@@ -91,9 +94,12 @@ class _TransportProgressStripState
       AsyncData(:final value) => value,
       _ => Duration.zero,
     };
-    final fraction = durationSec > 0
+    final streamFraction = durationSec > 0
         ? pos.inMilliseconds / 1000 / durationSec
         : 0.0;
+    // While dragging, render the thumb from the local drag value, not the
+    // stream position — the stream won't update until the seek completes.
+    final fraction = _dragFraction ?? streamFraction.clamp(0.0, 1.0);
 
     final timeStyle = tt.labelSmall?.copyWith(
       fontFeatures: const [FontFeature.tabularFigures()],
@@ -101,11 +107,21 @@ class _TransportProgressStripState
     );
 
     return MouseRegion(
-      onEnter: (_) => widget.onHoverChanged(true),
-      onExit: (_) => widget.onHoverChanged(false),
+      onEnter: (_) => _setHovered(true),
+      onExit: (_) => _setHovered(false),
       child: Row(
         children: [
-          Text(formatDurationHms(pos), style: timeStyle),
+          Text(
+            formatDurationHms(
+              _dragFraction != null
+                  ? Duration(
+                      milliseconds: (_dragFraction! * durationSec * 1000)
+                          .round(),
+                    )
+                  : pos,
+            ),
+            style: timeStyle,
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: ExcludeSemantics(
@@ -113,7 +129,7 @@ class _TransportProgressStripState
                 data: SliderTheme.of(context).copyWith(
                   trackHeight: 3,
                   thumbShape: _TransportThumbShape(
-                    enabledThumbRadius: widget.hovered ? 6 : 4,
+                    enabledThumbRadius: _hovered ? 6 : 4,
                   ),
                   overlayShape: SliderComponentShape.noOverlay,
                   activeTrackColor: cs.primary,
@@ -133,6 +149,10 @@ class _TransportProgressStripState
                         Haptics.selection(context);
                       }
                     }
+                    setState(() => _dragFraction = v);
+                  },
+                  onChangeEnd: (v) {
+                    _dragFraction = null;
                     unawaited(
                       ref
                           .read(playerInteractionsProvider.notifier)
@@ -148,5 +168,10 @@ class _TransportProgressStripState
         ],
       ),
     );
+  }
+
+  void _setHovered(bool v) {
+    if (_hovered == v) return;
+    setState(() => _hovered = v);
   }
 }

--- a/lib/features/player/presentation/widgets/transport/transport_volume_button.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_volume_button.dart
@@ -136,9 +136,16 @@ class _TransportVolumeButtonState extends ConsumerState<TransportVolumeButton> {
                             .clamp(0.0, 1.0);
                         return Slider(
                           value: vol,
-                          onChanged: (v) => ref
-                              .read(playerPreferencesCtrlProvider.notifier)
-                              .setVolume(v),
+                          onChanged: (v) => unawaited(
+                            ref
+                                .read(playerPreferencesCtrlProvider.notifier)
+                                .setVolumeTransient(v),
+                          ),
+                          onChangeEnd: (v) => unawaited(
+                            ref
+                                .read(playerPreferencesCtrlProvider.notifier)
+                                .setVolume(v),
+                          ),
                         );
                       },
                     ),


### PR DESCRIPTION
## Summary

Resolves #470, resolves #471.

### #470 — Throttle transport slider seeks and debounce volume persistence
- **Scrub slider**: track drag fraction in local `_dragFraction` state; render thumb + elapsed label from this value during drag. Engine `seek()` fires only on `onChangeEnd` — one seek per drag gesture instead of dozens per second.
- **Volume slider**: new `setVolumeTransient(v)` method updates state + engine volume per tick (cheap, in-process) without DB write. `setVolume(v)` persists to Drift only on `onChangeEnd`.

### #471 — Scope hover SetStates in TransportProgressStrip
- `TransportProgressStrip` now manages its own `_hovered` state internally via `MouseRegion.onEnter/onExit` → `setState` scoped to the strip subtree.
- Removed `hovered` / `onHoverChanged` parameters and parent `_sliderHovered` field from `GlobalTransportBar` — the entire 440-line transport bar no longer rebuilds when the cursor enters/exits the slider thumb area.

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 4985 pass
- [x] All existing transport bar tests pass unchanged