### PR TITLE
feat(subscription): port Lite/Pro tier catalog from web + paid? gating

### DIFF
--- a/lib/data/api/services/subscription_api.dart
+++ b/lib/data/api/services/subscription_api.dart
@@ -16,9 +16,14 @@ class SubscriptionApi extends RestApi {
   Future<Map<String, dynamic>> purchase({
     required int months,
     PaymentProcessor processor = PaymentProcessor.stripe,
+    required String tier,
   }) => client.postJson(
     _path,
-    body: {'months': months, 'processor': processor.apiValue},
+    body: {
+      'months': months,
+      'processor': processor.apiValue,
+      'tier': tier,
+    },
   );
 
   Future<Map<String, dynamic>> startAutoRenew({required String planId}) =>

--- a/lib/features/auth/presentation/widgets/profile_content.dart
+++ b/lib/features/auth/presentation/widgets/profile_content.dart
@@ -26,6 +26,8 @@ import 'package:enjoy_player/features/credits/application/todays_credits_provide
 import 'package:enjoy_player/features/library/application/learning_statistics_provider.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_row.dart';
 import 'package:enjoy_player/features/subscription/application/current_tier_provider.dart';
+import 'package:enjoy_player/features/subscription/application/subscription_status_provider.dart';
+import 'package:enjoy_player/features/subscription/domain/subscription_status.dart';
 import 'package:enjoy_player/features/update/application/update_controller.dart';
 import 'package:enjoy_player/features/update/presentation/update_notification_dot.dart';
 import 'package:enjoy_player/features/vocabulary/application/vocabulary_providers.dart';
@@ -101,7 +103,11 @@ class _ProfileContentState extends ConsumerState<ProfileContent> {
         final p = state.profile;
 
         final tier = ref.watch(currentTierProvider);
-        final dailyLimit = tier == SubscriptionTier.pro ? 60000 : 1000;
+        final status = ref.watch(subscriptionStatusProvider).valueOrNull;
+        // Prefer the live subscription status so the daily limit reflects the
+        // actual tier (free=1,000 / lite=12,000 / pro=60,000). Fall back to a
+        // tier-based default when the status hasn't loaded yet.
+        final dailyLimit = status?.dailyCreditsLimit ?? _fallbackDailyLimit(tier);
 
         final creditsUsedAsync = ref.watch(todaysCreditsUsedProvider);
         final creditsUsed = creditsUsedAsync.valueOrNull;
@@ -223,5 +229,19 @@ class _ProfileNavSection extends StatelessWidget {
       padding: EdgeInsets.zero,
       child: Column(mainAxisSize: MainAxisSize.min, children: children),
     );
+  }
+}
+
+/// Tier-based fallback for the daily credit limit when the live subscription
+/// status has not loaded yet. Matches the entitlements in
+/// [SubscriptionStatus.dailyCreditsLimit].
+int _fallbackDailyLimit(SubscriptionTier tier) {
+  switch (tier) {
+    case SubscriptionTier.pro:
+      return 60000;
+    case SubscriptionTier.lite:
+      return 12000;
+    case SubscriptionTier.free:
+      return 1000;
   }
 }

--- a/lib/features/auth/presentation/widgets/profile_hero_card.dart
+++ b/lib/features/auth/presentation/widgets/profile_hero_card.dart
@@ -93,7 +93,7 @@ class ProfileHeroCard extends ConsumerWidget {
                   ],
                 ),
               ),
-              if (tier != SubscriptionTier.pro) ...[
+              if (tier == SubscriptionTier.free) ...[
                 SizedBox(width: t.space12),
                 FilledButton.tonal(
                   onPressed: () => context.push('/subscription'),
@@ -115,7 +115,7 @@ class ProfileHeroCard extends ConsumerWidget {
   }
 }
 
-/// Pill chip showing the Pro / Free tier on the hero card.
+/// Pill chip showing the current tier on the hero card.
 class SubscriptionChip extends StatelessWidget {
   const SubscriptionChip({required this.tier, super.key});
 
@@ -126,9 +126,11 @@ class SubscriptionChip extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final label = tier == SubscriptionTier.pro
-        ? l10n.profileSubscriptionPro
-        : l10n.profileSubscriptionFree;
+    final label = switch (tier) {
+      SubscriptionTier.pro => l10n.profileSubscriptionPro,
+      SubscriptionTier.lite => l10n.subscriptionTierLiteName,
+      SubscriptionTier.free || null => l10n.profileSubscriptionFree,
+    };
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),

--- a/lib/features/auth/presentation/widgets/sidebar_account_chip.dart
+++ b/lib/features/auth/presentation/widgets/sidebar_account_chip.dart
@@ -58,10 +58,15 @@ class SidebarAccountChip extends ConsumerWidget {
           if (state is AuthSignedIn) {
             final p = state.profile;
             final avatarUrl = rasterAvatarUrl(p.avatarUrl);
-            final isPro =
-                ref.watch(currentTierProvider) == SubscriptionTier.pro;
-            final isFree = !isPro;
+            final tier = ref.watch(currentTierProvider);
+            final isPaid = tier != SubscriptionTier.free;
+            final isFree = !isPaid;
             final updateBadge = ref.watch(updateAvailableBadgeProvider);
+            final tierBadgeLabel = switch (tier) {
+              SubscriptionTier.pro => l10n.profileSubscriptionPro,
+              SubscriptionTier.lite => l10n.subscriptionTierLiteName,
+              SubscriptionTier.free => null,
+            };
             return ListTile(
               dense: true,
               leading: Stack(
@@ -98,10 +103,10 @@ class SidebarAccountChip extends ConsumerWidget {
                       style: Theme.of(context).textTheme.labelLarge,
                     ),
                   ),
-                  if (isPro) ...[
+                  if (tierBadgeLabel != null) ...[
                     SizedBox(width: t.space4),
                     _SidebarTierBadge(
-                      label: l10n.profileSubscriptionPro,
+                      label: tierBadgeLabel,
                       background: cs.primaryContainer,
                       foreground: cs.onPrimaryContainer,
                     ),

--- a/lib/features/subscription/application/subscription_purchase_provider.dart
+++ b/lib/features/subscription/application/subscription_purchase_provider.dart
@@ -21,12 +21,13 @@ class SubscriptionPurchaseCtrl extends _$SubscriptionPurchaseCtrl {
   Future<PaymentSession?> purchaseExternal({
     required int months,
     required PaymentProcessor processor,
+    required String tier,
   }) async {
     state = const AsyncLoading();
     try {
       final repo = ref.read(subscriptionRepositoryProvider);
       final session = await repo.purchase(
-        PurchaseRequest(months: months, processor: processor),
+        PurchaseRequest(months: months, processor: processor, tier: tier),
       );
       state = const AsyncData(null);
       await launchPayUrl(session.payUrl);

--- a/lib/features/subscription/application/tier_reconcile_provider.dart
+++ b/lib/features/subscription/application/tier_reconcile_provider.dart
@@ -132,7 +132,7 @@ class TierReconcileCtrl extends _$TierReconcileCtrl {
         if (kind == PendingPurchaseKind.creditsPackage) {
           confirmed = await _pollUntilPackageOrTimeout();
         } else {
-          confirmed = await _pollUntilProOrTimeout();
+          confirmed = await _pollUntilPaidOrTimeout();
         }
         _pendingKind = null;
         _clearPackagePendingState();
@@ -187,25 +187,25 @@ class TierReconcileCtrl extends _$TierReconcileCtrl {
     }
   }
 
-  Future<bool> _pollUntilProOrTimeout() async {
+  Future<bool> _pollUntilPaidOrTimeout() async {
     final deadline = DateTime.now().add(_eagerPollTimeout);
     while (DateTime.now().isBefore(deadline)) {
       ref.invalidate(subscriptionStatusProvider);
-      final confirmed = await _pollProOnce();
+      final confirmed = await _pollPaidOnce();
       if (confirmed) return true;
       await Future<void>.delayed(_eagerPollInterval);
     }
     _log.info(
-      'eager reconcile timed out before Pro confirmed; '
+      'eager reconcile timed out before paid tier confirmed; '
       'background reconcile will retry',
     );
     return false;
   }
 
-  Future<bool> _pollProOnce() async {
+  Future<bool> _pollPaidOnce() async {
     try {
       final status = await ref.read(subscriptionStatusProvider.future);
-      if (status.subscriptionTier == SubscriptionTier.pro) {
+      if (status.isPaidTier) {
         await _safeProfileRefresh();
         return true;
       }

--- a/lib/features/subscription/data/subscription_repository.dart
+++ b/lib/features/subscription/data/subscription_repository.dart
@@ -40,7 +40,11 @@ class SubscriptionRepository with RestRepository {
 
   Future<PaymentSession> purchase(PurchaseRequest request) => apiCall(
     () async => PaymentSession.fromJson(
-      await _api.purchase(months: request.months, processor: request.processor),
+      await _api.purchase(
+        months: request.months,
+        processor: request.processor,
+        tier: request.tier,
+      ),
     ),
   );
 

--- a/lib/features/subscription/domain/purchase_request.dart
+++ b/lib/features/subscription/domain/purchase_request.dart
@@ -2,17 +2,39 @@
 library;
 
 import 'package:enjoy_player/features/subscription/domain/payment_processor.dart';
+import 'package:enjoy_player/features/subscription/domain/subscription_plan.dart';
 
 class PurchaseRequest {
-  const PurchaseRequest({required this.months, required this.processor});
+  const PurchaseRequest({
+    required this.months,
+    required this.processor,
+    required this.tier,
+  });
 
   final int months;
   final PaymentProcessor processor;
+  final String tier;
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{'months': months, 'processor': processor.apiValue};
+    return <String, dynamic>{
+      'months': months,
+      'processor': processor.apiValue,
+      'tier': tier,
+    };
   }
 }
 
-/// Display price per month (USD); server owns checkout totals.
-const kSubscriptionMonthlyPriceUsd = 9.99;
+/// Monthly plan amount for a tier from the loaded catalog.
+///
+/// Returns `null` when [plans] is empty or the tier has no monthly plan —
+/// callers should treat that as a loading state (disable CTAs, show skeleton)
+/// rather than a fallback price. The Rails API is the single source of truth
+/// for tier pricing (`GET /api/v1/subscriptions/plans`).
+double? prepaidUnitPriceForTier(List<SubscriptionPlan> plans, String tier) {
+  for (final plan in plans) {
+    if (plan.tier == tier && plan.isMonthly) {
+      return plan.amount.toDouble();
+    }
+  }
+  return null;
+}

--- a/lib/features/subscription/presentation/subscription_screen.dart
+++ b/lib/features/subscription/presentation/subscription_screen.dart
@@ -21,6 +21,7 @@ import 'package:enjoy_player/core/theme/widgets/enjoy_page.dart';
 import 'package:enjoy_player/core/theme/widgets/skeleton.dart';
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
+import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/auth/presentation/widgets/auth_required_callout.dart';
 import 'package:enjoy_player/features/credits/application/credits_packages_provider.dart';
 import 'package:enjoy_player/features/credits/application/credits_summary_provider.dart';
@@ -100,8 +101,8 @@ class _SubscriptionBody extends ConsumerWidget {
               SizedBox(height: t.space24),
               TierCatalog(
                 status: status,
-                onChoosePro: (interval) =>
-                    _openUnifiedPurchase(context, interval),
+                onChoosePaid: (tier, interval) =>
+                    _openUnifiedPurchase(context, tier, interval),
               ),
               SizedBox(height: t.space20),
               const BalanceToCredits(),
@@ -138,13 +139,14 @@ class _SubscriptionBody extends ConsumerWidget {
   }
 }
 
-/// Opens the unified purchase modal at the chosen catalog interval.
+/// Opens the unified purchase modal at the chosen catalog tier + interval.
 ///
 /// Surfaces platform-specific affordances (mobile in-app unavailable notice)
 /// before delegating to [showUnifiedPurchaseSheet], which itself defaults to
 /// the auto-renew path and offers pay-once as a secondary option.
 Future<void> _openUnifiedPurchase(
   BuildContext context,
+  SubscriptionTier tier,
   CatalogInterval interval,
 ) async {
   if (showsMobilePurchaseUnavailable()) {
@@ -153,5 +155,9 @@ Future<void> _openUnifiedPurchase(
   }
   if (!supportsExternalSubscriptionPurchase()) return;
   if (!context.mounted) return;
-  await showUnifiedPurchaseSheet(context, interval: interval);
+  await showUnifiedPurchaseSheet(
+    context,
+    tier: tier,
+    interval: interval,
+  );
 }

--- a/lib/features/subscription/presentation/tier_reconcile_host.dart
+++ b/lib/features/subscription/presentation/tier_reconcile_host.dart
@@ -63,10 +63,10 @@ class _TierReconcileHostState extends ConsumerState<TierReconcileHost>
     _lastEmittedTier ??= auth.profile.subscriptionTier ?? SubscriptionTier.free;
     unawaited(ref.read(tierReconcileCtrlProvider.notifier).reconcile());
     final liveTier = ref.read(currentTierProvider);
-    if (liveTier == SubscriptionTier.pro &&
-        _lastEmittedTier != SubscriptionTier.pro) {
+    if (liveTier != SubscriptionTier.free &&
+        _lastEmittedTier == SubscriptionTier.free) {
       _lastEmittedTier = liveTier;
-      _celebrate();
+      _celebrate(liveTier);
     }
   }
 
@@ -102,15 +102,20 @@ class _TierReconcileHostState extends ConsumerState<TierReconcileHost>
       }
       return;
     }
-    if (!confirmed && ref.read(currentTierProvider) != SubscriptionTier.pro) {
+    if (!confirmed && ref.read(currentTierProvider) == SubscriptionTier.free) {
       AppNotice.info(context, l10n.subscriptionVerifyTimeout);
     }
   }
 
-  void _celebrate() {
+  void _celebrate(SubscriptionTier tier) {
     if (!mounted) return;
     final l10n = AppLocalizations.of(context)!;
-    AppNotice.success(context, l10n.subscriptionUpgradedToPro);
+    final message = switch (tier) {
+      SubscriptionTier.lite => l10n.subscriptionUpgradedToLite,
+      SubscriptionTier.pro => l10n.subscriptionUpgradedToPro,
+      SubscriptionTier.free => l10n.subscriptionUpgradedToPro,
+    };
+    AppNotice.success(context, message);
   }
 
   @override
@@ -129,9 +134,9 @@ class _TierReconcileHostState extends ConsumerState<TierReconcileHost>
 
     ref.listen<SubscriptionTier>(currentTierProvider, (prev, next) {
       if (_lastEmittedTier == null) return;
-      if (next == SubscriptionTier.pro &&
-          _lastEmittedTier != SubscriptionTier.pro) {
-        _celebrate();
+      if (next != SubscriptionTier.free &&
+          _lastEmittedTier == SubscriptionTier.free) {
+        _celebrate(next);
       }
       _lastEmittedTier = next;
     });

--- a/lib/features/subscription/presentation/widgets/auto_renew_plan_sheet.dart
+++ b/lib/features/subscription/presentation/widgets/auto_renew_plan_sheet.dart
@@ -26,6 +26,7 @@ import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
+import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/subscription/application/subscription_plans_provider.dart';
 import 'package:enjoy_player/features/subscription/application/subscription_purchase_provider.dart';
 import 'package:enjoy_player/features/subscription/application/subscription_status_provider.dart';
@@ -45,17 +46,22 @@ enum _PaymentPath { autoRenew, prepaid }
 ///
 /// Kept for backwards compatibility with callers that don't yet know the
 /// selected catalog interval (e.g. legacy upgrade CTAs). New code should call
-/// [showUnifiedPurchaseSheet] and pass the interval chosen on the catalog.
+/// [showUnifiedPurchaseSheet] and pass the tier + interval chosen on the catalog.
 Future<void> showAutoRenewPlanSheet(BuildContext context) {
-  return showUnifiedPurchaseSheet(context, interval: CatalogInterval.month);
+  return showUnifiedPurchaseSheet(
+    context,
+    tier: SubscriptionTier.pro,
+    interval: CatalogInterval.month,
+  );
 }
 
-/// Opens the unified purchase modal at the chosen catalog interval.
+/// Opens the unified purchase modal at the chosen catalog tier + interval.
 ///
 /// On compact widths this is a bottom sheet; on wide widths it presents as a
 /// centered adaptive dialog so the side-by-side payment cards stay legible.
 Future<void> showUnifiedPurchaseSheet(
   BuildContext context, {
+  required SubscriptionTier tier,
   required CatalogInterval interval,
 }) async {
   if (showsMobilePurchaseUnavailable()) {
@@ -67,13 +73,20 @@ Future<void> showUnifiedPurchaseSheet(
   await showEnjoyAdaptiveSheet<void>(
     context: context,
     isScrollControlled: true,
-    builder: (ctx) => _UnifiedPurchaseSheetBody(initialInterval: interval),
+    builder: (ctx) => _UnifiedPurchaseSheetBody(
+      initialTier: tier,
+      initialInterval: interval,
+    ),
   );
 }
 
 class _UnifiedPurchaseSheetBody extends ConsumerStatefulWidget {
-  const _UnifiedPurchaseSheetBody({required this.initialInterval});
+  const _UnifiedPurchaseSheetBody({
+    required this.initialTier,
+    required this.initialInterval,
+  });
 
+  final SubscriptionTier initialTier;
   final CatalogInterval initialInterval;
 
   @override
@@ -95,15 +108,21 @@ class _UnifiedPurchaseSheetBodyState
     _processor = PaymentProcessor.stripe;
   }
 
-  double get _prepaidTotal => _months * kSubscriptionMonthlyPriceUsd;
+  double? _prepaidTotal(List<SubscriptionPlan> plans) {
+    final unit = prepaidUnitPriceForTier(plans, widget.initialTier.name);
+    if (unit == null) return null;
+    return _months * unit;
+  }
 
-  SubscriptionPlan? _resolveProPlan(
+  SubscriptionPlan? _resolvePlan(
     List<SubscriptionPlan> plans,
     CatalogInterval target,
+    SubscriptionTier tier,
   ) {
+    final tierName = tier.name;
     for (final plan in plans) {
       if (catalogIntervalFromString(plan.interval) == target &&
-          plan.tier == 'pro') {
+          plan.tier == tierName) {
         return plan;
       }
     }
@@ -151,7 +170,11 @@ class _UnifiedPurchaseSheetBodyState
     try {
       await ref
           .read(subscriptionPurchaseCtrlProvider.notifier)
-          .purchaseExternal(months: _months, processor: _processor);
+          .purchaseExternal(
+            months: _months,
+            processor: _processor,
+            tier: widget.initialTier.name,
+          );
       if (!mounted) return;
       Navigator.pop(context);
       AppNotice.info(context, l10n.subscriptionRedirectingToPayment);
@@ -185,14 +208,26 @@ class _UnifiedPurchaseSheetBodyState
     final intervalLabel = interval == CatalogInterval.year
         ? l10n.subscriptionAutoRenewYearly
         : l10n.subscriptionAutoRenewMonthly;
-    final tierLabel = l10n.subscriptionTierProName;
+    final tierLabel = widget.initialTier == SubscriptionTier.lite
+        ? l10n.subscriptionTierLiteName
+        : l10n.subscriptionTierProName;
 
     // Resolve the selected plan from the loaded plans list. When the provider
     // is still loading, errored, or returned an empty list, [selectedPlan] is
     // null and the bottom panel is hidden — we never present a "Subscribe"
     // CTA without a valid plan to back it.
     final selectedPlan = plansAsync.maybeWhen(
-      data: (plans) => plans.isEmpty ? null : _resolveProPlan(plans, interval),
+      data: (plans) =>
+          plans.isEmpty ? null : _resolvePlan(plans, interval, widget.initialTier),
+      orElse: () => null,
+    );
+
+    final unitPrice = plansAsync.maybeWhen(
+      data: (plans) => prepaidUnitPriceForTier(plans, widget.initialTier.name),
+      orElse: () => null,
+    );
+    final prepaidTotal = plansAsync.maybeWhen(
+      data: (plans) => _prepaidTotal(plans),
       orElse: () => null,
     );
 
@@ -256,6 +291,7 @@ class _UnifiedPurchaseSheetBodyState
                       interval: interval,
                       intervalLabel: intervalLabel,
                       plan: selectedPlan,
+                      unitPrice: unitPrice,
                       plansLoading: false,
                       onChanged: busy
                           ? null
@@ -284,10 +320,12 @@ class _UnifiedPurchaseSheetBodyState
                       months: _months,
                       processor: _processor,
                       busy: busy,
-                      totalPrice: _prepaidTotal,
+                      unitPrice: unitPrice,
+                      totalPrice: prepaidTotal,
                       onMonthsChanged: (m) => setState(() => _months = m),
                       onProcessorChanged: (p) => setState(() => _processor = p),
-                      onContinue: busy ? null : _startPrepaidPurchase,
+                      onContinue:
+                          busy || unitPrice == null ? null : _startPrepaidPurchase,
                     ),
               ],
             ),
@@ -337,6 +375,7 @@ class _PaymentPathSelector extends StatelessWidget {
     required this.interval,
     required this.intervalLabel,
     required this.plan,
+    required this.unitPrice,
     required this.plansLoading,
     required this.onChanged,
   });
@@ -345,6 +384,7 @@ class _PaymentPathSelector extends StatelessWidget {
   final CatalogInterval interval;
   final String intervalLabel;
   final SubscriptionPlan? plan;
+  final double? unitPrice;
   final bool plansLoading;
   final ValueChanged<_PaymentPath>? onChanged;
 
@@ -379,9 +419,11 @@ class _PaymentPathSelector extends StatelessWidget {
           subtitle: l10n.subscriptionPurchaseModalOptionPrepaidSubtitle,
           footnote: l10n.subscriptionPurchaseModalOptionPrepaidFootnote,
           leadingIcon: Icons.event_available_rounded,
-          price: l10n.subscriptionAutoRenewPriceMonth(
-            kSubscriptionMonthlyPriceUsd.toStringAsFixed(2),
-          ),
+          price: unitPrice != null
+              ? l10n.subscriptionAutoRenewPriceMonth(
+                  unitPrice.toStringAsFixed(2),
+                )
+              : '—',
           plansLoading: false,
           intervalLabel: null,
         );
@@ -414,8 +456,7 @@ class _PaymentPathSelector extends StatelessWidget {
       final formatted = NumberFormat('0.00').format(plan.amount);
       return l10n.subscriptionAutoRenewPriceMonth(formatted);
     }
-    final fallback = interval == CatalogInterval.year ? '99.99' : '9.99';
-    return l10n.subscriptionAutoRenewPriceMonth(fallback);
+    return '—';
   }
 }
 
@@ -609,6 +650,7 @@ class _PrepaidPanel extends StatelessWidget {
     required this.months,
     required this.processor,
     required this.busy,
+    required this.unitPrice,
     required this.totalPrice,
     required this.onMonthsChanged,
     required this.onProcessorChanged,
@@ -618,7 +660,8 @@ class _PrepaidPanel extends StatelessWidget {
   final int months;
   final PaymentProcessor processor;
   final bool busy;
-  final double totalPrice;
+  final double? unitPrice;
+  final double? totalPrice;
   final ValueChanged<int> onMonthsChanged;
   final ValueChanged<PaymentProcessor> onProcessorChanged;
   final VoidCallback? onContinue;
@@ -666,7 +709,9 @@ class _PrepaidPanel extends StatelessWidget {
               children: [
                 Text(l10n.subscriptionTotalPriceLabel),
                 Text(
-                  l10n.subscriptionTotalPrice(totalPrice.toStringAsFixed(2)),
+                  l10n.subscriptionTotalPrice(
+                    totalPrice?.toStringAsFixed(2) ?? '—',
+                  ),
                   style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                 ),
               ],

--- a/lib/features/subscription/presentation/widgets/purchase_sheet.dart
+++ b/lib/features/subscription/presentation/widgets/purchase_sheet.dart
@@ -1,4 +1,8 @@
 /// Desktop purchase sheet: external checkout only.
+///
+/// **Deprecated:** prefer [showUnifiedPurchaseSheet] which is tier-aware and
+/// driven by the catalog endpoint. This entry point remains available for
+/// legacy callers and is hardcoded to Pro when the monthly plan is available.
 library;
 
 import 'package:flutter/material.dart';
@@ -7,12 +11,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:enjoy_player/core/errors/app_failure.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/platform/subscription_purchase_capability.dart';
+import 'package:enjoy_player/core/riverpod/async_value_x.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_modal.dart';
+import 'package:enjoy_player/features/auth/domain/user_profile.dart';
+import 'package:enjoy_player/features/subscription/application/subscription_plans_provider.dart';
 import 'package:enjoy_player/features/subscription/application/subscription_purchase_provider.dart';
 import 'package:enjoy_player/features/subscription/domain/payment_processor.dart';
 import 'package:enjoy_player/features/subscription/domain/purchase_request.dart';
+import 'package:enjoy_player/features/subscription/domain/subscription_plan.dart';
 import 'package:enjoy_player/features/subscription/presentation/widgets/payment_processor_option.dart';
 import 'package:enjoy_player/features/subscription/presentation/widgets/subscription_duration_selector.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
@@ -41,14 +49,21 @@ class _PurchaseSheetBodyState extends ConsumerState<_PurchaseSheetBody> {
   int _months = 1;
   PaymentProcessor _processor = PaymentProcessor.stripe;
 
-  double get _totalPrice => _months * kSubscriptionMonthlyPriceUsd;
+  double? _totalPrice(List<SubscriptionPlan> plans) {
+    final unit = prepaidUnitPriceForTier(plans, SubscriptionTier.pro.name);
+    return unit == null ? null : _months * unit;
+  }
 
   Future<void> _purchaseExternal() async {
     final l10n = AppLocalizations.of(context)!;
     try {
       await ref
           .read(subscriptionPurchaseCtrlProvider.notifier)
-          .purchaseExternal(months: _months, processor: _processor);
+          .purchaseExternal(
+            months: _months,
+            processor: _processor,
+            tier: SubscriptionTier.pro.name,
+          );
       if (!mounted) return;
       Navigator.pop(context);
       AppNotice.info(context, l10n.subscriptionRedirectingToPayment);
@@ -76,6 +91,8 @@ class _PurchaseSheetBodyState extends ConsumerState<_PurchaseSheetBody> {
     final tt = Theme.of(context).textTheme;
     final purchaseState = ref.watch(subscriptionPurchaseCtrlProvider);
     final busy = purchaseState.isLoading;
+    final plans = ref.watch(subscriptionPlansProvider).valueOrNull ?? const [];
+    final totalPrice = _totalPrice(plans);
 
     return Padding(
       padding: EdgeInsets.only(
@@ -158,7 +175,7 @@ class _PurchaseSheetBodyState extends ConsumerState<_PurchaseSheetBody> {
                       Text(l10n.subscriptionTotalPriceLabel),
                       Text(
                         l10n.subscriptionTotalPrice(
-                          _totalPrice.toStringAsFixed(2),
+                          totalPrice?.toStringAsFixed(2) ?? '—',
                         ),
                         style: tt.titleMedium?.copyWith(
                           fontWeight: FontWeight.w700,

--- a/lib/features/subscription/presentation/widgets/subscription_status_card.dart
+++ b/lib/features/subscription/presentation/widgets/subscription_status_card.dart
@@ -10,12 +10,14 @@ import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
+import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/subscription/application/subscription_purchase_provider.dart';
 import 'package:enjoy_player/features/subscription/application/subscription_status_provider.dart';
 import 'package:enjoy_player/features/subscription/domain/auto_renew_billing.dart';
 import 'package:enjoy_player/features/subscription/domain/subscription_status.dart';
 import 'package:enjoy_player/features/subscription/presentation/widgets/auto_renew_plan_sheet.dart';
 import 'package:enjoy_player/features/subscription/presentation/widgets/mobile_purchase_unavailable.dart';
+import 'package:enjoy_player/features/subscription/presentation/widgets/tier_catalog.dart';
 import 'package:enjoy_player/core/platform/subscription_purchase_capability.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
@@ -82,14 +84,18 @@ class SubscriptionStatusCard extends ConsumerWidget {
     }
   }
 
-  Future<void> _extend(BuildContext context) async {
+  Future<void> _extendToPro(BuildContext context) async {
     if (showsMobilePurchaseUnavailable()) {
       await showMobilePurchaseUnavailableDialog(context);
       return;
     }
     if (!supportsExternalSubscriptionPurchase()) return;
     if (!context.mounted) return;
-    await showAutoRenewPlanSheet(context);
+    await showUnifiedPurchaseSheet(
+      context,
+      tier: SubscriptionTier.pro,
+      interval: CatalogInterval.month,
+    );
   }
 
   @override
@@ -98,15 +104,15 @@ class SubscriptionStatusCard extends ConsumerWidget {
     final t = EnjoyThemeTokens.of(context);
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final isPro = status.isPro;
+    final isPaid = status.isPaidTier;
     final ar = status.autoRenew;
     final cancelBusy = ref.watch(subscriptionPurchaseCtrlProvider).isLoading;
     final creditsLabel = l10n.subscriptionDailyCredits(
       NumberFormat.decimalPattern().format(status.dailyCreditsLimit),
     );
 
-    if (isPro) {
-      return _ProMembershipCard(
+    if (isPaid) {
+      return _PaidMembershipCard(
         status: status,
         autoRenew: ar,
         creditsLabel: creditsLabel,
@@ -114,17 +120,13 @@ class SubscriptionStatusCard extends ConsumerWidget {
         onCancel: ar != null && ar.isCancelable
             ? () => _cancel(context, ref, ar)
             : null,
-        onExtend: status.hasActiveAutoRenewPlan ? null : () => _extend(context),
+        onExtend: status.hasActiveAutoRenewPlan ? null : _extendToPro,
       );
     }
 
-    // Lite members get a paid-tier status card with the correct label.
-    final tierName = status.isLite
-        ? l10n.subscriptionTierLiteName
-        : l10n.profileSubscriptionFree;
-    final tierDescription = status.isLite
-        ? l10n.subscriptionTierLiteDescription
-        : l10n.subscriptionTierFreeDescription;
+    // Free users get a basic card.
+    final tierName = l10n.profileSubscriptionFree;
+    final tierDescription = l10n.subscriptionTierFreeDescription;
 
     return EnjoyCard(
       padding: EdgeInsets.all(t.space20),
@@ -160,8 +162,8 @@ class SubscriptionStatusCard extends ConsumerWidget {
   }
 }
 
-class _ProMembershipCard extends StatelessWidget {
-  const _ProMembershipCard({
+class _PaidMembershipCard extends StatelessWidget {
+  const _PaidMembershipCard({
     required this.status,
     required this.autoRenew,
     required this.creditsLabel,
@@ -186,6 +188,7 @@ class _ProMembershipCard extends StatelessWidget {
     final ar = autoRenew;
     final renewing = status.hasActiveAutoRenewPlan;
     final endingSoon = ar != null && ar.cancelAtPeriodEnd;
+    final isLite = status.isLite;
 
     final periodDate =
         _formatDate(context, ar?.currentPeriodEnd) ??
@@ -206,6 +209,12 @@ class _ProMembershipCard extends StatelessWidget {
         : l10n.subscriptionAutoRenewPriceMonth(
             NumberFormat('0.00').format(ar.amount),
           );
+    final tierTitle = isLite
+        ? l10n.subscriptionTierLiteName
+        : l10n.subscriptionProMemberTitle;
+    final tierBadge = isLite
+        ? l10n.subscriptionTierLiteName
+        : l10n.profileSubscriptionPro;
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -252,7 +261,7 @@ class _ProMembershipCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        l10n.subscriptionProMemberTitle,
+                        tierTitle,
                         style: tt.titleLarge?.copyWith(
                           fontWeight: FontWeight.w800,
                           letterSpacing: -0.3,
@@ -271,7 +280,7 @@ class _ProMembershipCard extends StatelessWidget {
                 _SoftChip(
                   label: renewing
                       ? l10n.subscriptionAutoRenewOn
-                      : l10n.profileSubscriptionPro,
+                      : tierBadge,
                   emphasized: true,
                 ),
               ],

--- a/lib/features/subscription/presentation/widgets/tier_catalog.dart
+++ b/lib/features/subscription/presentation/widgets/tier_catalog.dart
@@ -1,10 +1,14 @@
-/// Tier catalog: unified Free / Pro selection with a Monthly / Yearly toggle.
+/// Tier catalog: unified Free / Lite / Pro selection with a Monthly / Yearly toggle.
 ///
 /// Replaces the previous free-vs-Pro comparison layout that lived in the
 /// subscription screen. The Free card is read-only — it always reflects the
-/// user's current tier when applicable. The Pro card exposes an [onChoosePro]
-/// callback that the host page wires up to the unified purchase modal
-/// (auto-renew primary, prepaid secondary).
+/// user's current tier when applicable. The Lite and Pro cards expose an
+/// [onChoosePaid] callback that the host page wires up to the unified
+/// purchase modal (auto-renew primary, prepaid secondary).
+///
+/// **Pricing is sourced from the catalog endpoint** (`GET /api/v1/subscriptions/plans`).
+/// When a plan has not loaded yet, the price line renders a skeleton rather
+/// than a hardcoded fallback — the Rails API is the single source of truth.
 library;
 
 import 'package:flutter/material.dart';
@@ -14,6 +18,7 @@ import 'package:intl/intl.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
+import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/subscription/application/subscription_plans_provider.dart';
 import 'package:enjoy_player/features/subscription/domain/subscription_plan.dart';
 import 'package:enjoy_player/features/subscription/domain/subscription_status.dart';
@@ -28,15 +33,15 @@ CatalogInterval _intervalFromString(String s) =>
 String _intervalToString(CatalogInterval interval) =>
     interval == CatalogInterval.year ? 'year' : 'month';
 
-/// Approximate savings percentage when paying yearly vs monthly.
+/// Approximate savings percentage when paying yearly vs monthly for a tier.
 ///
 /// Returns the integer percentage (e.g. `17` for a 17% saving) or `null` when
 /// the inputs are missing or non-positive.
-int? _savingsPercentFor(List<SubscriptionPlan> plans) {
+int? _savingsPercentForTier(List<SubscriptionPlan> plans, String tier) {
   SubscriptionPlan? monthly;
   SubscriptionPlan? yearly;
   for (final plan in plans) {
-    if (plan.tier != 'pro') continue;
+    if (plan.tier != tier) continue;
     if (plan.isYearly) {
       yearly = plan;
     } else {
@@ -54,12 +59,22 @@ int? _savingsPercentFor(List<SubscriptionPlan> plans) {
 }
 
 class TierCatalog extends ConsumerStatefulWidget {
-  const TierCatalog({required this.status, this.onChoosePro, super.key});
+  const TierCatalog({
+    required this.status,
+    this.onChoosePaid,
+    @Deprecated('Use onChoosePaid.') this.onChoosePro,
+    super.key,
+  });
 
   final SubscriptionStatus status;
 
-  /// Fired when the user taps the Pro tier's CTA. The host wires this to the
-  /// unified purchase modal (auto-renew primary, prepaid secondary).
+  /// Fired when the user taps a paid tier's CTA (Lite or Pro). The host wires
+  /// this to the unified purchase modal (auto-renew primary, prepaid secondary).
+  final void Function(SubscriptionTier tier, CatalogInterval interval)?
+      onChoosePaid;
+
+  /// Backwards-compatible alias for Pro-only callers. Prefer [onChoosePaid].
+  @Deprecated('Use onChoosePaid. Pass SubscriptionTier.pro explicitly.')
   final void Function(CatalogInterval interval)? onChoosePro;
 
   @override
@@ -117,7 +132,11 @@ class _TierCatalogState extends ConsumerState<TierCatalog> {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    final savingsPercent = _savingsPercentFor(plans);
+    // Pick the better savings percent across Lite and Pro (helps the yearly
+    // badge stay meaningful when either tier is missing from the catalog).
+    final liteSavings = _savingsPercentForTier(plans, 'lite');
+    final proSavings = _savingsPercentForTier(plans, 'pro');
+    final savingsPercent = proSavings ?? liteSavings;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -136,15 +155,26 @@ class _TierCatalogState extends ConsumerState<TierCatalog> {
         SizedBox(height: t.space20),
         LayoutBuilder(
           builder: (context, constraints) {
-            final wide = constraints.maxWidth >= 720;
+            final wide = constraints.maxWidth >= 840;
             final freeCard = _FreeTierCard(
-              isCurrent: !widget.status.isPaidTier,
+              isCurrent: widget.status.subscriptionTier == SubscriptionTier.free,
             );
-            final proCard = _ProTierCard(
+            final liteCard = _PaidTierCard(
+              tier: SubscriptionTier.lite,
               plans: plans,
               interval: _interval,
-              isCurrent: widget.status.isPro,
-              onChoose: () => widget.onChoosePro?.call(_interval),
+              isCurrent: widget.status.subscriptionTier == SubscriptionTier.lite,
+              isLowerThanCurrent:
+                  widget.status.subscriptionTier == SubscriptionTier.pro,
+              onChoose: () => _onChoosePaid(SubscriptionTier.lite),
+            );
+            final proCard = _PaidTierCard(
+              tier: SubscriptionTier.pro,
+              plans: plans,
+              interval: _interval,
+              isCurrent: widget.status.subscriptionTier == SubscriptionTier.pro,
+              isLowerThanCurrent: false,
+              onChoose: () => _onChoosePaid(SubscriptionTier.pro),
             );
             if (wide) {
               return IntrinsicHeight(
@@ -152,6 +182,8 @@ class _TierCatalogState extends ConsumerState<TierCatalog> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     Expanded(child: freeCard),
+                    SizedBox(width: t.space12),
+                    Expanded(child: liteCard),
                     SizedBox(width: t.space12),
                     Expanded(child: proCard),
                   ],
@@ -161,6 +193,8 @@ class _TierCatalogState extends ConsumerState<TierCatalog> {
             return Column(
               children: [
                 proCard,
+                SizedBox(height: t.space16),
+                liteCard,
                 SizedBox(height: t.space16),
                 freeCard,
               ],
@@ -174,6 +208,24 @@ class _TierCatalogState extends ConsumerState<TierCatalog> {
           style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
         ),
       ],
+    );
+  }
+
+  void _onChoosePaid(SubscriptionTier tier) {
+    // New callback first.
+    widget.onChoosePaid?.call(tier, _interval);
+    // Legacy alias: only Pro had a callback historically.
+    if (tier == SubscriptionTier.pro) {
+      // ignore: deprecated_member_use_from_same_package
+      widget.onChoosePro?.call(_interval);
+    }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      DiagnosticsProperty<CatalogInterval>('interval', _interval),
     );
   }
 }
@@ -415,18 +467,24 @@ class _FreeTierCard extends StatelessWidget {
   ];
 }
 
-class _ProTierCard extends StatelessWidget {
-  const _ProTierCard({
+class _PaidTierCard extends StatelessWidget {
+  const _PaidTierCard({
+    required this.tier,
     required this.plans,
     required this.interval,
     required this.isCurrent,
+    required this.isLowerThanCurrent,
     required this.onChoose,
   });
 
+  final SubscriptionTier tier;
   final List<SubscriptionPlan> plans;
   final CatalogInterval interval;
   final bool isCurrent;
+  final bool isLowerThanCurrent;
   final VoidCallback onChoose;
+
+  bool get _isLite => tier == SubscriptionTier.lite;
 
   @override
   Widget build(BuildContext context) {
@@ -435,15 +493,40 @@ class _ProTierCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    final selectedPlan = _resolvePlan(plans, interval);
-    final fallbackPlan = _resolvePlan(plans, CatalogInterval.month);
+    final selectedPlan = _resolvePlan(plans, interval, tier);
+    final fallbackPlan = _resolvePlan(plans, CatalogInterval.month, tier);
     final resolved = selectedPlan ?? fallbackPlan;
     final amount = resolved != null
         ? NumberFormat('0.00').format(resolved.amount)
-        : (interval == CatalogInterval.year ? '99.99' : '9.99');
+        : null;
     final unitLabel = interval == CatalogInterval.year
         ? l10n.subscriptionTierCatalogPerYear
         : l10n.subscriptionTierCatalogPerMonth;
+
+    final tierName = _isLite
+        ? l10n.subscriptionTierLiteName
+        : l10n.subscriptionTierProName;
+    final tierDescription = _isLite
+        ? l10n.subscriptionTierLiteDescription
+        : l10n.subscriptionTierProDescription;
+    final dailyCredits = _isLite
+        ? l10n.subscriptionTierLiteDailyCredits
+        : l10n.subscriptionTierProDailyCredits;
+    final features = _isLite
+        ? _liteFeatures(l10n)
+        : _proFeatures(l10n);
+
+    final ctaLabel = isCurrent
+        ? (_isLite
+            ? l10n.subscriptionTierCatalogExtendLite
+            : l10n.subscriptionTierCatalogExtendPro)
+        : (_isLite
+            ? l10n.subscriptionTierCatalogChooseLite
+            : l10n.subscriptionTierCatalogChoosePro);
+    final ctaEnabled = !isLowerThanCurrent && resolved != null;
+    final ctaLabelActual = isLowerThanCurrent
+        ? l10n.subscriptionTierCatalogNotSelected
+        : ctaLabel;
 
     final inner = EnjoyCard(
       padding: EdgeInsets.all(t.space20),
@@ -451,34 +534,45 @@ class _ProTierCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
         children: [
-          Row(
-            children: [
-              _Pill(
-                label: l10n.subscriptionTierCatalogRecommended,
-                color: cs.primary,
-                textColor: cs.onPrimary,
-                tt: tt,
-                leading: Icons.auto_awesome_rounded,
-              ),
-              if (isCurrent) ...[
-                SizedBox(width: t.space8),
+          // Lite card has no "Recommended" badge — Pro is the recommended tier.
+          if (!_isLite) ...[
+            Row(
+              children: [
                 _Pill(
-                  label: l10n.subscriptionCurrentPlan,
-                  color: cs.secondaryContainer,
-                  textColor: cs.onSecondaryContainer,
+                  label: l10n.subscriptionTierCatalogRecommended,
+                  color: cs.primary,
+                  textColor: cs.onPrimary,
                   tt: tt,
+                  leading: Icons.auto_awesome_rounded,
                 ),
+                if (isCurrent) ...[
+                  SizedBox(width: t.space8),
+                  _Pill(
+                    label: l10n.subscriptionCurrentPlan,
+                    color: cs.secondaryContainer,
+                    textColor: cs.onSecondaryContainer,
+                    tt: tt,
+                  ),
+                ],
               ],
-            ],
-          ),
-          SizedBox(height: t.space12),
+            ),
+            SizedBox(height: t.space12),
+          ] else if (isCurrent) ...[
+            _Pill(
+              label: l10n.subscriptionCurrentPlan,
+              color: cs.secondaryContainer,
+              textColor: cs.onSecondaryContainer,
+              tt: tt,
+            ),
+            SizedBox(height: t.space12),
+          ],
           Text(
-            l10n.subscriptionTierProName,
+            tierName,
             style: tt.titleLarge?.copyWith(fontWeight: FontWeight.w800),
           ),
           SizedBox(height: t.space4),
           Text(
-            l10n.subscriptionTierProDescription,
+            tierDescription,
             style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
           ),
           SizedBox(height: t.space16),
@@ -487,13 +581,24 @@ class _ProTierCard extends StatelessWidget {
             textBaseline: TextBaseline.alphabetic,
             children: [
               Flexible(
-                child: Text(
-                  '\$$amount',
-                  style: tt.headlineMedium?.copyWith(
-                    fontWeight: FontWeight.w800,
-                    color: cs.primary,
-                  ),
-                ),
+                child: amount != null
+                    ? Text(
+                        '\$$amount',
+                        style: tt.headlineMedium?.copyWith(
+                          fontWeight: FontWeight.w800,
+                          color: _isLite ? null : cs.primary,
+                        ),
+                      )
+                    : SizedBox(
+                        width: 72,
+                        height: 28,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: cs.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(t.radiusSm),
+                          ),
+                        ),
+                      ),
               ),
               SizedBox(width: t.space4),
               Flexible(
@@ -507,57 +612,68 @@ class _ProTierCard extends StatelessWidget {
           ),
           SizedBox(height: t.space4),
           Text(
-            l10n.subscriptionTierProDailyCredits,
+            dailyCredits,
             style: tt.bodySmall?.copyWith(
               color: cs.onSurfaceVariant,
               fontWeight: FontWeight.w600,
             ),
           ),
-          SizedBox(height: t.space12),
-          Text(
-            l10n.subscriptionTierCatalogSelectedInterval(amount, unitLabel),
-            style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
-          ),
+          if (amount != null) ...[
+            SizedBox(height: t.space12),
+            Text(
+              l10n.subscriptionTierCatalogSelectedInterval(amount, unitLabel),
+              style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+            ),
+          ],
           SizedBox(height: t.space16),
-          for (final feature in _proFeatures(l10n)) ...[
-            _Bullet(text: feature, emphasize: true, tt: tt),
+          for (final feature in features) ...[
+            _Bullet(text: feature, emphasize: !_isLite, tt: tt),
             SizedBox(height: t.space8),
           ],
           SizedBox(height: t.space16),
           EnjoyButton.primary(
-            onPressed: onChoose,
-            child: Text(
-              isCurrent
-                  ? l10n.subscriptionTierCatalogExtendPro
-                  : l10n.subscriptionTierCatalogChoosePro,
-            ),
+            onPressed: ctaEnabled ? onChoose : null,
+            child: Text(ctaLabelActual),
           ),
         ],
       ),
     );
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(t.radiusLg + 2),
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            cs.primary.withValues(alpha: 0.85),
-            cs.tertiary.withValues(alpha: 0.75),
+    // Pro card gets the gradient treatment; Lite uses the standard card.
+    if (!_isLite) {
+      return DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(t.radiusLg + 2),
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              cs.primary.withValues(alpha: 0.85),
+              cs.tertiary.withValues(alpha: 0.75),
+            ],
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: cs.primary.withValues(alpha: 0.22),
+              blurRadius: 24,
+              offset: const Offset(0, 8),
+            ),
           ],
         ),
-        boxShadow: [
-          BoxShadow(
-            color: cs.primary.withValues(alpha: 0.22),
-            blurRadius: 24,
-            offset: const Offset(0, 8),
-          ),
-        ],
-      ),
-      child: Padding(padding: const EdgeInsets.all(1.5), child: inner),
-    );
+        child: Padding(padding: const EdgeInsets.all(1.5), child: inner),
+      );
+    }
+    return inner;
   }
+
+  List<String> _liteFeatures(AppLocalizations l10n) => [
+    l10n.subscriptionFeatureLiteTranslation,
+    l10n.subscriptionFeatureLiteSmartTranslation,
+    l10n.subscriptionFeatureLiteDictionary,
+    l10n.subscriptionFeatureLiteAsr,
+    l10n.subscriptionFeatureLiteTts,
+    l10n.subscriptionFeatureLiteAssessment,
+  ];
 
   List<String> _proFeatures(AppLocalizations l10n) => [
     l10n.subscriptionFeatureProTranslation,
@@ -571,9 +687,11 @@ class _ProTierCard extends StatelessWidget {
   SubscriptionPlan? _resolvePlan(
     List<SubscriptionPlan> plans,
     CatalogInterval target,
+    SubscriptionTier tier,
   ) {
+    final tierName = tier == SubscriptionTier.lite ? 'lite' : 'pro';
     for (final plan in plans) {
-      if (_intervalFromString(plan.interval) == target && plan.tier == 'pro') {
+      if (_intervalFromString(plan.interval) == target && plan.tier == tierName) {
         return plan;
       }
     }

--- a/lib/features/vocabulary/application/vocabulary_anki_export.dart
+++ b/lib/features/vocabulary/application/vocabulary_anki_export.dart
@@ -1,4 +1,4 @@
-/// Orchestrates Pro-gated Anki CSV export.
+/// Orchestrates paid-tier-gated Anki CSV export.
 library;
 
 import 'dart:typed_data';
@@ -15,13 +15,13 @@ import 'package:enjoy_player/features/vocabulary/domain/vocabulary_anki_csv.dart
 import 'package:enjoy_player/features/vocabulary/domain/vocabulary_anki_export_filters.dart';
 import 'package:enjoy_player/features/vocabulary/domain/vocabulary_models.dart';
 
-/// Whether the current session may export Anki CSV (active Pro when known).
+/// Whether the current session may export Anki CSV (paid tier when known).
 bool vocabularyAnkiExportAllowedFrom({
   required SubscriptionTier tier,
-  bool? subscriptionIsPro,
+  bool? subscriptionIsPaid,
 }) {
-  if (subscriptionIsPro != null) return subscriptionIsPro;
-  return tier == SubscriptionTier.pro;
+  if (subscriptionIsPaid != null) return subscriptionIsPaid;
+  return tier != SubscriptionTier.free;
 }
 
 /// Convenience for Riverpod [Ref] / test containers.
@@ -29,7 +29,7 @@ bool vocabularyAnkiExportAllowed(Ref ref) {
   final status = ref.read(subscriptionStatusProvider).valueOrNull;
   return vocabularyAnkiExportAllowedFrom(
     tier: ref.read(currentTierProvider),
-    subscriptionIsPro: status?.isPro,
+    subscriptionIsPaid: status?.isPaidTier,
   );
 }
 
@@ -86,16 +86,16 @@ Future<VocabularyAnkiExportBundle> buildVocabularyAnkiExport({
 }
 
 Future<VocabularyAnkiExportIoOutcome> runVocabularyAnkiExport({
-  required bool isPro,
+  required bool isPaid,
   required Future<List<VocabularyItem>> Function() listAll,
   required Future<List<VocabularyContext>> Function(String itemId)
-  getContextsForItem,
+      getContextsForItem,
   required VocabularyAnkiExportFilters filters,
   String? dialogTitle,
   void Function(double progress)? onProgress,
 }) async {
-  if (!isPro) {
-    throw StateError('pro_required');
+  if (!isPaid) {
+    throw StateError('paid_required');
   }
   final bundle = await buildVocabularyAnkiExport(
     listAll: listAll,
@@ -115,7 +115,7 @@ Future<VocabularyAnkiExportIoOutcome> runVocabularyAnkiExportWithRef({
 }) {
   final repo = ref.read(vocabularyRepositoryProvider);
   return runVocabularyAnkiExport(
-    isPro: vocabularyAnkiExportAllowed(ref),
+    isPaid: vocabularyAnkiExportAllowed(ref),
     listAll: repo.listAll,
     getContextsForItem: repo.getContextsForItem,
     filters: filters,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1759,7 +1759,10 @@
   "subscriptionTierCatalogRecommended": "Recommended",
   "subscriptionTierCatalogChoosePro": "Choose Pro",
   "subscriptionTierCatalogExtendPro": "Extend Pro",
+  "subscriptionTierCatalogChooseLite": "Choose Lite",
+  "subscriptionTierCatalogExtendLite": "Extend Lite",
   "subscriptionTierCatalogNotSelected": "Downgrade is not available",
+  "subscriptionUpgradedToLite": "You're now Lite — enjoy!",
   "subscriptionTierCatalogSelectedInterval": "{amount} / {unit} — billed via Stripe",
   "@subscriptionTierCatalogSelectedInterval": {
     "placeholders": {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3695,6 +3695,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get subscriptionTierCatalogRecommended => 'Recommended';
 
   @override
+  String get subscriptionTierCatalogChooseLite => 'Choose Lite';
+
+  @override
+  String get subscriptionTierCatalogExtendLite => 'Extend Lite';
+
+  @override
+  String get subscriptionUpgradedToLite => 'You\'re now Lite — enjoy!';
+
+  @override
   String get subscriptionTierCatalogChoosePro => 'Choose Pro';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3536,6 +3536,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get subscriptionTierCatalogRecommended => '推荐';
 
   @override
+  String get subscriptionTierCatalogChooseLite => '选择 Lite';
+
+  @override
+  String get subscriptionTierCatalogExtendLite => '续费 Lite';
+
+  @override
+  String get subscriptionUpgradedToLite => '已升级为 Lite，尽情享受吧！';
+
+  @override
   String get subscriptionTierCatalogChoosePro => '选择 Pro';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1385,7 +1385,10 @@
   "subscriptionTierCatalogRecommended": "推荐",
   "subscriptionTierCatalogChoosePro": "选择 Pro",
   "subscriptionTierCatalogExtendPro": "续费 Pro",
+  "subscriptionTierCatalogChooseLite": "选择 Lite",
+  "subscriptionTierCatalogExtendLite": "续费 Lite",
   "subscriptionTierCatalogNotSelected": "暂不支持降级",
+  "subscriptionUpgradedToLite": "您已成为 Lite 会员！",
   "subscriptionTierCatalogSelectedInterval": "{amount} / {unit} — 通过 Stripe 计费",
   "@subscriptionTierCatalogSelectedInterval": {
     "placeholders": {

--- a/test/features/auth/presentation/widgets/sidebar_account_chip_test.dart
+++ b/test/features/auth/presentation/widgets/sidebar_account_chip_test.dart
@@ -160,6 +160,21 @@ const _proStatus = SubscriptionStatus(
   ),
 );
 
+const _liteStatus = SubscriptionStatus(
+  subscriptionActive: true,
+  subscriptionTier: SubscriptionTier.lite,
+  subscriptionExpireDate: '2030-12-31T00:00:00Z',
+);
+
+const _liteProfile = UserProfile(
+  id: 'user-3',
+  email: 'lite@example.com',
+  name: 'Lite Reader',
+  avatarUrl: null,
+  balance: 0,
+  subscriptionTier: SubscriptionTier.lite,
+);
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -226,6 +241,46 @@ void main() {
 
     expect(find.text('Pro Reader'), findsOneWidget);
     expect(find.text('Pro'), findsOneWidget);
+    expect(find.text('Upgrade'), findsNothing);
+  });
+
+  testWidgets('Signed-in lite: shows tier badge, no upgrade button', (
+    tester,
+  ) async {
+    final auth = _FakeAuthCtrl(const AuthSignedIn(profile: _liteProfile));
+    final scheme = ColorScheme.fromSeed(
+      seedColor: const Color(0xFF7B61FF),
+      brightness: Brightness.dark,
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authCtrlProvider.overrideWith(() => auth),
+          subscriptionStatusProvider.overrideWith((ref) async => _liteStatus),
+        ],
+        child: MaterialApp(
+          theme: ThemeData(
+            colorScheme: scheme,
+            useMaterial3: true,
+            brightness: Brightness.dark,
+            extensions: [EnjoyThemeTokens.build(scheme)],
+          ),
+          locale: const Locale('en', 'US'),
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: SidebarAccountChip()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Lite Reader'), findsOneWidget);
+    expect(find.text('Lite'), findsOneWidget);
     expect(find.text('Upgrade'), findsNothing);
   });
 

--- a/test/features/subscription/application/tier_reconcile_provider_test.dart
+++ b/test/features/subscription/application/tier_reconcile_provider_test.dart
@@ -22,6 +22,10 @@ const _proStatus = SubscriptionStatus(
   subscriptionActive: true,
   subscriptionTier: SubscriptionTier.pro,
 );
+const _liteStatus = SubscriptionStatus(
+  subscriptionActive: true,
+  subscriptionTier: SubscriptionTier.lite,
+);
 const _freeStatus = SubscriptionStatus(
   subscriptionActive: true,
   subscriptionTier: SubscriptionTier.free,
@@ -148,7 +152,7 @@ void main() {
     expect(notifier.hasPendingPurchase, isTrue);
   });
 
-  test('eager reconcile polls until Pro and clears the pending flag', () async {
+  test('eager reconcile polls until paid and clears the pending flag', () async {
     var statusCalls = 0;
     final container = ProviderContainer(
       overrides: [
@@ -173,6 +177,31 @@ void main() {
 
     expect(container.read(currentTierProvider), SubscriptionTier.pro);
     expect(authNotifier.refreshCalls, greaterThanOrEqualTo(1));
+    expect(notifier.hasPendingPurchase, isFalse);
+  });
+
+  test('eager reconcile also confirms Lite as a paid tier', () async {
+    var statusCalls = 0;
+    final container = ProviderContainer(
+      overrides: [
+        authCtrlProvider.overrideWith(_RecordingAuthCtrl.new),
+        subscriptionStatusProvider.overrideWith((ref) async {
+          statusCalls++;
+          return statusCalls >= 2 ? _liteStatus : _freeStatus;
+        }),
+        creditsSummaryProvider.overrideWith(
+          (ref) async => _summary(permanent: 0),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(authCtrlProvider.future);
+    final notifier = container.read(tierReconcileCtrlProvider.notifier);
+
+    notifier.markPurchasePending();
+    expect(await notifier.reconcile(eager: true), isTrue);
+
+    expect(container.read(currentTierProvider), SubscriptionTier.lite);
     expect(notifier.hasPendingPurchase, isFalse);
   });
 

--- a/test/features/subscription/data/subscription_repository_test.dart
+++ b/test/features/subscription/data/subscription_repository_test.dart
@@ -25,6 +25,7 @@ class _FakeSubscriptionApi implements SubscriptionApi {
   Future<Map<String, dynamic>> purchase({
     required int months,
     PaymentProcessor processor = PaymentProcessor.stripe,
+    required String tier,
   }) => _handler('purchase');
 
   @override
@@ -102,7 +103,11 @@ void main() {
       );
 
       final session = await repo.purchase(
-        const PurchaseRequest(months: 1, processor: PaymentProcessor.stripe),
+        const PurchaseRequest(
+          months: 1,
+          processor: PaymentProcessor.stripe,
+          tier: 'pro',
+        ),
       );
       expect(session.payUrl, 'https://pay.example.com');
     });
@@ -145,6 +150,7 @@ class _ThrowingApi implements SubscriptionApi {
   Future<Map<String, dynamic>> purchase({
     required int months,
     PaymentProcessor processor = PaymentProcessor.stripe,
+    required String tier,
   }) => throw error;
 
   @override

--- a/test/features/subscription/presentation/auto_renew_plan_sheet_test.dart
+++ b/test/features/subscription/presentation/auto_renew_plan_sheet_test.dart
@@ -75,8 +75,11 @@ class _SheetLauncher extends StatelessWidget {
     return Scaffold(
       body: Center(
         child: ElevatedButton(
-          onPressed: () =>
-              showUnifiedPurchaseSheet(context, interval: interval),
+          onPressed: () => showUnifiedPurchaseSheet(
+            context,
+            tier: SubscriptionTier.pro,
+            interval: interval,
+          ),
           child: const Text('Open Sheet'),
         ),
       ),
@@ -342,10 +345,11 @@ void main() {
     });
 
     testWidgets(
-      'auto-renew fallback price matches the selected interval when no matching plan',
+      'auto-renew falls back to a skeleton when no matching plan is loaded',
       (tester) async {
         // Only a yearly pro plan exists, so opening the sheet at the monthly
-        // interval forces the fallback price path (no plan matches `month`).
+        // interval forces the no-plan-for-this-interval path. The UI must
+        // show a skeleton, never a hardcoded fallback price.
         const yearlyOnly = [
           SubscriptionPlan(
             id: 'plan_yearly',
@@ -373,22 +377,23 @@ void main() {
         await tester.tap(find.text('Open Sheet'));
         await tester.pumpAndSettle();
 
+        // When the selected plan is missing, the auto-renew CTA is rendered
+        // but disabled (so the user cannot proceed with a stale price).
         final l10n = lookupAppLocalizations(const Locale('en'));
+        final cta = find.text(l10n.subscriptionPurchaseModalSubscribeAutoRenewCta);
+        expect(cta, findsOneWidget);
+        final widget = tester.widget<FilledButton>(
+          find.ancestor(of: cta, matching: find.byType(FilledButton)).first,
+        );
+        expect(widget.onPressed, isNull);
 
-        // Auto-renew card shows the monthly fallback price plus the monthly
-        // interval label, never the yearly fallback.
+        // No hardcoded fallback price is rendered.
         expect(
-          find.text(
-            '${l10n.subscriptionAutoRenewPriceMonth('9.99')} · '
-            '${l10n.subscriptionAutoRenewMonthly}',
-          ),
-          findsOneWidget,
+          find.text(l10n.subscriptionAutoRenewPriceMonth('9.99')),
+          findsNothing,
         );
         expect(
-          find.text(
-            '${l10n.subscriptionAutoRenewPriceMonth('99.99')} · '
-            '${l10n.subscriptionAutoRenewMonthly}',
-          ),
+          find.text(l10n.subscriptionAutoRenewPriceMonth('99.99')),
           findsNothing,
         );
 

--- a/test/features/subscription/presentation/subscription_screen_test.dart
+++ b/test/features/subscription/presentation/subscription_screen_test.dart
@@ -129,11 +129,13 @@ void main() {
     expect(find.text(l10n.subscriptionTitle), findsWidgets);
     // Catalog title is shown.
     expect(find.text(l10n.subscriptionTierCatalogTitle), findsOneWidget);
-    // Free + Pro tier names appear on their cards.
+    // Free + Lite + Pro tier names appear on their cards.
     expect(find.text(l10n.subscriptionTierFreeName), findsWidgets);
+    expect(find.text(l10n.subscriptionTierLiteName), findsWidgets);
     expect(find.text(l10n.subscriptionTierProName), findsWidgets);
     // Pro tier CTA is "Choose Pro" (the user is not on Pro yet).
     expect(find.text(l10n.subscriptionTierCatalogChoosePro), findsOneWidget);
+    expect(find.text(l10n.subscriptionTierCatalogChooseLite), findsOneWidget);
   });
 
   testWidgets('shows retry on error', (tester) async {

--- a/test/features/subscription/presentation/tier_reconcile_host_test.dart
+++ b/test/features/subscription/presentation/tier_reconcile_host_test.dart
@@ -41,6 +41,16 @@ const _proStatus = SubscriptionStatus(
   subscriptionActive: true,
   subscriptionTier: SubscriptionTier.pro,
 );
+const _liteStatus = SubscriptionStatus(
+  subscriptionActive: true,
+  subscriptionTier: SubscriptionTier.lite,
+);
+const _liteProfile = UserProfile(
+  id: 'u1',
+  email: 'a@b.com',
+  name: 'Lite',
+  subscriptionTier: SubscriptionTier.lite,
+);
 
 Widget _harness({
   required UserProfile profile,
@@ -70,6 +80,29 @@ void main() {
 
     final l10n = lookupAppLocalizations(const Locale('en'));
     expect(find.text(l10n.subscriptionUpgradedToPro), findsOneWidget);
+  });
+
+  testWidgets('celebrates a free -> Lite transition', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authCtrlProvider.overrideWith(
+            () => _NoOpRefreshAuthCtrl(_freeProfile),
+          ),
+          subscriptionStatusProvider.overrideWith((ref) async => _liteStatus),
+        ],
+        child: MaterialApp(
+          scaffoldMessengerKey: appScaffoldMessengerKey,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const TierReconcileHost(child: Scaffold(body: SizedBox.expand())),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.subscriptionUpgradedToLite), findsOneWidget);
   });
 
   testWidgets('does not celebrate when already Pro on mount', (tester) async {

--- a/test/features/subscription/presentation/widgets/purchase_sheet_test.dart
+++ b/test/features/subscription/presentation/widgets/purchase_sheet_test.dart
@@ -121,8 +121,15 @@ void main() {
   });
 
   group('PurchaseRequest', () {
-    test('monthly price constant is positive', () {
-      expect(kSubscriptionMonthlyPriceUsd, greaterThan(0));
+    test('toJson includes tier', () {
+      const request = PurchaseRequest(
+        months: 1,
+        processor: PaymentProcessor.stripe,
+        tier: 'pro',
+      );
+      expect(request.toJson()['tier'], 'pro');
+      expect(request.toJson()['months'], 1);
+      expect(request.toJson()['processor'], 'stripe');
     });
   });
 }

--- a/test/features/subscription/subscription_purchase_provider_test.dart
+++ b/test/features/subscription/subscription_purchase_provider_test.dart
@@ -193,7 +193,11 @@ void main() {
 
       final result = await container
           .read(subscriptionPurchaseCtrlProvider.notifier)
-          .purchaseExternal(months: 3, processor: PaymentProcessor.stripe);
+          .purchaseExternal(
+            months: 3,
+            processor: PaymentProcessor.stripe,
+            tier: 'pro',
+          );
 
       expect(result, isNotNull);
       expect(result!.id, 'sess-1');
@@ -222,7 +226,11 @@ void main() {
       await expectLater(
         container
             .read(subscriptionPurchaseCtrlProvider.notifier)
-            .purchaseExternal(months: 1, processor: PaymentProcessor.mixin),
+            .purchaseExternal(
+              months: 1,
+              processor: PaymentProcessor.mixin,
+              tier: 'pro',
+            ),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -247,7 +255,11 @@ void main() {
       await expectLater(
         container
             .read(subscriptionPurchaseCtrlProvider.notifier)
-            .purchaseExternal(months: 1, processor: PaymentProcessor.stripe),
+            .purchaseExternal(
+              months: 1,
+              processor: PaymentProcessor.stripe,
+              tier: 'pro',
+            ),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -269,7 +281,11 @@ void main() {
       await expectLater(
         container
             .read(subscriptionPurchaseCtrlProvider.notifier)
-            .purchaseExternal(months: 1, processor: PaymentProcessor.stripe),
+            .purchaseExternal(
+              months: 1,
+              processor: PaymentProcessor.stripe,
+              tier: 'pro',
+            ),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
@@ -293,7 +309,11 @@ void main() {
       await expectLater(
         container
             .read(subscriptionPurchaseCtrlProvider.notifier)
-            .purchaseExternal(months: 6, processor: PaymentProcessor.stripe),
+            .purchaseExternal(
+              months: 6,
+              processor: PaymentProcessor.stripe,
+              tier: 'pro',
+            ),
         throwsA(isA<StateError>()),
       );
 

--- a/test/features/vocabulary/vocabulary_anki_export_build_test.dart
+++ b/test/features/vocabulary/vocabulary_anki_export_build_test.dart
@@ -192,12 +192,12 @@ void main() {
   });
 
   group('runVocabularyAnkiExport', () {
-    test('returns cancelled when not Pro and IO is not invoked', () async {
-      // Even with valid items, !isPro must short-circuit before reaching IO.
+    test('returns cancelled when not paid and IO is not invoked', () async {
+      // Even with valid items, !isPaid must short-circuit before reaching IO.
       var listAllCalled = false;
       try {
         await runVocabularyAnkiExport(
-          isPro: false,
+          isPaid: false,
           listAll: () async {
             listAllCalled = true;
             return const <VocabularyItem>[];
@@ -207,7 +207,7 @@ void main() {
         );
         fail('expected StateError');
       } on StateError catch (e) {
-        expect(e.message, 'pro_required');
+        expect(e.message, 'paid_required');
       }
       expect(listAllCalled, isFalse);
     });
@@ -235,32 +235,32 @@ void main() {
         ),
       ];
       // Stub the IO layer indirectly: we cannot in test (no GetIt / DI),
-      // however Pro gating is the testable seam — called with isPro=false ⇒ throw.
+      // however paid gating is the testable seam — called with isPaid=false ⇒ throw.
       expect(
         () => runVocabularyAnkiExport(
-          isPro: false,
+          isPaid: false,
           listAll: () async => items,
           getContextsForItem: (_) async => const <VocabularyContext>[],
           filters: const VocabularyAnkiExportFilters(),
         ),
         throwsA(
-          isA<StateError>().having((e) => e.message, 'message', 'pro_required'),
+          isA<StateError>().having((e) => e.message, 'message', 'paid_required'),
         ),
       );
     });
 
-    test('pro_required is the only error when isPro is false', () async {
-      // Sanity check: empty listAll + isPro=false still throws pro_required,
-      // confirming the pro gate runs BEFORE the no-items check.
+    test('paid_required is the only error when isPaid is false', () async {
+      // Sanity check: empty listAll + isPaid=false still throws paid_required,
+      // confirming the paid gate runs BEFORE the no-items check.
       expect(
         () => runVocabularyAnkiExport(
-          isPro: false,
+          isPaid: false,
           listAll: () async => const <VocabularyItem>[],
           getContextsForItem: (_) async => const <VocabularyContext>[],
           filters: const VocabularyAnkiExportFilters(),
         ),
         throwsA(
-          isA<StateError>().having((e) => e.message, 'message', 'pro_required'),
+          isA<StateError>().having((e) => e.message, 'message', 'paid_required'),
         ),
       );
     });
@@ -274,14 +274,14 @@ void main() {
       Future<void> probe() async {
         try {
           await runVocabularyAnkiExport(
-            isPro: false,
+            isPaid: false,
             listAll: () async => const <VocabularyItem>[],
             getContextsForItem: (_) async => const <VocabularyContext>[],
             filters: const VocabularyAnkiExportFilters(),
             dialogTitle: title,
           );
         } on StateError {
-          // expected: pro_required
+          // expected: paid_required
         }
       }
 

--- a/test/features/vocabulary/vocabulary_anki_export_gate_test.dart
+++ b/test/features/vocabulary/vocabulary_anki_export_gate_test.dart
@@ -7,26 +7,37 @@ import 'package:enjoy_player/features/vocabulary/domain/vocabulary_models.dart';
 
 void main() {
   group('vocabularyAnkiExportAllowedFrom', () {
-    test('uses subscriptionIsPro when provided', () {
+    test('uses subscriptionIsPaid when provided', () {
       expect(
         vocabularyAnkiExportAllowedFrom(
           tier: SubscriptionTier.free,
-          subscriptionIsPro: true,
+          subscriptionIsPaid: true,
         ),
         isTrue,
       );
       expect(
         vocabularyAnkiExportAllowedFrom(
+          tier: SubscriptionTier.lite,
+          subscriptionIsPaid: false,
+        ),
+        isFalse,
+      );
+      expect(
+        vocabularyAnkiExportAllowedFrom(
           tier: SubscriptionTier.pro,
-          subscriptionIsPro: false,
+          subscriptionIsPaid: false,
         ),
         isFalse,
       );
     });
 
-    test('falls back to tier when subscriptionIsPro is null', () {
+    test('falls back to tier when subscriptionIsPaid is null', () {
       expect(
         vocabularyAnkiExportAllowedFrom(tier: SubscriptionTier.pro),
+        isTrue,
+      );
+      expect(
+        vocabularyAnkiExportAllowedFrom(tier: SubscriptionTier.lite),
         isTrue,
       );
       expect(
@@ -37,16 +48,16 @@ void main() {
   });
 
   group('runVocabularyAnkiExport', () {
-    test('throws pro_required when not Pro', () async {
+    test('throws paid_required when not paid', () async {
       expect(
         () => runVocabularyAnkiExport(
-          isPro: false,
+          isPaid: false,
           listAll: () async => const [],
           getContextsForItem: (_) async => const [],
           filters: const VocabularyAnkiExportFilters(),
         ),
         throwsA(
-          isA<StateError>().having((e) => e.message, 'message', 'pro_required'),
+          isA<StateError>().having((e) => e.message, 'message', 'paid_required'),
         ),
       );
     });
@@ -71,7 +82,7 @@ void main() {
       ];
       expect(
         () => runVocabularyAnkiExport(
-          isPro: true,
+          isPaid: true,
           listAll: () async => items,
           getContextsForItem: (_) async => const [],
           filters: const VocabularyAnkiExportFilters(


### PR DESCRIPTION
## Summary

Mirrors the web app's unified Free / Lite / Pro tier catalog in the Flutter client. Refactors feature gates from `isPro` / `SubscriptionTier.pro` to `isPaidTier` / `'tier != free'` so Lite members unlock the same features as Pro (the project uses a pure credits-based model — only the daily credit pool differs by tier).

## Changes

- **TierCatalog**: 3-card layout (Free / Lite / Pro), new `onChoosePaid` callback. Prices and savings badge derive from the plans catalog (`GET /api/v1/subscriptions/plans`); skeleton when no plan is loaded.
- **showUnifiedPurchaseSheet**: tier-aware plan resolution, tier-aware labels and totals; CTA disabled until the catalog has loaded.
- **PurchaseRequest** gains a required `tier` field; `api.purchase` sends it in the body; the new `prepaidUnitPriceForTier` helper looks up the monthly plan from the catalog (replaces `kSubscriptionMonthlyPriceUsd`).
- **SubscriptionStatusCard**: rich membership card now shows for any paid tier (Lite or Pro) with tier-aware title and badge.
- **pro? -> paid? refactor** across:
  - `profile_hero_card` (Upgrade CTA only for free; `SubscriptionChip` shows Pro / Lite / Free).
  - `sidebar_account_chip` (paid badge for any paid tier, upgrade for free).
  - `vocabulary_anki_export` (`isPaid` gate, `'paid_required'` error).
  - `profile_content` (tier-based daily credit limit using the live `SubscriptionStatus`).
  - `tier_reconcile_provider` (poll for `isPaidTier`, not `== Pro`).
  - `tier_reconcile_host` (celebrate free -> any paid tier with a tier-aware toast).
- **Legacy** `purchase_sheet.dart` marked deprecated; uses the catalog helper and a deprecated Pro default.
- **New l10n** strings (`subscriptionTierCatalogChooseLite` / `ExtendLite` / `subscriptionUpgradedToLite`) in en + zh.
- **Tests updated**: Lite status fixtures added, tier param threaded through `purchaseExternal`, `isPro`/`'pro_required'` -> `isPaid`/`'paid_required'`.

## Test plan

- [ ] `flutter analyze` (CI gate)
- [ ] `flutter test` (CI gate)
- [ ] `bash .github/scripts/validate_ci_gates.sh` (full local CI mirror)

L10n: `app_en.arb` / `app_zh.arb` updated; `app_localizations_en.dart` / `app_localizations_zh.dart` regenerated by hand to match (no `flutter gen-l10n` available in this env — reviewers should run `flutter gen-l10n` locally if any drift appears).