### PR TITLE
refactor(craft): extract shared CraftFailureCard (#506)

### DIFF
--- a/lib/features/craft/presentation/audio_stage.dart
+++ b/lib/features/craft/presentation/audio_stage.dart
@@ -12,16 +12,15 @@ import 'dart:typed_data';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/azure_voice.dart';
-import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
 import 'package:enjoy_player/features/craft/presentation/craft_solid_transcript_stt_hint.dart';
 import 'package:enjoy_player/features/craft/presentation/voice_picker.dart';
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Audio stage for the Express flow.
@@ -184,7 +183,7 @@ class _AudioStageState extends ConsumerState<AudioStage> {
     }
 
     if (state.failure != null) {
-      return _FailureCard(
+      return CraftFailureCard(
         failure: state.failure!,
         l10n: l10n,
         onRetry: () =>
@@ -670,71 +669,6 @@ class _PreviewPlayer extends StatelessWidget {
           ),
           Text(fmt(duration), style: timeStyle),
         ],
-      ),
-    );
-  }
-}
-
-class _FailureCard extends StatelessWidget {
-  const _FailureCard({
-    required this.failure,
-    required this.l10n,
-    required this.onRetry,
-  });
-
-  final CraftFailure failure;
-  final AppLocalizations l10n;
-  final VoidCallback onRetry;
-
-  String _actionLabel() {
-    switch (failure.action) {
-      case CraftFailureAction.openAiSettings:
-        return l10n.craftOpenAiSettings;
-      case CraftFailureAction.signIn:
-        return l10n.craftSignInRequired;
-      default:
-        return l10n.craftRetry;
-    }
-  }
-
-  void _handleAction(BuildContext context) {
-    switch (failure.action) {
-      case CraftFailureAction.openAiSettings:
-        unawaited(context.push('/settings/ai-providers'));
-      case CraftFailureAction.signIn:
-        unawaited(context.push('/sign-in'));
-      default:
-        onRetry();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.error_outline_rounded,
-              size: 48,
-              color: theme.colorScheme.error,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              failure.message(l10n),
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyLarge,
-            ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: () => _handleAction(context),
-              child: Text(_actionLabel()),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/features/craft/presentation/capture_stage.dart
+++ b/lib/features/craft/presentation/capture_stage.dart
@@ -11,7 +11,6 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 
@@ -19,8 +18,8 @@ import 'package:enjoy_player/core/application/app_language_catalog.dart';
 import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
-import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Voice capture stage for the Express flow.
@@ -332,7 +331,7 @@ class _CaptureStageState extends ConsumerState<CaptureStage> {
 
     // Show failure card if any.
     if (state.failure != null) {
-      return _FailureCard(
+      return CraftFailureCard(
         failure: state.failure!,
         l10n: l10n,
         onRetry: _startRecording,
@@ -808,71 +807,6 @@ class _TextFallback extends StatelessWidget {
           label: Text(l10n.craftRewriteGenerateAudio),
         ),
       ],
-    );
-  }
-}
-
-class _FailureCard extends StatelessWidget {
-  const _FailureCard({
-    required this.failure,
-    required this.l10n,
-    required this.onRetry,
-  });
-
-  final CraftFailure failure;
-  final AppLocalizations l10n;
-  final VoidCallback onRetry;
-
-  String _actionLabel() {
-    switch (failure.action) {
-      case CraftFailureAction.openAiSettings:
-        return l10n.craftOpenAiSettings;
-      case CraftFailureAction.signIn:
-        return l10n.craftSignInRequired;
-      default:
-        return l10n.craftRetry;
-    }
-  }
-
-  void _handleAction(BuildContext context) {
-    switch (failure.action) {
-      case CraftFailureAction.openAiSettings:
-        unawaited(context.push('/settings/ai-providers'));
-      case CraftFailureAction.signIn:
-        unawaited(context.push('/sign-in'));
-      default:
-        onRetry();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.error_outline_rounded,
-              size: 48,
-              color: theme.colorScheme.error,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              failure.message(l10n),
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyLarge,
-            ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: () => _handleAction(context),
-              child: Text(_actionLabel()),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/features/craft/presentation/rewrite_stage.dart
+++ b/lib/features/craft/presentation/rewrite_stage.dart
@@ -9,16 +9,15 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/azure_voice.dart';
-import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
 import 'package:enjoy_player/features/craft/domain/craft_request.dart';
 import 'package:enjoy_player/features/craft/presentation/style_picker.dart';
 import 'package:enjoy_player/features/craft/presentation/voice_picker.dart';
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Rewrite stage for the Express flow.
@@ -117,7 +116,7 @@ class _RewriteStageState extends ConsumerState<RewriteStage> {
     }
 
     if (state.failure != null) {
-      return _FailureCard(
+      return CraftFailureCard(
         failure: state.failure!,
         l10n: l10n,
         onRetry: () => unawaited(_regenerate()),
@@ -584,71 +583,6 @@ class _ActionButtons extends StatelessWidget {
           ],
         ),
       ],
-    );
-  }
-}
-
-class _FailureCard extends StatelessWidget {
-  const _FailureCard({
-    required this.failure,
-    required this.l10n,
-    required this.onRetry,
-  });
-
-  final CraftFailure failure;
-  final AppLocalizations l10n;
-  final VoidCallback onRetry;
-
-  String _actionLabel() {
-    switch (failure.action) {
-      case CraftFailureAction.openAiSettings:
-        return l10n.craftOpenAiSettings;
-      case CraftFailureAction.signIn:
-        return l10n.craftSignInRequired;
-      default:
-        return l10n.craftRetry;
-    }
-  }
-
-  void _handleAction(BuildContext context) {
-    switch (failure.action) {
-      case CraftFailureAction.openAiSettings:
-        unawaited(context.push('/settings/ai-providers'));
-      case CraftFailureAction.signIn:
-        unawaited(context.push('/sign-in'));
-      default:
-        onRetry();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.error_outline_rounded,
-              size: 48,
-              color: theme.colorScheme.error,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              failure.message(l10n),
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyLarge,
-            ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: () => _handleAction(context),
-              child: Text(_actionLabel()),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/features/craft/presentation/widgets/craft_failure_card.dart
+++ b/lib/features/craft/presentation/widgets/craft_failure_card.dart
@@ -1,0 +1,89 @@
+/// Shared failure card used by every Craft stage (audio, capture, rewrite).
+///
+/// Centralises the icon + localized message + action button layout so the
+/// three stages render identical failure UX and route the same way:
+///
+/// * [CraftFailureAction.openAiSettings] → push `/settings/ai-providers`
+/// * [CraftFailureAction.signIn]         → push `/sign-in`
+/// * anything else (including the
+///   [CraftFailureAction.switchToSpeakDirectly] case inherited from the
+///   duplicated originals) falls back to the supplied [onRetry] callback.
+///
+/// Previously the same widget lived three times — one private copy each in
+/// `audio_stage.dart`, `capture_stage.dart`, and `rewrite_stage.dart` —
+/// see [issue #506](https://github.com/baizhiheizi/enjoy_player/issues/506).
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+
+class CraftFailureCard extends StatelessWidget {
+  const CraftFailureCard({
+    required this.failure,
+    required this.l10n,
+    required this.onRetry,
+    super.key,
+  });
+
+  final CraftFailure failure;
+  final AppLocalizations l10n;
+  final VoidCallback onRetry;
+
+  String _actionLabel() {
+    switch (failure.action) {
+      case CraftFailureAction.openAiSettings:
+        return l10n.craftOpenAiSettings;
+      case CraftFailureAction.signIn:
+        return l10n.craftSignInRequired;
+      default:
+        return l10n.craftRetry;
+    }
+  }
+
+  void _handleAction(BuildContext context) {
+    switch (failure.action) {
+      case CraftFailureAction.openAiSettings:
+        unawaited(context.push('/settings/ai-providers'));
+      case CraftFailureAction.signIn:
+        unawaited(context.push('/sign-in'));
+      default:
+        onRetry();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline_rounded,
+              size: 48,
+              color: theme.colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              failure.message(l10n),
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: () => _handleAction(context),
+              child: Text(_actionLabel()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/craft/presentation/craft_failure_card_test.dart
+++ b/test/features/craft/presentation/craft_failure_card_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+import 'package:enjoy_player/l10n/app_localizations_en.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap(Widget child, {GoRouter? router}) {
+    if (router == null) {
+      return MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: Scaffold(body: child),
+      );
+    }
+    return MaterialApp.router(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      routerConfig: router,
+    );
+  }
+
+  testWidgets('CraftFailureCard renders the failure message and error icon', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(
+        CraftFailureCard(
+          failure: const CraftTranslateFailure(),
+          l10n: AppLocalizationsEn(),
+          onRetry: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.error_outline_rounded), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('CraftFailureCard invokes onRetry when action is retry', (
+    tester,
+  ) async {
+    var retried = 0;
+    await tester.pumpWidget(
+      wrap(
+        CraftFailureCard(
+          failure: const CraftTranslateFailure(),
+          l10n: AppLocalizationsEn(),
+          onRetry: () => retried++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Retry'));
+    await tester.pump();
+
+    expect(retried, 1);
+  });
+
+  testWidgets(
+    'CraftFailureCard routes to /settings/ai-providers for openAiSettings',
+    (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => Scaffold(
+              body: CraftFailureCard(
+                failure: const CraftTtsFailure(
+                  action: CraftFailureAction.openAiSettings,
+                ),
+                l10n: AppLocalizationsEn(),
+                onRetry: () {},
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/settings/ai-providers',
+            builder: (_, _) =>
+                const Scaffold(body: Text('ai-providers destination')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(wrap(const SizedBox.shrink(), router: router));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open AI settings'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Open AI settings'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ai-providers destination'), findsOneWidget);
+    },
+  );
+
+  testWidgets('CraftFailureCard routes to /sign-in for signIn failure', (
+    tester,
+  ) async {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => Scaffold(
+            body: CraftFailureCard(
+              failure: const CraftSignInRequiredFailure(),
+              l10n: AppLocalizationsEn(),
+              onRetry: () {},
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sign-in',
+          builder: (_, _) => const Scaffold(body: Text('sign-in destination')),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(wrap(const SizedBox.shrink(), router: router));
+    await tester.pumpAndSettle();
+
+    // The action label also doubles as the failure message; tap the button.
+    await tester.tap(find.widgetWithText(FilledButton, 'Sign in to use Craft'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('sign-in destination'), findsOneWidget);
+  });
+
+  testWidgets('CraftFailureCard shows Retry label and calls onRetry for '
+      'switchToSpeakDirectly (inherited fallback behavior)', (tester) async {
+    var retried = 0;
+    await tester.pumpWidget(
+      wrap(
+        CraftFailureCard(
+          failure: const CraftSameLanguageFailure(),
+          l10n: AppLocalizationsEn(),
+          onRetry: () => retried++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Retry'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Retry'));
+    await tester.pump();
+    expect(retried, 1);
+  });
+}


### PR DESCRIPTION
Resolves #506.

The same private `_FailureCard` widget was duplicated in
`audio_stage.dart`, `capture_stage.dart`, and `rewrite_stage.dart`
(~64 lines, three copies, byte-identical behavior). Extract a single
`CraftFailureCard` under `features/craft/presentation/widgets/` and have
all three stages import it.

## What changed

- **New widget** — `lib/features/craft/presentation/widgets/craft_failure_card.dart`
  - Owns the icon + localized message + action button layout.
  - Routes `openAiSettings` → `/settings/ai-providers`,
    `signIn` → `/sign-in`, everything else → `onRetry()`.
  - Public so the three stages can share it directly.
- **Stage files** — `audio_stage.dart`, `capture_stage.dart`,
  `rewrite_stage.dart` drop their local `_FailureCard` and the now-unused
  `craft_failure.dart` / `go_router.dart` imports; they instantiate
  `CraftFailureCard` with the same arguments they were already passing.
- **New focused widget tests** —
  `test/features/craft/presentation/craft_failure_card_test.dart` covers
  every action branch plus the inherited
  `switchToSpeakDirectly` fall-through behavior.

## Behavior preservation

- Identical icon, padding, spacing, button, and text style.
- Identical routing destinations for `openAiSettings` and `signIn`.
- The default branch keeps falling through to `onRetry` — including the
  `CraftFailureAction.switchToSpeakDirectly` case, which the duplicated
  widgets already routed to retry. Fixing that misrouting is intentionally
  out of scope for this PR and would be a separate behavior change.

## Verification

- `dart format` — clean.
- `flutter analyze` — `No issues found!`
- `flutter test` — all 5047 tests pass (including 5 new
  `CraftFailureCard` tests and the 209 pre-existing craft tests).

## Notes

- Net change: `-204` duplicated lines, `+265` lines for the new shared
  widget + tests.
- The shared widget follows the established `features/<x>/presentation/widgets/`
  pattern already used by vocabulary, auth, settings, and ai.
