### PR TITLE
refactor(craft): extract shared CraftLoadingView (#507)

### DIFF
--- a/lib/features/craft/presentation/audio_stage.dart
+++ b/lib/features/craft/presentation/audio_stage.dart
@@ -21,6 +21,7 @@ import 'package:enjoy_player/features/craft/domain/azure_voice.dart';
 import 'package:enjoy_player/features/craft/presentation/craft_solid_transcript_stt_hint.dart';
 import 'package:enjoy_player/features/craft/presentation/voice_picker.dart';
 import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_loading_view.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Audio stage for the Express flow.
@@ -179,7 +180,7 @@ class _AudioStageState extends ConsumerState<AudioStage> {
     );
 
     if (state.isSynthesizing) {
-      return _LoadingView(l10n: l10n);
+      return CraftLoadingView(message: l10n.craftLoadingSynthesizing);
     }
 
     if (state.failure != null) {
@@ -376,31 +377,6 @@ class _AudioActions extends StatelessWidget {
           label: Text(sayAnotherLabel),
         ),
       ],
-    );
-  }
-}
-
-class _LoadingView extends StatelessWidget {
-  const _LoadingView({required this.l10n});
-
-  final AppLocalizations l10n;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const CircularProgressIndicator(),
-          const SizedBox(height: 16),
-          Text(
-            l10n.craftLoadingSynthesizing,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/features/craft/presentation/capture_stage.dart
+++ b/lib/features/craft/presentation/capture_stage.dart
@@ -20,6 +20,7 @@ import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
 import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_loading_view.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Voice capture stage for the Express flow.
@@ -326,7 +327,7 @@ class _CaptureStageState extends ConsumerState<CaptureStage> {
 
     // Show transcribing indicator.
     if (state.isTranscribing) {
-      return _TranscribingIndicator(l10n: l10n);
+      return CraftLoadingView(message: l10n.craftLoadingTranscribing);
     }
 
     // Show failure card if any.
@@ -730,31 +731,6 @@ class _AmplitudeBarsPainter extends CustomPainter {
     return old.count != count ||
         old.writeIndex != writeIndex ||
         old.color != color;
-  }
-}
-
-class _TranscribingIndicator extends StatelessWidget {
-  const _TranscribingIndicator({required this.l10n});
-
-  final AppLocalizations l10n;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const CircularProgressIndicator(),
-          const SizedBox(height: 16),
-          Text(
-            l10n.craftLoadingTranscribing,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }
 

--- a/lib/features/craft/presentation/rewrite_stage.dart
+++ b/lib/features/craft/presentation/rewrite_stage.dart
@@ -18,6 +18,7 @@ import 'package:enjoy_player/features/craft/domain/craft_request.dart';
 import 'package:enjoy_player/features/craft/presentation/style_picker.dart';
 import 'package:enjoy_player/features/craft/presentation/voice_picker.dart';
 import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_loading_view.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// Rewrite stage for the Express flow.
@@ -112,7 +113,7 @@ class _RewriteStageState extends ConsumerState<RewriteStage> {
     // First rewrite (no target yet): keep the full-screen loading hint.
     // Re-translate / regenerate: keep the form visible with inline progress.
     if (state.isTranslating && !state.hasTranslation) {
-      return _LoadingView(l10n: l10n);
+      return CraftLoadingView(message: l10n.craftLoadingRewriting);
     }
 
     if (state.failure != null) {
@@ -233,31 +234,6 @@ class _RewriteStageState extends ConsumerState<RewriteStage> {
 }
 
 // === Sub-widgets ===
-
-class _LoadingView extends StatelessWidget {
-  const _LoadingView({required this.l10n});
-
-  final AppLocalizations l10n;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const CircularProgressIndicator(),
-          const SizedBox(height: 16),
-          Text(
-            l10n.craftLoadingRewriting,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
 
 class _NativeTextCard extends StatelessWidget {
   const _NativeTextCard({

--- a/lib/features/craft/presentation/widgets/craft_loading_view.dart
+++ b/lib/features/craft/presentation/widgets/craft_loading_view.dart
@@ -1,0 +1,42 @@
+/// Shared loading-state view used by every Craft stage (audio, capture,
+/// rewrite).
+///
+/// Renders a centered `CircularProgressIndicator` with the supplied
+/// [message] underneath in the muted `onSurfaceVariant` body style.
+/// Each stage passes its own localized string — e.g.
+///
+/// ```dart
+/// CraftLoadingView(message: l10n.craftLoadingSynthesizing)
+/// ```
+///
+/// Previously the same widget lived three times — once in each Craft stage —
+/// see [issue #507](https://github.com/baizhiheizi/enjoy_player/issues/507).
+library;
+
+import 'package:flutter/material.dart';
+
+class CraftLoadingView extends StatelessWidget {
+  const CraftLoadingView({required this.message, super.key});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 16),
+          Text(
+            message,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/pronounce/application/pronounce_playback_controller.g.dart
+++ b/lib/features/pronounce/application/pronounce_playback_controller.g.dart
@@ -44,7 +44,7 @@ final class PronouncePlaybackControllerProvider
 }
 
 String _$pronouncePlaybackControllerHash() =>
-    r'1f47dd45f77bd906ed238e572a2d7dd8706accbe';
+    r'd3afdd768cd3af9567b55ff0073a05fe3a4beaff';
 
 abstract class _$PronouncePlaybackController
     extends $Notifier<PronouncePlaybackState> {

--- a/test/features/craft/presentation/craft_loading_view_test.dart
+++ b/test/features/craft/presentation/craft_loading_view_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:enjoy_player/features/craft/presentation/widgets/craft_loading_view.dart';
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  testWidgets('CraftLoadingView shows a CircularProgressIndicator', (
+    tester,
+  ) async {
+    await tester.pumpWidget(wrap(const CraftLoadingView(message: 'Loading…')));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('CraftLoadingView renders the supplied message text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(const CraftLoadingView(message: 'Synthesizing audio…')),
+    );
+    await tester.pump();
+
+    expect(find.text('Synthesizing audio…'), findsOneWidget);
+  });
+
+  testWidgets('CraftLoadingView centers its column on screen', (tester) async {
+    await tester.pumpWidget(wrap(const CraftLoadingView(message: 'Loading…')));
+    await tester.pump();
+
+    final center = tester.widget<Center>(find.byType(Center));
+    final column = tester.widget<Column>(find.byType(Column));
+    expect(center, isNotNull);
+    expect(column.mainAxisSize, MainAxisSize.min);
+  });
+
+  testWidgets('CraftLoadingView applies onSurfaceVariant color to the text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(wrap(const CraftLoadingView(message: 'Loading…')));
+    await tester.pump();
+
+    final text = tester.widget<Text>(find.text('Loading…'));
+    final theme = Theme.of(tester.element(find.text('Loading…')));
+    expect(text.style?.color, theme.colorScheme.onSurfaceVariant);
+  });
+}


### PR DESCRIPTION
Resolves #507.

The same private loading-state layout was duplicated three times across
the Craft stages:

- `audio_stage.dart` had a `_LoadingView` using `craftLoadingSynthesizing`
- `capture_stage.dart` had a `_TranscribingIndicator` using
  `craftLoadingTranscribing`
- `rewrite_stage.dart` had a `_LoadingView` using `craftLoadingRewriting`

All three render the identical centered `CircularProgressIndicator` +
`onSurfaceVariant` body text. Extract a single `CraftLoadingView` under
`features/craft/presentation/widgets/` that accepts the localized
message as a `String`, and have each stage pass its own `l10n` key at
the call site.

## What changed

- **New widget** — `lib/features/craft/presentation/widgets/craft_loading_view.dart`
  - Owns the centered indicator + 16px gap + muted message layout.
  - Accepts a plain `String message`, so it has no `AppLocalizations`
    dependency and no opinion about which localized string to use.
- **Stage files** — `audio_stage.dart`, `capture_stage.dart`,
  `rewrite_stage.dart` drop their private `_LoadingView` /
  `_TranscribingIndicator` classes and call `CraftLoadingView` with the
  matching `l10n` key.
- **New focused widget tests** —
  `test/features/craft/presentation/craft_loading_view_test.dart`
  covers the indicator, message text, layout (centered, min column),
  and the muted `onSurfaceVariant` text color.

## Behavior preservation

- Identical `CircularProgressIndicator`, padding, and 16px gap.
- Identical `bodyMedium` text style with `onSurfaceVariant` color.
- Each stage keeps its own localized message
  (`craftLoadingSynthesizing`, `craftLoadingTranscribing`,
  `craftLoadingRewriting`).

## Verification

- `dart format` — clean.
- `flutter analyze` — `No issues found!`
- `flutter test` — all 5051 tests pass (including 4 new
  `CraftLoadingView` tests and the 209 pre-existing craft tests).

## Notes

- Builds on the same branch as PR #508 (`CraftFailureCard`), since both
  extract shared widgets under `features/craft/presentation/widgets/`.
- Net change for #507 alone: `-78` duplicated lines, `+97` lines for the
  new shared widget + tests.
