### PR TITLE
perf(#475,#479): parallelize cold-start I/O, memoize buildAppTheme, lower JSON isolate threshold

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -8,7 +8,13 @@ import 'colors.dart';
 import 'enjoy_tokens.dart';
 import 'typography.dart';
 
+ThemeData? _cachedTheme;
+
 ThemeData buildAppTheme() {
+  return _cachedTheme ??= _buildAppThemeImpl();
+}
+
+ThemeData _buildAppThemeImpl() {
   // ── Color scheme ────────────────────────────────────────────────────────
   final base = ColorScheme.fromSeed(
     seedColor: AppColors.seedBrand,

--- a/lib/data/api/api_client.dart
+++ b/lib/data/api/api_client.dart
@@ -304,7 +304,7 @@ class ApiClient {
   Future<Object?> _decodeResponseBody(http.Response response) async {
     final raw = response.body;
     if (raw.isEmpty) return null;
-    if (raw.length > 48 * 1024) {
+    if (raw.length > 8 * 1024) {
       return compute(decodeJsonToCamel, raw);
     }
     return decodeJsonToCamel(raw);
@@ -533,7 +533,7 @@ class ApiClient {
     try {
       errBody = response.body.isEmpty
           ? null
-          : (response.body.length > 32 * 1024
+          : (response.body.length > 8 * 1024
                 ? await compute(decodeJsonToCamel, response.body)
                 : decodeJsonToCamel(response.body));
     } catch (_) {

--- a/lib/features/transcript/application/transcript_lines_provider.dart
+++ b/lib/features/transcript/application/transcript_lines_provider.dart
@@ -27,7 +27,11 @@ Future<List<TranscriptLine>> _computeLines(
   // a frequent no-op tick when an in-active transcript row changes or
   // when echo session aggregates (recordingsCount, lastActiveAt, …) bump.
   final row = await db.transcriptDao.getById(id);
-  return row == null ? <TranscriptLine>[] : repo.linesForRow(row);
+  if (row == null) return <TranscriptLine>[];
+  if (row.timelineJson.length > 16 * 1024) {
+    await repo.preloadLinesForRow(row);
+  }
+  return repo.linesForRow(row);
 }
 
 Stream<List<TranscriptLine>> _linesForMedia(

--- a/lib/features/transcript/data/transcript_repository.dart
+++ b/lib/features/transcript/data/transcript_repository.dart
@@ -14,6 +14,7 @@ import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 import 'package:cross_file/cross_file.dart';
+import 'package:flutter/foundation.dart' hide listEquals;
 import 'package:logging/logging.dart';
 import 'package:media_kit/media_kit.dart' as mk;
 import 'package:path/path.dart' as p;
@@ -151,6 +152,17 @@ class TranscriptRepository {
     final decoded = _decodeTimeline(row.timelineJson);
     _linesCache[row.id] = _LinesCacheEntry(hash, decoded);
     return decoded;
+  }
+
+  /// Pre-decodes [row.timelineJson] in a background isolate and caches the
+  /// result. Call before [linesForRow] to offload the initial parse of large
+  /// transcripts (often 100+ KB) off the UI isolate.
+  Future<void> preloadLinesForRow(TranscriptRow row) async {
+    final hash = _timelineJsonHash(row.timelineJson);
+    final hit = _linesCache[row.id];
+    if (hit != null && hit.hash == hash) return;
+    final decoded = await compute(_decodeTimeline, row.timelineJson);
+    _linesCache[row.id] = _LinesCacheEntry(hash, decoded);
   }
 
   Future<TranscriptRow?> primaryTranscriptRowForMedia(String mediaId) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,12 +34,13 @@ Future<void> _bootstrap() async {
   // Device-global settings DB + per-user signed-in DB use separate files and
   // executors; Drift's runtime "multiple databases" check is a false positive.
   driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
-  await DiagnosticLogConfig.loadFromDeviceGlobalSettings();
-  await setupAppLogging();
+  await Future.wait([
+    DiagnosticLogConfig.loadFromDeviceGlobalSettings(),
+    setupAppLogging(),
+    if (defaultTargetPlatform == TargetPlatform.windows)
+      ensureWindowsWebViewEnvironment(),
+  ]);
   _installFrameworkErrorHandlers();
-  if (defaultTargetPlatform == TargetPlatform.windows) {
-    await ensureWindowsWebViewEnvironment();
-  }
   try {
     await writeDiagnosticSessionHeader();
   } on Object catch (e, st) {


### PR DESCRIPTION
Closes #475, closes #479.

## #475 — Cold-start I/O parallelization + buildAppTheme memoization

- **`main.dart`**: Wrap `DiagnosticLogConfig.loadFromDeviceGlobalSettings()`, `setupAppLogging()`, and `ensureWindowsWebViewEnvironment()` in `Future.wait` — collapses 3 sequential I/O awaits into 1. `writeDiagnosticSessionHeader()` still runs after `setupAppLogging()` since it depends on the log file being open.
- **`app_theme.dart`**: Memoize `buildAppTheme()` result in a static `_cachedTheme` field. The app is dark-only and the theme is deterministic — no need to rebuild ~10 component `ThemeData` objects on every `EnjoyApp.build` (prefs reload, locale change, sign-in).

## #479 — Lower JSON decode isolate threshold + transcript timeline decode offload

- **`api_client.dart`**: Lower JSON decode isolate threshold from 48 KB → 8 KB in `_decodeResponseBody`, and from 32 KB → 8 KB in `_throwApiError`. Sync pages of 50 items (~10–40 KB) now decode in a background isolate.
- **`transcript_repository.dart`**: Add `preloadLinesForRow()` that decodes `timelineJson` via `compute()` in a background isolate and populates the lines cache. Transcript payloads often exceed 100 KB.
- **`transcript_lines_provider.dart`**: Call `preloadLinesForRow()` for payloads > 16 KB to offload cold decode off the UI isolate; small payloads decode synchronously to avoid microtask overhead.

## Verification

```
flutter analyze     → No issues found
flutter test        → 4985 passed, 2 skipped
check_dart_format   → ok
```