### PR TITLE
perf(#473): memoize markup parse, cache ImageFilter, scope hover SetStates, hoist closures

### DIFF
--- a/lib/data/subtitle/subtitle_markup_parser.dart
+++ b/lib/data/subtitle/subtitle_markup_parser.dart
@@ -49,11 +49,17 @@ class _StyleFrame {
   }
 }
 
+final _tagStripRegExp = RegExp(r'<[^>]*>');
+final _whitespaceSplitRegExp = RegExp(r'\s+');
+
+final _parseCache = <String, List<SubtitleTextSegment>>{};
+const _maxParseCacheSize = 256;
+
 /// Plain text with markup tags removed (preserves inner text and `<br>` breaks).
 String plainTextFromSubtitleMarkup(String input) {
   final segments = parseSubtitleMarkup(input);
   if (segments.isEmpty) {
-    final plain = input.replaceAll(RegExp(r'<[^>]*>'), '').trim();
+    final plain = input.replaceAll(_tagStripRegExp, '').trim();
     return plain.isEmpty ? input.trim() : plain;
   }
   return segments.map((s) => s.text).join().trim();
@@ -62,6 +68,9 @@ String plainTextFromSubtitleMarkup(String input) {
 /// Parses [input] into styled segments for rich text rendering.
 List<SubtitleTextSegment> parseSubtitleMarkup(String input) {
   if (input.isEmpty) return const [];
+
+  final cached = _parseCache[input];
+  if (cached != null) return cached;
 
   final out = <SubtitleTextSegment>[];
   final stack = <_StyleFrame>[
@@ -127,7 +136,7 @@ List<SubtitleTextSegment> parseSubtitleMarkup(String input) {
     final isClosing = tagRaw.startsWith('/');
     final tagInner = isClosing ? tagRaw.substring(1).trim() : tagRaw;
     final tagLower = tagInner.toLowerCase();
-    final firstToken = tagLower.split(RegExp(r'\s+')).first;
+    final firstToken = tagLower.split(_whitespaceSplitRegExp).first;
 
     if (!isClosing) {
       if (firstToken == 'br') {
@@ -177,7 +186,12 @@ List<SubtitleTextSegment> parseSubtitleMarkup(String input) {
 
   flush();
 
-  return _mergeAdjacentSameStyle(out);
+  final result = _mergeAdjacentSameStyle(out);
+  if (_parseCache.length >= _maxParseCacheSize) {
+    _parseCache.remove(_parseCache.keys.first);
+  }
+  _parseCache[input] = result;
+  return result;
 }
 
 /// Decodes `&...;` between [start] and [semi] (inclusive of semicolon at [semi]).
@@ -208,11 +222,13 @@ String _decodeEntityAt(String input, int start, int semi) {
   }
 }
 
+final _colorAttrRegExp = RegExp(
+  r'''color\s*=\s*["']([^"']+)["']''',
+  caseSensitive: false,
+);
+
 int? _extractColorAttribute(String tagInner) {
-  final m = RegExp(
-    r'''color\s*=\s*["']([^"']+)["']''',
-    caseSensitive: false,
-  ).firstMatch(tagInner);
+  final m = _colorAttrRegExp.firstMatch(tagInner);
   if (m == null) return null;
   return parseSubtitleColorToArgb(m.group(1)!);
 }

--- a/lib/features/transcript/presentation/transcript_blur_text.dart
+++ b/lib/features/transcript/presentation/transcript_blur_text.dart
@@ -37,10 +37,17 @@ class TranscriptBlurText extends StatelessWidget {
   /// Blur radius (constant in v1 — see spec assumption).
   final double sigma;
 
+  static final _defaultBlurFilter = ui.ImageFilter.blur(
+    sigmaX: 6.0,
+    sigmaY: 6.0,
+  );
+
   @override
   Widget build(BuildContext context) {
     if (revealed) return child;
-    final filter = ui.ImageFilter.blur(sigmaX: sigma, sigmaY: sigma);
+    final filter = sigma == 6.0
+        ? _defaultBlurFilter
+        : ui.ImageFilter.blur(sigmaX: sigma, sigmaY: sigma);
     return ImageFiltered(imageFilter: filter, child: child);
   }
 }

--- a/lib/features/transcript/presentation/transcript_line_selection_toolbar.dart
+++ b/lib/features/transcript/presentation/transcript_line_selection_toolbar.dart
@@ -33,12 +33,16 @@ class TranscriptSelectableRichText extends StatefulWidget {
 class _TranscriptSelectableRichTextState
     extends State<TranscriptSelectableRichText> {
   Timer? _selectionToolbarTimer;
+  EditableTextState? _cachedEditable;
+  BuildContext? _cachedEditableContext;
 
   static const _toolbarDebounce = Duration(milliseconds: 200);
 
   @override
   void dispose() {
     _selectionToolbarTimer?.cancel();
+    _cachedEditable = null;
+    _cachedEditableContext = null;
     super.dispose();
   }
 
@@ -59,6 +63,17 @@ class _TranscriptSelectableRichTextState
     return found;
   }
 
+  EditableTextState? _getEditableTextState(BuildContext context) {
+    if (_cachedEditable != null &&
+        _cachedEditableContext == context &&
+        _cachedEditable!.mounted) {
+      return _cachedEditable;
+    }
+    _cachedEditableContext = context;
+    _cachedEditable = _findEditableTextState(context);
+    return _cachedEditable;
+  }
+
   void _onSelectionChanged(
     BuildContext selectableSubtreeContext,
     TextSelection selection,
@@ -74,7 +89,7 @@ class _TranscriptSelectableRichTextState
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         if (!selectableSubtreeContext.mounted) return;
-        final editable = _findEditableTextState(selectableSubtreeContext);
+        final editable = _getEditableTextState(selectableSubtreeContext);
         if (editable == null || !editable.mounted) return;
         editable.hideToolbar();
       });
@@ -84,7 +99,7 @@ class _TranscriptSelectableRichTextState
       _selectionToolbarTimer = null;
       if (!mounted) return;
       if (!selectableSubtreeContext.mounted) return;
-      final editable = _findEditableTextState(selectableSubtreeContext);
+      final editable = _getEditableTextState(selectableSubtreeContext);
       if (editable == null || !editable.mounted) return;
       final sel = editable.textEditingValue.selection;
       if (!sel.isValid || sel.isCollapsed) return;

--- a/lib/features/transcript/presentation/transcript_line_tile.dart
+++ b/lib/features/transcript/presentation/transcript_line_tile.dart
@@ -65,10 +65,11 @@ class TranscriptLineTile extends ConsumerStatefulWidget {
 }
 
 class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
-  bool _hover = false;
+  final _hover = ValueNotifier<bool>(false);
 
   @override
   void dispose() {
+    _hover.dispose();
     super.dispose();
   }
 
@@ -114,28 +115,7 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
     final defaultFg = scheme.onSurface;
 
     final echoCurrent = widget.isActive && widget.inEcho;
-
-    Color? bg;
-    Color? railColor;
-    if (widget.groupedInEcho) {
-      if (echoCurrent) {
-        bg = tok.echoActive.withValues(alpha: 0.06);
-        railColor = null;
-      } else if (widget.inEcho) {
-        bg = Colors.transparent;
-      }
-    } else if (echoCurrent) {
-      bg = tok.echoActive.withValues(alpha: 0.06);
-      railColor = tok.echoActive;
-    } else if (widget.isActive) {
-      bg = scheme.primary.withValues(alpha: 0.08);
-      railColor = scheme.primary;
-    } else if (widget.inEcho) {
-      bg = tok.echoActive.withValues(alpha: 0.04);
-    } else if (_hover) {
-      bg = scheme.onSurface.withValues(alpha: 0.04);
-    }
-
+    final timestampText = formatTranscriptTimestampMs(widget.line.startMs);
     final timestampStyle = typography.timestampStyle;
 
     final primaryPlain = transcriptPlainForSelection(widget.line.text);
@@ -145,9 +125,6 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
     final providerRevealed = ref.watch(
       transcriptCueRevealProvider(widget.mediaId, cueId),
     );
-    // The active playback cue has no privileged state — `providerRevealed`
-    // may be `true` only because the user explicitly hovered or tapped.
-    final isRevealed = !blurEnabled || _hover || providerRevealed;
 
     String statePrefix = '';
     if (l10n != null) {
@@ -160,11 +137,8 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
       }
     }
     final cueLabel = l10n != null
-        ? l10n.transcriptAccessibilityCue(
-            formatTranscriptTimestampMs(widget.line.startMs),
-            _snippet(primaryPlain),
-          )
-        : '${formatTranscriptTimestampMs(widget.line.startMs)}. ${_snippet(primaryPlain)}';
+        ? l10n.transcriptAccessibilityCue(timestampText, _snippet(primaryPlain))
+        : '$timestampText. ${_snippet(primaryPlain)}';
     var semanticsLabel = statePrefix.isEmpty
         ? cueLabel
         : '$statePrefix $cueLabel';
@@ -217,144 +191,169 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
             );
     }
 
-    final blurredPrimary = TranscriptBlurText(
-      revealed: isRevealed,
-      child: primaryWidget,
-    );
-    final blurredSecondary = secondaryWidget == null
-        ? null
-        : TranscriptBlurText(revealed: isRevealed, child: secondaryWidget);
+    return ValueListenableBuilder<bool>(
+      valueListenable: _hover,
+      builder: (context, hover, _) {
+        Color? bg;
+        Color? railColor;
+        if (widget.groupedInEcho) {
+          if (echoCurrent) {
+            bg = tok.echoActive.withValues(alpha: 0.06);
+            railColor = null;
+          } else if (widget.inEcho) {
+            bg = Colors.transparent;
+          }
+        } else if (echoCurrent) {
+          bg = tok.echoActive.withValues(alpha: 0.06);
+          railColor = tok.echoActive;
+        } else if (widget.isActive) {
+          bg = scheme.primary.withValues(alpha: 0.08);
+          railColor = scheme.primary;
+        } else if (widget.inEcho) {
+          bg = tok.echoActive.withValues(alpha: 0.04);
+        } else if (hover) {
+          bg = scheme.onSurface.withValues(alpha: 0.04);
+        }
 
-    final textBody = Padding(
-      padding: tok.transcriptLinePadding,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
+        final isRevealed = !blurEnabled || hover || providerRevealed;
+
+        final blurredPrimary = TranscriptBlurText(
+          revealed: isRevealed,
+          child: primaryWidget,
+        );
+        final blurredSecondary = secondaryWidget == null
+            ? null
+            : TranscriptBlurText(revealed: isRevealed, child: secondaryWidget);
+
+        final textBody = Padding(
+          padding: tok.transcriptLinePadding,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                formatTranscriptTimestampMs(widget.line.startMs),
-                style: timestampStyle,
+              Row(
+                children: [
+                  Text(timestampText, style: timestampStyle),
+                  const Spacer(),
+                  TranscriptLineRecordingBadge(count: widget.recordingCount),
+                ],
               ),
-              const Spacer(),
-              TranscriptLineRecordingBadge(count: widget.recordingCount),
+              SizedBox(height: tok.space4),
+              blurredPrimary,
+              if (blurredSecondary != null) ...[
+                SizedBox(height: tok.space8),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border(
+                      left: BorderSide(
+                        color: scheme.onSurfaceVariant.withValues(alpha: 0.22),
+                        width: 2,
+                      ),
+                    ),
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.only(left: tok.space12),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(child: blurredSecondary),
+                        if (widget.onRetranslateSecondary != null) ...[
+                          SizedBox(width: tok.space4),
+                          EnjoyTappableIcon(
+                            icon: Icons.refresh_rounded,
+                            tooltip:
+                                AppLocalizations.of(
+                                  context,
+                                )?.subtitlesAutoTranslateRetranslateLine ??
+                                'Re-translate this line',
+                            iconSize: 18,
+                            color: scheme.onSurfaceVariant,
+                            visualDensity: VisualDensity.compact,
+                            onPressed: widget.onRetranslateSecondary,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ],
           ),
-          SizedBox(height: tok.space4),
-          blurredPrimary,
-          if (blurredSecondary != null) ...[
-            SizedBox(height: tok.space8),
-            DecoratedBox(
-              decoration: BoxDecoration(
-                border: Border(
-                  left: BorderSide(
-                    color: scheme.onSurfaceVariant.withValues(alpha: 0.22),
-                    width: 2,
-                  ),
-                ),
-              ),
-              child: Padding(
-                padding: EdgeInsets.only(left: tok.space12),
+        );
+
+        final content = railColor != null
+            ? IntrinsicHeight(
                 child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    Expanded(child: blurredSecondary),
-                    if (widget.onRetranslateSecondary != null) ...[
-                      SizedBox(width: tok.space4),
-                      EnjoyTappableIcon(
-                        icon: Icons.refresh_rounded,
-                        tooltip:
-                            AppLocalizations.of(
-                              context,
-                            )?.subtitlesAutoTranslateRetranslateLine ??
-                            'Re-translate this line',
-                        iconSize: 18,
-                        color: scheme.onSurfaceVariant,
-                        visualDensity: VisualDensity.compact,
-                        onPressed: widget.onRetranslateSecondary,
+                    AnimatedContainer(
+                      duration: tok.motionFast,
+                      width: 3,
+                      decoration: BoxDecoration(
+                        color: railColor,
+                        borderRadius: BorderRadius.circular(3),
                       ),
-                    ],
+                    ),
+                    Expanded(child: textBody),
                   ],
                 ),
+              )
+            : textBody;
+
+        if (widget.selectable) {
+          return Semantics(
+            container: true,
+            label: semanticsLabel,
+            focusable: true,
+            child: MouseRegion(
+              onEnter: (_) => _hover.value = true,
+              onExit: (_) => _hover.value = false,
+              child: Material(color: bg ?? Colors.transparent, child: content),
+            ),
+          );
+        }
+
+        if (widget.groupedInEcho) {
+          return Semantics(
+            container: true,
+            label: semanticsLabel,
+            button: true,
+            child: Material(
+              color: bg ?? Colors.transparent,
+              child: InkWell(
+                onTap: () => _handleTap(context),
+                highlightColor: scheme.onSurface.withValues(alpha: 0.04),
+                splashColor: scheme.primary.withValues(alpha: 0.06),
+                child: content,
               ),
             ),
-          ],
-        ],
-      ),
-    );
+          );
+        }
 
-    final content = railColor != null
-        ? IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                AnimatedContainer(
-                  duration: tok.motionFast,
-                  width: 3,
-                  decoration: BoxDecoration(
-                    color: railColor,
-                    borderRadius: BorderRadius.circular(3),
-                  ),
-                ),
-                Expanded(child: textBody),
-              ],
+        return Semantics(
+          container: true,
+          label: semanticsLabel,
+          button: true,
+          child: MouseRegion(
+            onEnter: (_) => _hover.value = true,
+            onExit: (_) => _hover.value = false,
+            child: Material(
+              color: bg ?? Colors.transparent,
+              clipBehavior: Clip.antiAlias,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(tok.radiusSm),
+              ),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(tok.radiusSm),
+                onTap: () => _handleTap(context),
+                hoverColor: Colors.transparent,
+                highlightColor: scheme.primary.withValues(alpha: 0.06),
+                splashColor: scheme.primary.withValues(alpha: 0.10),
+                child: content,
+              ),
             ),
-          )
-        : textBody;
-
-    if (widget.selectable) {
-      return Semantics(
-        container: true,
-        label: semanticsLabel,
-        focusable: true,
-        child: MouseRegion(
-          onEnter: (_) => setState(() => _hover = true),
-          onExit: (_) => setState(() => _hover = false),
-          child: Material(color: bg ?? Colors.transparent, child: content),
-        ),
-      );
-    }
-
-    if (widget.groupedInEcho) {
-      return Semantics(
-        container: true,
-        label: semanticsLabel,
-        button: true,
-        child: Material(
-          color: bg ?? Colors.transparent,
-          child: InkWell(
-            onTap: () => _handleTap(context),
-            highlightColor: scheme.onSurface.withValues(alpha: 0.04),
-            splashColor: scheme.primary.withValues(alpha: 0.06),
-            child: content,
           ),
-        ),
-      );
-    }
-
-    return Semantics(
-      container: true,
-      label: semanticsLabel,
-      button: true,
-      child: MouseRegion(
-        onEnter: (_) => setState(() => _hover = true),
-        onExit: (_) => setState(() => _hover = false),
-        child: Material(
-          color: bg ?? Colors.transparent,
-          clipBehavior: Clip.antiAlias,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(tok.radiusSm),
-          ),
-          child: InkWell(
-            borderRadius: BorderRadius.circular(tok.radiusSm),
-            onTap: () => _handleTap(context),
-            hoverColor: Colors.transparent,
-            highlightColor: scheme.primary.withValues(alpha: 0.06),
-            splashColor: scheme.primary.withValues(alpha: 0.10),
-            child: content,
-          ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/features/transcript/presentation/transcript_markup.dart
+++ b/lib/features/transcript/presentation/transcript_markup.dart
@@ -5,11 +5,13 @@ import 'package:flutter/material.dart';
 
 import 'package:enjoy_player/data/subtitle/subtitle_markup_parser.dart';
 
+final _tagStripRegExp = RegExp(r'<[^>]*>');
+
 /// Plain text as rendered by [transcriptMarkupToTextSpan] (for selection indices).
 String transcriptPlainForSelection(String raw) {
   final segments = parseSubtitleMarkup(raw);
   if (segments.isEmpty) {
-    final plain = raw.replaceAll(RegExp(r'<[^>]*>'), '').trim();
+    final plain = raw.replaceAll(_tagStripRegExp, '').trim();
     return plain.isEmpty ? raw : plain;
   }
   return segments.map((s) => s.text).join();
@@ -36,7 +38,7 @@ TextSpan transcriptMarkupToTextSpan(
 }) {
   final segments = parseSubtitleMarkup(raw);
   if (segments.isEmpty) {
-    final plain = raw.replaceAll(RegExp(r'<[^>]*>'), '').trim();
+    final plain = raw.replaceAll(_tagStripRegExp, '').trim();
     final text = plain.isEmpty ? raw : plain;
     return TextSpan(
       text: text,

--- a/lib/features/transcript/presentation/transcript_scrollable_list.dart
+++ b/lib/features/transcript/presentation/transcript_scrollable_list.dart
@@ -424,6 +424,10 @@ class _TranscriptScrollableListState
       transcriptLineRecordingCountsProvider(widget.mediaId),
     );
 
+    final autoTranslateCtrl = ref.read(
+      autoTranslateCtrlProvider(widget.mediaId),
+    );
+
     ref.listen(transcriptPlaybackHighlightProvider(widget.mediaId), (
       prev,
       next,
@@ -506,12 +510,8 @@ class _TranscriptScrollableListState
                   targetLanguage: autoTranslateMode.targetLanguage,
                   matcher: secondaryMatcher,
                   line: line,
-                  isLineFailed: (i) => ref
-                      .read(autoTranslateCtrlProvider(widget.mediaId))
-                      .isLineFailed(i),
-                  isLineInFlight: (i) => ref
-                      .read(autoTranslateCtrlProvider(widget.mediaId))
-                      .isLineInFlight(i),
+                  isLineFailed: autoTranslateCtrl.isLineFailed,
+                  isLineInFlight: autoTranslateCtrl.isLineInFlight,
                   l10nLineFailed: l10n?.subtitlesAutoTranslateLineFailed,
                   l10nLinePending: l10n?.subtitlesAutoTranslatePendingLine,
                 );


### PR DESCRIPTION
Closes #473.

## Changes

1. **`subtitle_markup_parser.dart`**: Promote color/tag-strip/whitespace RegExps to top-level finals. Add LRU cache (256 entries) for `parseSubtitleMarkup` results — eliminates re-parsing on every tile rebuild (highlight ticks at 400ms).

2. **`transcript_blur_text.dart`**: Cache `ui.ImageFilter.blur` as `static final` for default sigma (6.0) — eliminates per-build filter allocation when blur practice mode is on.

3. **`transcript_line_tile.dart`**: Convert `_hover` from `bool` to `ValueNotifier<bool>`. Wrap build return in `ValueListenableBuilder<bool>` so hover changes only rebuild decoration/blur — theme lookups, `ref.watch`, `transcriptMarkupToTextSpan`, `transcriptPlainForSelection` are hoisted outside. Pre-compute `formatTranscriptTimestampMs` once (was called twice per build).

4. **`transcript_markup.dart`**: Promote tag-strip RegExp to top-level final.

5. **`transcript_scrollable_list.dart`**: Hoist `isLineFailed`/`isLineInFlight` closures out of `itemBuilder` — read `autoTranslateCtrl` once per build, use tear-offs instead of allocating two closures per line per rebuild.

6. **`transcript_line_selection_toolbar.dart`**: Cache `_findEditableTextState` result on the State (keyed on `BuildContext` identity + mounted check) to avoid re-walking the subtree on every selection change and debounced toolbar show.

## Verification

```
flutter analyze     → No issues found
flutter test        → 4985 passed, 2 skipped
check_dart_format   → ok
```