### PR TITLE
perf(player): scope surface target sync + splitter rebuilds

### DIFF
--- a/lib/features/player/presentation/layouts/video_player_layout.dart
+++ b/lib/features/player/presentation/layouts/video_player_layout.dart
@@ -52,23 +52,6 @@ class _VideoPlayerLayoutState extends State<VideoPlayerLayout> {
   /// Minimum transcript column width when layout allows it.
   static const double _kMinTranscriptWidth = 360;
 
-  @override
-  void initState() {
-    super.initState();
-    _transcriptWidthPx = widget.initialTranscriptSplitWidthPx;
-  }
-
-  @override
-  void didUpdateWidget(covariant VideoPlayerLayout oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.initialTranscriptSplitWidthPx !=
-            oldWidget.initialTranscriptSplitWidthPx &&
-        widget.initialTranscriptSplitWidthPx != null &&
-        _transcriptWidthPx == null) {
-      _transcriptWidthPx = widget.initialTranscriptSplitWidthPx;
-    }
-  }
-
   /// Transcript may use at most this fraction of total width (video keeps >=50%).
   static const double _kMaxTranscriptFraction = 0.5;
 
@@ -83,35 +66,51 @@ class _VideoPlayerLayoutState extends State<VideoPlayerLayout> {
   static const double _kMobileVideoAspectHeight = 9;
 
   /// User-chosen transcript width in pixels; `null` = use default fraction.
-  double? _transcriptWidthPx;
+  late final ValueNotifier<double?> _transcriptWidthNotifier = ValueNotifier(
+    widget.initialTranscriptSplitWidthPx,
+  );
 
   /// Hover on splitter (desktop) for a faint affordance — no hard divider line.
-  bool _splitterHovered = false;
+  final ValueNotifier<bool> _splitterHovered = ValueNotifier(false);
 
   /// Whether the mouse hovers the video column (desktop side-by-side only).
-  bool _videoColumnHovered = false;
+  final ValueNotifier<bool> _videoColumnHovered = ValueNotifier(false);
 
-  void _setVideoColumnHovered(bool hovered) {
-    if (!mounted || hovered == _videoColumnHovered) return;
-    setState(() => _videoColumnHovered = hovered);
+  @override
+  void didUpdateWidget(covariant VideoPlayerLayout oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialTranscriptSplitWidthPx !=
+            oldWidget.initialTranscriptSplitWidthPx &&
+        widget.initialTranscriptSplitWidthPx != null &&
+        _transcriptWidthNotifier.value == null) {
+      _transcriptWidthNotifier.value = widget.initialTranscriptSplitWidthPx;
+    }
   }
 
-  double _transcriptWidthForTotal(double totalWidth) {
+  @override
+  void dispose() {
+    _transcriptWidthNotifier.dispose();
+    _splitterHovered.dispose();
+    _videoColumnHovered.dispose();
+    super.dispose();
+  }
+
+  double _transcriptWidthForTotal(double totalWidth, double? widthPx) {
     final maxW = totalWidth * _kMaxTranscriptFraction;
     final minW = math.min(_kMinTranscriptWidth, maxW);
     final defaultW = totalWidth * _kDefaultTranscriptFraction;
-    final raw = _transcriptWidthPx ?? defaultW;
+    final raw = widthPx ?? defaultW;
     return raw.clamp(minW, maxW);
   }
 
   void _applyDragDelta(double totalWidth, double deltaDx) {
     final maxW = totalWidth * _kMaxTranscriptFraction;
     final minW = math.min(_kMinTranscriptWidth, maxW);
-    final current = _transcriptWidthForTotal(totalWidth);
-    setState(() {
-      // Drag left widens transcript, drag right narrows it.
-      _transcriptWidthPx = (current - deltaDx).clamp(minW, maxW);
-    });
+    final current = _transcriptWidthForTotal(
+      totalWidth,
+      _transcriptWidthNotifier.value,
+    );
+    _transcriptWidthNotifier.value = (current - deltaDx).clamp(minW, maxW);
   }
 
   @override
@@ -129,56 +128,77 @@ class _VideoPlayerLayoutState extends State<VideoPlayerLayout> {
 
         if (useSideBySide) {
           final total = constraints.maxWidth;
-          final tw = _transcriptWidthForTotal(total);
-          final vw = math.max(0.0, total - tw - _kSplitterHitWidth);
+          return ValueListenableBuilder<double?>(
+            valueListenable: _transcriptWidthNotifier,
+            builder: (context, widthPx, child) {
+              final tw = _transcriptWidthForTotal(total, widthPx);
+              final vw = math.max(0.0, total - tw - _kSplitterHitWidth);
 
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              SizedBox(
-                width: vw,
-                child: SafeArea(
-                  top: true,
-                  bottom: false,
-                  left: false,
-                  right: false,
-                  child: _VideoColumn(
-                    engine: widget.engine,
-                    isHovered: _videoColumnHovered,
-                    onHoverChanged: _setVideoColumnHovered,
-                    showButtonsInTitleBar: true,
-                    surfaceOverlay: widget.surfaceOverlay,
+              return Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ValueListenableBuilder<bool>(
+                    valueListenable: _videoColumnHovered,
+                    builder: (context, hovered, _) {
+                      return SizedBox(
+                        width: vw,
+                        child: SafeArea(
+                          top: true,
+                          bottom: false,
+                          left: false,
+                          right: false,
+                          child: _VideoColumn(
+                            engine: widget.engine,
+                            isHovered: hovered,
+                            onHoverChanged: (v) =>
+                                _videoColumnHovered.value = v,
+                            showButtonsInTitleBar: true,
+                            surfaceOverlay: widget.surfaceOverlay,
+                          ),
+                        ),
+                      );
+                    },
                   ),
-                ),
-              ),
-              _ResizeSplitter(
-                hitWidth: _kSplitterHitWidth,
-                hovered: _splitterHovered,
-                onHover: (v) => setState(() => _splitterHovered = v),
-                semanticLabel: AppLocalizations.of(
-                  context,
-                )!.playerTranscriptResizeHint,
-                onDragDelta: (dx) => _applyDragDelta(total, dx),
-                onDragEnd: () => widget.onTranscriptSplitWidthCommitted?.call(
-                  _transcriptWidthForTotal(total),
-                ),
-              ),
-              SizedBox(
-                width: tw,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: cs.surface,
-                    border: Border(
-                      left: BorderSide(
-                        color: cs.outlineVariant.withValues(alpha: 0.4),
-                        width: 1,
+                  ValueListenableBuilder<bool>(
+                    valueListenable: _splitterHovered,
+                    builder: (context, splitterHovered, _) {
+                      return _ResizeSplitter(
+                        hitWidth: _kSplitterHitWidth,
+                        hovered: splitterHovered,
+                        onHover: (v) => _splitterHovered.value = v,
+                        semanticLabel: AppLocalizations.of(
+                          context,
+                        )!.playerTranscriptResizeHint,
+                        onDragDelta: (dx) => _applyDragDelta(total, dx),
+                        onDragEnd: () =>
+                            widget.onTranscriptSplitWidthCommitted?.call(
+                              _transcriptWidthForTotal(
+                                total,
+                                _transcriptWidthNotifier.value,
+                              ),
+                            ),
+                      );
+                    },
+                  ),
+                  SizedBox(
+                    width: tw,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: cs.surface,
+                        border: Border(
+                          left: BorderSide(
+                            color: cs.outlineVariant.withValues(alpha: 0.4),
+                            width: 1,
+                          ),
+                        ),
                       ),
+                      child: child,
                     ),
                   ),
-                  child: widget.transcript,
-                ),
-              ),
-            ],
+                ],
+              );
+            },
+            child: widget.transcript,
           );
         }
 

--- a/lib/features/player/presentation/widgets/player_surface_target.dart
+++ b/lib/features/player/presentation/widgets/player_surface_target.dart
@@ -88,6 +88,9 @@ class _PlayerSurfaceTargetState extends ConsumerState<PlayerSurfaceTarget> {
     super.dispose();
   }
 
+  Offset? _lastOffset;
+  Size? _lastSize;
+
   void _sync() {
     if (!mounted || !widget.enabled) return;
     final box = context.findRenderObject() as RenderBox?;
@@ -95,6 +98,12 @@ class _PlayerSurfaceTargetState extends ConsumerState<PlayerSurfaceTarget> {
     final size = box.size;
     if (size.width <= 0 || size.height <= 0) return;
     final offset = box.localToGlobal(Offset.zero);
+
+    // Delta gate: skip registry write when geometry hasn't changed.
+    if (_lastOffset == offset && _lastSize == size) return;
+    _lastOffset = offset;
+    _lastSize = size;
+
     final cur = ref.read(playerSurfaceRegistryProvider);
     if (cur?.id != widget.id) {
       _registry.attach(
@@ -123,14 +132,7 @@ class _PlayerSurfaceTargetState extends ConsumerState<PlayerSurfaceTarget> {
         WidgetsBinding.instance.addPostFrameCallback((_) => _sync());
         return false;
       },
-      child: SizeChangedLayoutNotifier(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            WidgetsBinding.instance.addPostFrameCallback((_) => _sync());
-            return widget.child;
-          },
-        ),
-      ),
+      child: SizeChangedLayoutNotifier(child: widget.child),
     );
   }
 }


### PR DESCRIPTION
Closes #477

## Changes

### PlayerSurfaceTarget
- **Remove LayoutBuilder**: The `LayoutBuilder.builder` scheduled `addPostFrameCallback((_) => _sync())` on every build — now removed. `SizeChangedLayoutNotifier` alone drives size-change syncs.
- **Delta gate**: `_sync()` now checks `_lastOffset == offset && _lastSize == size` before writing to the registry. Prevents redundant registry writes from ancestor layout shifts (transport bar, keyboard, dialogs) that change global offset without changing the target's own size.

### VideoPlayerLayout
- **ValueNotifier for split width**: `_transcriptWidthPx` → `ValueNotifier<double?>`. Drag updates go through `_transcriptWidthNotifier.value = ...` instead of `setState`.
- **widget.transcript as child**: The transcript subtree is passed as the `child` parameter to `ValueListenableBuilder<double?>`, so it is **not** rebuilt when the split width changes. Only the `SizedBox` widths are recomputed.
- **Hover isolation**: `_splitterHovered` and `_videoColumnHovered` converted to `ValueNotifier<bool>`, each wrapped in their own `ValueListenableBuilder`. Hover changes no longer trigger `setState` on `_VideoPlayerLayoutState`.

## Impact

| Trigger | Before | After |
|---------|--------|-------|
| Splitter drag (60/s) | Full `VideoPlayerLayout` rebuild incl. transcript | `SizedBox` width update only; transcript skipped |
| Splitter hover | Full rebuild | `_ResizeSplitter` only |
| Video hover | Full rebuild | `_VideoColumn` only |
| Layout shift | `_sync()` on every LayoutBuilder build | `_sync()` only on actual size change |