### PR TITLE
chore(agents): apply three /better-harness fixes

### DIFF
--- a/.agents/skills/flutter-add-widget-test/SKILL.md
+++ b/.agents/skills/flutter-add-widget-test/SKILL.md
@@ -8,10 +8,10 @@ metadata:
 # Writing Flutter Widget Tests
 
 ## Contents
-- [Setup & Configuration](#setup--configuration)
+- [Setup & Configuration](#setup-configuration)
 - [Core Components](#core-components)
 - [Workflow: Implementing a Widget Test](#workflow-implementing-a-widget-test)
-- [Interaction & State Management](#interaction--state-management)
+- [Interaction & State Management](#interaction-state-management)
 - [Examples](#examples)
 
 ## Setup & Configuration

--- a/.agents/skills/flutter-fix-layout-issues/SKILL.md
+++ b/.agents/skills/flutter-fix-layout-issues/SKILL.md
@@ -5,24 +5,25 @@ metadata:
   model: models/gemini-3.1-pro-preview
   last_modified: Tue, 21 Apr 2026 19:45:59 GMT
 ---
+
 # Resolving Flutter Layout Errors
 
 ## Contents
 - [Constraint Violation Diagnostics](#constraint-violation-diagnostics)
 - [Layout Error Resolution Workflow](#layout-error-resolution-workflow)
-- [Examples](#examples)
+- [Examples](references/examples.md)
 
 ## Constraint Violation Diagnostics
 
-Flutter layout operates on a strict rule: **Constraints go down. Sizes go up. Parent sets position.** Layout errors occur when this negotiation fails, typically due to unbounded constraints or unconstrained children. 
+Flutter layout operates on a strict rule: **Constraints go down. Sizes go up. Parent sets position.** Layout errors occur when this negotiation fails, typically due to unbounded constraints or unconstrained children.
 
 Diagnose layout failures using the following error signatures:
 
-*   **"Vertical viewport was given unbounded height"**: Triggered when a scrollable widget (`ListView`, `GridView`) is placed inside an unconstrained vertical parent (`Column`). The parent provides infinite height, and the child attempts to expand infinitely.
-*   **"An InputDecorator...cannot have an unbounded width"**: Triggered when a `TextField` or `TextFormField` is placed inside an unconstrained horizontal parent (`Row`). The text field attempts to determine its width based on infinite available space.
-*   **"RenderFlex overflowed"**: Triggered when a child of a `Row` or `Column` requests a size larger than the parent's allocated constraints. Visually indicated by yellow and black warning stripes.
-*   **"Incorrect use of ParentData widget"**: Triggered when a `ParentDataWidget` is not a direct descendant of its required ancestor. (e.g., `Expanded` outside a `Flex`, `Positioned` outside a `Stack`).
-*   **"RenderBox was not laid out"**: A cascading side-effect error. Ignore this and look further up the stack trace for the primary constraint violation (usually an unbounded height/width error).
+* **"Vertical viewport was given unbounded height"**: Triggered when a scrollable widget (`ListView`, `GridView`) is placed inside an unconstrained vertical parent (`Column`). The parent provides infinite height, and the child attempts to expand infinitely.
+* **"An InputDecorator...cannot have an unbounded width"**: Triggered when a `TextField` or `TextFormField` is placed inside an unconstrained horizontal parent (`Row`). The text field attempts to determine its width based on infinite available space.
+* **"RenderFlex overflowed"**: Triggered when a child of a `Row` or `Column` requests a size larger than the parent's allocated constraints. Visually indicated by yellow and black warning stripes.
+* **"Incorrect use of ParentData widget"**: Triggered when a `ParentDataWidget` is not a direct descendant of its required ancestor. (e.g., `Expanded` outside a `Flex`, `Positioned` outside a `Stack`).
+* **"RenderBox was not laid out"**: A cascading side-effect error. Ignore this and look further up the stack trace for the primary constraint violation (usually an unbounded height/width error).
 
 ## Layout Error Resolution Workflow
 
@@ -41,90 +42,4 @@ Copy and use this checklist to systematically resolve layout constraint violatio
 
 ## Examples
 
-### Fixing Unbounded Height (ListView in Column)
-
-**Input (Error State):**
-```dart
-// Throws "Vertical viewport was given unbounded height"
-Column(
-  children: <Widget>[
-    const Text('Header'),
-    ListView(
-      children: const <Widget>[
-        ListTile(title: Text('Item 1')),
-        ListTile(title: Text('Item 2')),
-      ],
-    ),
-  ],
-)
-```
-
-**Output (Resolved State):**
-```dart
-// Wrap ListView in Expanded to constrain its height to the remaining Column space
-Column(
-  children: <Widget>[
-    const Text('Header'),
-    Expanded(
-      child: ListView(
-        children: const <Widget>[
-          ListTile(title: Text('Item 1')),
-          ListTile(title: Text('Item 2')),
-        ],
-      ),
-    ),
-  ],
-)
-```
-
-### Fixing Unbounded Width (TextField in Row)
-
-**Input (Error State):**
-```dart
-// Throws "An InputDecorator...cannot have an unbounded width"
-Row(
-  children: [
-    const Icon(Icons.search),
-    TextField(), 
-  ],
-)
-```
-
-**Output (Resolved State):**
-```dart
-// Wrap TextField in Expanded to constrain its width to the remaining Row space
-Row(
-  children: [
-    const Icon(Icons.search),
-    Expanded(
-      child: TextField(),
-    ),
-  ],
-)
-```
-
-### Fixing RenderFlex Overflow
-
-**Input (Error State):**
-```dart
-// Throws "A RenderFlex overflowed by X pixels on the right"
-Row(
-  children: [
-    const Icon(Icons.info),
-    const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
-  ],
-)
-```
-
-**Output (Resolved State):**
-```dart
-// Wrap the Text widget in Expanded to force it to wrap within the available constraints
-Row(
-  children: [
-    const Icon(Icons.info),
-    Expanded(
-      child: const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
-    ),
-  ],
-)
-```
+For complete input/output Dart examples covering unbounded height (`ListView` in `Column`), unbounded width (`TextField` in `Row`), and `RenderFlex` overflow, see [examples.md](references/examples.md).

--- a/.agents/skills/flutter-fix-layout-issues/references/examples.md
+++ b/.agents/skills/flutter-fix-layout-issues/references/examples.md
@@ -1,0 +1,89 @@
+# Examples
+
+### Fixing Unbounded Height (ListView in Column)
+
+**Input (Error State):**
+```dart
+// Throws "Vertical viewport was given unbounded height"
+Column(
+  children: <Widget>[
+    const Text('Header'),
+    ListView(
+      children: const <Widget>[
+        ListTile(title: Text('Item 1')),
+        ListTile(title: Text('Item 2')),
+      ],
+    ),
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap ListView in Expanded to constrain its height to the remaining Column space
+Column(
+  children: <Widget>[
+    const Text('Header'),
+    Expanded(
+      child: ListView(
+        children: const <Widget>[
+          ListTile(title: Text('Item 1')),
+          ListTile(title: Text('Item 2')),
+        ],
+      ),
+    ),
+  ],
+)
+```
+
+### Fixing Unbounded Width (TextField in Row)
+
+**Input (Error State):**
+```dart
+// Throws "An InputDecorator...cannot have an unbounded width"
+Row(
+  children: [
+    const Icon(Icons.search),
+    TextField(),
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap TextField in Expanded to constrain its width to the remaining Row space
+Row(
+  children: [
+    const Icon(Icons.search),
+    Expanded(
+      child: TextField(),
+    ),
+  ],
+)
+```
+
+### Fixing RenderFlex Overflow
+
+**Input (Error State):**
+```dart
+// Throws "A RenderFlex overflowed by X pixels on the right"
+Row(
+  children: [
+    const Icon(Icons.info),
+    const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap the Text widget in Expanded to force it to wrap within the available constraints
+Row(
+  children: [
+    const Icon(Icons.info),
+    Expanded(
+      child: const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
+    ),
+  ],
+)
+```

--- a/.agents/skills/flutter-use-http-package/SKILL.md
+++ b/.agents/skills/flutter-use-http-package/SKILL.md
@@ -8,8 +8,8 @@ metadata:
 # Implementing Flutter Networking
 
 ## Contents
-- [Configuration & Permissions](#configuration--permissions)
-- [Request Execution & Response Handling](#request-execution--response-handling)
+- [Configuration & Permissions](#configuration-permissions)
+- [Request Execution & Response Handling](#request-execution-response-handling)
 - [Background Parsing](#background-parsing)
 - [Workflow: Executing Network Operations](#workflow-executing-network-operations)
 - [Examples](#examples)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,18 @@ Guidance for humans and AI coding agents working in this repository.
 - **Documentation hygiene**: Architectural decisions → new ADR in [`docs/decisions/`](docs/decisions/). Feature behavior changes → update [`docs/features/<feature>.md`](docs/features/). Shared UI interaction patterns → [ADR-0018](docs/decisions/0018-shared-interactive-primitives.md).
 - **Page layout**: New screens pick an [`EnjoyPageKind`](lib/core/layout/enjoy_page_kind.dart) and use [`EnjoyPage`](lib/core/theme/widgets/enjoy_page.dart) / layout tokens (`pageGutter`, `formMaxWidth`, `hubMaxWidth`). Do not invent per-screen max widths or ad-hoc full-bleed forms on desktop — see [ADR-0055](docs/decisions/0055-adaptive-page-layout-system.md) and [app-ui.md](docs/features/app-ui.md#page-layout).
 
+## AI-debug route
+
+When a failing test blocks the tree, the smallest reproducer is one focused test — `testName` is the `test('…')` description, not the file name:
+
+```bash
+flutter test test/path/to/specific_test.dart -n testName
+```
+
+Runtime logs (redacted; INFO+ by default, FINE+ when **Settings → About → Diagnostic logging** is on) land at `{applicationSupport}/logs/enjoy-player.log` (rotated: `enjoy-player.log`, `.1`, `.2`, ~2 MB each). Per platform: Windows `%APPDATA%\Enjoy\Enjoy Player\logs\`, macOS `~/Library/Application Support/Enjoy/logs/`, Linux `~/.local/share/enjoy/logs/`, iOS / Android inside the app sandbox (export via **Settings → About → Export diagnostic report**).
+
+The first line of a fresh log is a **session banner** — `app=<version>+<buildNumber> platform=<os> mode=<debug|profile|release> channel=<distributionChannel> locale=<localeTag> diagnosticVerbose=<bool>` — that ties every subsequent line to one cold start; treat that banner as the correlation identity when triaging a user report. New code uses [`logNamed`](lib/core/logging/log.dart) (never `print()`) — see [conventions.md § Logging](docs/conventions.md#logging) and [diagnostics.md](docs/features/diagnostics.md).
+
 ## Lookup language catalog
 
 The transcript lookup sheet (`lib/features/lookup/`) uses a **separate** `kSupportedLookupLanguageTags` catalog (14 tags) in [`lib/core/application/app_language_catalog.dart`](lib/core/application/app_language_catalog.dart), decoupled from `kSupportedNativeLanguageTags` (profile "native", 2 tags) and `kSupportedFocusLanguageTags` (profile "learning", 8 tags). Widening the lookup picker must not regress profile / settings UI. See [ADR-0042](docs/decisions/0042-multi-language-lookup-catalog.md) and [docs/features/dictionary-lookup.md § Languages](docs/features/dictionary-lookup.md#languages).


### PR DESCRIPTION
## Summary

Resolves the three findings from the 2026-08-01 `/better-harness` review on this project.

| Finding | Severity | Fix |
|---|---|---|
| `agents-md-omits-ai-debug-route` | Medium | Add `## AI-debug route` section to AGENTS.md |
| `skills-broken-toc-anchors` | Low | Fix 4 broken intra-document TOC anchors in 2 Skills |
| `skills-no-progressive-disclosure` | Low (pilot) | Restructure `flutter-fix-layout-issues` into thin route + `references/` |

## Changes

### `AGENTS.md` (+12 lines, 74 -> 86)

Adds an `## AI-debug route` section between Hard rules and Lookup language catalog. Names:

- the [`logNamed`](lib/core/logging/log.dart) facade (with `never print()` reminder)
- the focused-test one-liner: `flutter test test/path/to/specific_test.dart -n testName`
- runtime log location `{applicationSupport}/logs/enjoy-player.log` with the per-platform enumeration (Windows `%APPDATA%\Enjoy\Enjoy Player\logs\`, macOS `~/Library/Application Support/Enjoy/logs/`, Linux `~/.local/share/enjoy/logs/`, iOS / Android app sandbox with the export route)
- the **session banner** correlation identity (`app=… platform=… mode=… channel=… locale=… diagnosticVerbose=…`) written by `writeDiagnosticSessionHeader` on every cold start

Linked sections: `conventions.md § Logging` and `diagnostics.md`. Root length still well under the 120-line threshold.

### `.agents/skills/flutter-add-widget-test/SKILL.md` (2 line edits)

Two broken TOC anchors use the wrong slug. The lint's `headingAnchor` collapses `\s+` to a single `-`, so the rendered anchor for `## Setup & Configuration` is `setup-configuration` (not `setup--configuration`):

- `#setup--configuration` -> `#setup-configuration`
- `#interaction--state-management` -> `#interaction-state-management`

### `.agents/skills/flutter-use-http-package/SKILL.md` (2 line edits)

Same fix for two more broken anchors:

- `#configuration--permissions` -> `#configuration-permissions`
- `#request-execution--response-handling` -> `#request-execution-response-handling`

### `.agents/skills/flutter-fix-layout-issues/` (restructure)

Pilot for the progressive-disclosure pattern:

- `SKILL.md` shrinks 131 -> 46 lines. Keeps frontmatter, title, TOC, `## Constraint Violation Diagnostics`, `## Layout Error Resolution Workflow` (with the 9-step `### Task Progress` checklist intact), and a one-paragraph `## Examples` that links to `references/examples.md`.
- `references/examples.md` (new, 90 lines) holds the three input/output Dart code blocks (`ListView` in `Column`, `TextField` in `Row`, `RenderFlex` overflow) -- byte-equivalent to the original `## Examples` body, with `# Examples` as the top-level heading so the link target has a real title.

The single relative Markdown link (`[examples.md](references/examples.md)`) satisfies the `existingLocalReferences.length > 0` half of the lint's conjunction and drops the file under the 120-line `lineCount > 120` half, so the advisory is gone.

## Validation

`better-harness coding-agent-practices asset-baseline qoder --workspace . --json`:

| Metric | Before | After |
|---|---|---|
| Total findings | 14 | **9** |
| `skill-missing-local-reference` errors | 4 | **0** |
| `skill-long-without-progressive-references` advisories | 10 | **9** (pilot Skill cleared) |
| Lint envelope errors | 4 | **0** |
| Lint envelope missing references | 0 | 0 |

The 9 remaining progressive-disclosure advisories are on the other 9 Skills and are intentionally untouched -- each would need its own `/better-harness fix this issue` pass to apply the same thin-route + `references/` pattern.

## Out of scope (intentionally not committed)

- `.qoder/better-harness/` -- harness output directory (run artefacts, render logs, scratch). This is harness state, not project state. It is untracked and is not part of this PR.
- The other 9 progressive-disclosure advisories on the remaining Skills.
