### PR TITLE
ci(setup-flutter): document warm-cache invariant

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -100,6 +100,12 @@ runs:
 
         echo "$flutter_root/bin" >> "$GITHUB_PATH"
         echo "FLUTTER_ROOT=$flutter_root" >> "$GITHUB_ENV"
+
+        # Keep this executable probe: it warms Flutter's lazy bootstrap cache
+        # while RUNNER_TOOL_CACHE is writable. gh-aw later mounts that cache
+        # read-only; a cold SDK would hit EROFS before `dart analyze` or
+        # `flutter test` starts. Do not replace this with a metadata-only check.
+        # See #501 for the runner/tool-cache failure chain.
         "$flutter_bin" --version
 
     - name: Install Flutter (Windows)
@@ -148,4 +154,10 @@ runs:
 
         (Join-Path $flutterRoot 'bin') | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         "FLUTTER_ROOT=$flutterRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+        # Keep this executable probe: it warms Flutter's lazy bootstrap cache
+        # while RUNNER_TOOL_CACHE is writable. gh-aw later mounts that cache
+        # read-only; a cold SDK would hit EROFS before `dart analyze` or
+        # `flutter test` starts. Do not replace this with a metadata-only check.
+        # See #501 for the runner/tool-cache failure chain.
         & $flutterBat --version

--- a/test/features/sync/domain/sync_types_test.dart
+++ b/test/features/sync/domain/sync_types_test.dart
@@ -21,10 +21,7 @@ void main() {
         'youtube_subscription',
       );
       expect(SyncEntityType.vocabularyItem.wireName, 'vocabulary_item');
-      expect(
-        SyncEntityType.vocabularyContext.wireName,
-        'vocabulary_context',
-      );
+      expect(SyncEntityType.vocabularyContext.wireName, 'vocabulary_context');
     });
 
     test('tryParse round-trips every wire name', () {
@@ -160,7 +157,12 @@ void main() {
         failed: 1,
         errors: ['a'],
       );
-      final b = const SyncResult(success: true, synced: 1, failed: 0, errors: []);
+      final b = const SyncResult(
+        success: true,
+        synced: 1,
+        failed: 0,
+        errors: [],
+      );
 
       expect(a.merge(b).errors, ['a']);
     });


### PR DESCRIPTION
## Summary

- document why both trailing `flutter --version` probes must run while the tool cache is writable
- replace the automated fallback patch with a shorter rationale that avoids its inaccurate stamp path
- restore the Dart format gate for the sync test added by #500

## Audit findings

- #502 is the protected-file fallback for #501, not a separate behavior defect
- the generated AWF mount logic confirms eligible `RUNNER_TOOL_CACHE` paths are mounted read-only
- the threat warning came from a detector pricing/parse failure; the artifact was manually reviewed
- the setup action behavior is unchanged

## Verification

- `bash .github/scripts/validate_ci_gates.sh --all`
  - Dart format: clean
  - codegen drift: clean
  - `flutter analyze`: no issues
  - `flutter test`: 5,014 passed, 6 skipped

Closes #501
Closes #502