### PR TITLE
refactor(release): dedupe TestFlight upload + ASC private-key resolution

### DIFF
--- a/.github/scripts/release_apple.sh
+++ b/.github/scripts/release_apple.sh
@@ -137,16 +137,12 @@ if [[ "${RELEASE_SKIP_BUILD}" != true ]]; then
     flutter build ipa --release --export-options-plist=ios/ExportOptions.export.plist
 
     if [[ "${UPLOAD_TESTFLIGHT}" == true ]]; then
-      KEY_PATH="${RUNNER_TEMP:-/tmp}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-      release_write_asc_api_private_key "${KEY_PATH}"
-      # altool discovers AuthKey_<id>.p8 on its private-keys search path.
-      export API_PRIVATE_KEYS_DIR="$(dirname "${KEY_PATH}")"
       IPA="$(ls -1 "${root}/build/ios/ipa/"*.ipa | head -1)"
-      echo ">>> Upload IPA to TestFlight: ${IPA}"
-      xcrun altool --upload-app --type ios --file "${IPA}" \
-        --apiKey "${APP_STORE_CONNECT_API_KEY_ID}" \
-        --apiIssuer "${APP_STORE_CONNECT_ISSUER_ID}"
-      rm -f "${KEY_PATH}"
+      if [[ -z "${IPA}" ]]; then
+        echo "Missing IPA under build/ios/ipa/ — flutter build ipa did not produce one." >&2
+        exit 1
+      fi
+      release_upload_testflight_ipa "${IPA}"
     fi
   fi
 
@@ -173,14 +169,7 @@ else
       echo "Missing IPA under build/ios/ipa/ — build first or drop --skip-build." >&2
       exit 1
     fi
-    KEY_PATH="${RUNNER_TEMP:-/tmp}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-    release_write_asc_api_private_key "${KEY_PATH}"
-    export API_PRIVATE_KEYS_DIR="$(dirname "${KEY_PATH}")"
-    echo ">>> Upload existing IPA to TestFlight: ${IPA}"
-    xcrun altool --upload-app --type ios --file "${IPA}" \
-      --apiKey "${APP_STORE_CONNECT_API_KEY_ID}" \
-      --apiIssuer "${APP_STORE_CONNECT_ISSUER_ID}"
-    rm -f "${KEY_PATH}"
+    release_upload_testflight_ipa "${IPA}"
   fi
 
   if [[ "${NOTARIZE}" == true || "${RELEASE_PUBLISH}" == true ]]; then

--- a/.github/scripts/release_lib.sh
+++ b/.github/scripts/release_lib.sh
@@ -367,16 +367,7 @@ release_load_asc_env() {
   fi
 
   if [[ -z "${APP_STORE_CONNECT_API_PRIVATE_KEY:-}" && -n "${APP_STORE_CONNECT_API_KEY_ID:-}" ]]; then
-    if [[ -n "${APP_STORE_CONNECT_API_PRIVATE_KEY_PATH:-}" && -f "${APP_STORE_CONNECT_API_PRIVATE_KEY_PATH}" ]]; then
-      key_path="${APP_STORE_CONNECT_API_PRIVATE_KEY_PATH}"
-    elif [[ -f "${cache_dir}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8" ]]; then
-      key_path="${cache_dir}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-    elif [[ -f "${root}/.apple/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8" ]]; then
-      # Legacy repo-local path; prefer migrating to ~/.config/enjoy-player/.
-      key_path="${root}/.apple/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-    elif [[ -f "${HOME}/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8" ]]; then
-      key_path="${HOME}/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-    fi
+    key_path="$(release_resolve_asc_private_key "${root}" "${cache_dir}" "${APP_STORE_CONNECT_API_KEY_ID}")"
     if [[ -n "${key_path}" ]]; then
       APP_STORE_CONNECT_API_PRIVATE_KEY="$(cat "${key_path}")"
       export APP_STORE_CONNECT_API_PRIVATE_KEY
@@ -387,6 +378,58 @@ release_load_asc_env() {
   if release_asc_env_ready; then
     export APP_STORE_CONNECT_API_KEY_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_API_PRIVATE_KEY
   fi
+}
+
+# Resolve the App Store Connect API private key path with full precedence.
+# Prints the first existing match and the source bucket (on stdout, NUL-separated
+# when the caller asks for both via the second positional mode); returns 1 when
+# no file is found. Buckets mirror release_load_asc_env so the preflight can
+# report canonical / legacy / explicit-path / standard private_keys cases from
+# the same source of truth.
+#
+# Usage:
+#   release_resolve_asc_private_key <root> <cache_dir> <key_id>
+#     -> prints "<bucket>\t<path>" on stdout when found; empty + rc=1 otherwise.
+#
+# Buckets:
+#   explicit  — APP_STORE_CONNECT_API_PRIVATE_KEY_PATH override (if set + readable)
+#   cache     — <cache_dir>/AuthKey_<KEY_ID>.p8  (preferred canonical location)
+#   legacy    — <root>/.apple/AuthKey_<KEY_ID>.p8  (pre-~/.config/enjoy-player)
+#   standard  — ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8  (Apple CLI default)
+release_resolve_asc_private_key() {
+  local root="$1"
+  local cache_dir="$2"
+  local key_id="$3"
+  local candidate=""
+
+  if [[ -z "${key_id}" ]]; then
+    return 1
+  fi
+
+  if [[ -n "${APP_STORE_CONNECT_API_PRIVATE_KEY_PATH:-}" && -f "${APP_STORE_CONNECT_API_PRIVATE_KEY_PATH}" ]]; then
+    printf 'explicit\t%s\n' "${APP_STORE_CONNECT_API_PRIVATE_KEY_PATH}"
+    return 0
+  fi
+
+  candidate="${cache_dir}/AuthKey_${key_id}.p8"
+  if [[ -f "${candidate}" ]]; then
+    printf 'cache\t%s\n' "${candidate}"
+    return 0
+  fi
+
+  candidate="${root}/.apple/AuthKey_${key_id}.p8"
+  if [[ -f "${candidate}" ]]; then
+    printf 'legacy\t%s\n' "${candidate}"
+    return 0
+  fi
+
+  candidate="${HOME}/.appstoreconnect/private_keys/AuthKey_${key_id}.p8"
+  if [[ -f "${candidate}" ]]; then
+    printf 'standard\t%s\n' "${candidate}"
+    return 0
+  fi
+
+  return 1
 }
 
 # Write App Store Connect API .p8 from APP_STORE_CONNECT_API_PRIVATE_KEY.
@@ -416,6 +459,44 @@ release_write_asc_api_private_key() {
     echo "ASC API private key is not a PEM (missing BEGIN PRIVATE KEY)." >&2
     return 1
   fi
+}
+
+# Upload an iOS IPA to TestFlight via altool using the already-loaded ASC env.
+# Stages the .p8 under ${RUNNER_TEMP:-/tmp}, exports API_PRIVATE_KEYS_DIR for
+# altool's discovery, runs `xcrun altool --upload-app`, and guarantees the
+# temporary key is removed (trap-based) so a failed upload does not leak the
+# credential on disk.
+#
+# Required env (call release_load_asc_env first):
+#   APP_STORE_CONNECT_API_KEY_ID, APP_STORE_CONNECT_ISSUER_ID,
+#   APP_STORE_CONNECT_API_PRIVATE_KEY.
+#
+# Args:
+#   $1 IPA path (must exist; caller validates before invoking).
+release_upload_testflight_ipa() {
+  local ipa="$1"
+  local key_path="${RUNNER_TEMP:-/tmp}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+
+  if [[ ! -f "${ipa}" ]]; then
+    echo "release_upload_testflight_ipa: missing IPA: ${ipa}" >&2
+    return 1
+  fi
+  if ! release_asc_env_ready; then
+    echo "release_upload_testflight_ipa: ASC credentials not loaded." >&2
+    return 1
+  fi
+
+  release_write_asc_api_private_key "${key_path}"
+  # altool discovers AuthKey_<id>.p8 on its private-keys search path.
+  export API_PRIVATE_KEYS_DIR="$(dirname "${key_path}")"
+
+  # Ensure the temporary key is removed even if altool fails mid-upload.
+  trap 'rm -f "${key_path}"' RETURN
+
+  echo ">>> Upload IPA to TestFlight: ${ipa}"
+  xcrun altool --upload-app --type ios --file "${ipa}" \
+    --apiKey "${APP_STORE_CONNECT_API_KEY_ID}" \
+    --apiIssuer "${APP_STORE_CONNECT_ISSUER_ID}"
 }
 
 # Stop stale Gradle daemons so the next bundle build picks up gradle.properties

--- a/.github/scripts/verify_macos_release_env.sh
+++ b/.github/scripts/verify_macos_release_env.sh
@@ -96,12 +96,27 @@ fi
 
 if [[ -n "${APP_STORE_CONNECT_API_KEY_ID:-}" ]]; then
   ok "API key id: ${APP_STORE_CONNECT_API_KEY_ID}"
-  preferred_p8="${asc_dir}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-  legacy_p8="${root}/.apple/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-  if [[ -f "${preferred_p8}" ]]; then
-    ok "AuthKey at ${preferred_p8}"
-  elif [[ -f "${legacy_p8}" ]]; then
-    warn "AuthKey still at legacy ${legacy_p8} — move to ${preferred_p8}"
+  # Single source of truth for key location: release_resolve_asc_private_key.
+  # We render its bucket/path into the existing OK/WARN messages so the preflight
+  # agrees with release_load_asc_env about where the .p8 came from.
+  if resolved="$(release_resolve_asc_private_key "${root}" "${asc_dir}" "${APP_STORE_CONNECT_API_KEY_ID}")"; then
+    resolved_bucket="${resolved%%	*}"
+    resolved_path="${resolved#*	}"
+    case "${resolved_bucket}" in
+      cache)
+        ok "AuthKey at ${resolved_path}"
+        ;;
+      legacy)
+        warn "AuthKey still at legacy ${resolved_path} — move to ${asc_dir}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+        ;;
+      standard)
+        ok "AuthKey at standard location ${resolved_path}"
+        warn "Move AuthKey to ${asc_dir}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8 so it survives runner re-imaging"
+        ;;
+      explicit)
+        ok "AuthKey from APP_STORE_CONNECT_API_PRIVATE_KEY_PATH (${resolved_path})"
+        ;;
+    esac
   else
     warn "AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8 not found under ${asc_dir}"
   fi


### PR DESCRIPTION
Closes #529, closes #530.

## Issue #529 — TestFlight upload flow

`release_apple.sh` had two near-identical upload blocks
(built IPA path at L139-L149 and `--skip-build` retry at L175-L183) that each:

1. constructed `RUNNER_TEMP/AuthKey_<KEY_ID>.p8`,
2. staged it via `release_write_asc_api_private_key`,
3. exported `API_PRIVATE_KEYS_DIR`,
4. ran `xcrun altool --upload-app` with the same `--apiKey` / `--apiIssuer`,
5. removed the temp file.

Extract that flow into `release_upload_testflight_ipa` in `release_lib.sh`. The helper uses a `trap ... RETURN` so the temporary key is removed even when `altool` fails mid-upload (closes the credential-on-disk leak path that the original `rm -f` only covered on the happy path). Both call sites in `release_apple.sh` now just locate the IPA and call the helper.

## Issue #530 — ASC private-key path resolution

`release_load_asc_env` (release_lib.sh) and `verify_macos_release_env.sh` each independently walked the ASC .p8 candidate paths (`APP_STORE_CONNECT_API_PRIVATE_KEY_PATH` → `~/.config/enjoy-player/AuthKey` → `.apple/AuthKey` → `~/.appstoreconnect/private_keys/AuthKey`). Adding a new supported location meant editing both files, and the preflight could warn about a missing canonical key even when the loader had found a valid standard / private_keys file.

Introduce `release_resolve_asc_private_key` that prints `<bucket>\t<path>` for the first existing match and returns 1 otherwise. Buckets:
- `explicit` — `APP_STORE_CONNECT_API_PRIVATE_KEY_PATH` override
- `cache` — `<~/.config/enjoy-player>/AuthKey_<KEY_ID>.p8` (preferred canonical)
- `legacy` — `<root>/.apple/AuthKey_<KEY_ID>.p8` (pre-migration)
- `standard` — `~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8` (Apple CLI default)

`release_load_asc_env` consumes the resolver to load the key; `verify_macos_release_env.sh` consumes it for its canonical / legacy / standard / explicit OK/WARN messages. The preflight can no longer disagree with the loader about whether a key is usable.

## Files

- `.github/scripts/release_lib.sh` — +2 helpers (`release_resolve_asc_private_key`, `release_upload_testflight_ipa`); `release_load_asc_env` now delegates.
- `.github/scripts/release_apple.sh` — both upload blocks replaced with `release_upload_testflight_ipa`.
- `.github/scripts/verify_macos_release_env.sh` — ASC key location section consumes the resolver.

## Verification

```bash
bash -n .github/scripts/release_lib.sh
bash -n .github/scripts/release_apple.sh
bash -n .github/scripts/verify_macos_release_env.sh
```

Plus smoke tests confirming:
- `release_resolve_asc_private_key` ordering (`explicit > cache > legacy > standard`), empty key_id guard.
- `release_upload_testflight_ipa` happy path, altool-failure cleanup, and missing-IPA fast-fail (no key staged).
- `verify_macos_release_env.sh` consumes the resolver in the same `<bucket>\t<path>` pattern it expects.

Real Apple release verification is gated to macOS runners and will run on first PR CI; this refactor is otherwise additive and only edits the ASC + TestFlight sections.