### PR TITLE
fix(ai): send usage.tts.textLength instead of durationSeconds

### DIFF
--- a/docs/features/craft.md
+++ b/docs/features/craft.md
@@ -138,7 +138,7 @@ Per-call voice selection is v1 scope; the provider-default voice is used for ini
 | Synthesize | `ttsServiceProvider` → `EnjoyTtsCapability` → Azure Speech SDK (worker token) | `ttsServiceProvider` → BYOK TTS (OpenAI `/audio/speech` or Azure Speech subscription key) |
 
 **Azure Speech SDK wiring** (`lib/features/craft/data/craft_tts_service_synthesizer.dart`):
-1. Fetch a short-lived Azure token via `AzureTokenCache.getToken(purpose: 'tts')` (worker endpoint `POST /azure/tokens`, 9-min TTL).
+1. Fetch a short-lived Azure token via `AzureTokenCache.getToken(purpose: 'tts', textLength: text.length)` (worker endpoint `POST /azure/tokens`, 9-min TTL). The TTS body sends `usage.tts.textLength` (character count) — not a duration estimate — to match the worker `azureTokenBodySchema` Zod validator and the web `@enjoy/ai` contract.
 2. Call `AzureSpeech.instance.synthesize(text, voice, locale)` through the native plugin ([`packages/azure_speech`](../../packages/azure_speech/)).
 3. The native SDK returns a WAV byte buffer; saved to the app's audio directory.
 

--- a/lib/data/api/services/ai/azure_token_cache.dart
+++ b/lib/data/api/services/ai/azure_token_cache.dart
@@ -33,14 +33,24 @@ final class AzureTokenCache {
   /// the call budget. The completer is cleared once the fetch settles.
   Future<({String token, String region})>? _inFlight;
 
-  /// [durationSeconds] is forwarded for worker-side cost estimation.
+  /// Forwards the worker-side cost signal that matches [purpose].
   ///
-  /// [purpose] controls the worker-side token usage tag. Defaults to
-  /// `'assessment'` for back-compat with the assessment flow; pass `'tts'`
-  /// for Enjoy TTS synthesis (Craft from text).
+  /// The worker `POST /azure/tokens` schema (Zod) requires different
+  /// payload shapes per purpose:
+  ///
+  /// * `'assessment'` — `usage.assessment.durationSeconds` (int ≥ 0).
+  /// * `'tts'` — `usage.tts.textLength` (int ≥ 0, character count of the
+  ///   text to synthesize). Mirrors the web `@enjoy/ai` contract
+  ///   (`tts: { textLength: params.text.length }`).
+  ///
+  /// Pass the matching field for [purpose]; the other is ignored.
+  /// [purpose] defaults to `'assessment'` for back-compat with the
+  /// assessment flow; pass `'tts'` for Enjoy TTS synthesis (Craft from
+  /// text).
   Future<({String token, String region})> getToken({
-    required int durationSeconds,
     String purpose = 'assessment',
+    int? durationSeconds,
+    int? textLength,
   }) async {
     final now = DateTime.now();
     final at = _fetchedAt;
@@ -65,7 +75,7 @@ final class AzureTokenCache {
                     'durationSeconds': durationSeconds,
                   },
                 if (purpose == 'tts')
-                  'tts': <String, dynamic>{'durationSeconds': durationSeconds},
+                  'tts': <String, dynamic>{'textLength': textLength},
               },
             );
 

--- a/lib/features/ai/data/enjoy/enjoy_tts_capability.dart
+++ b/lib/features/ai/data/enjoy/enjoy_tts_capability.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:azure_speech/azure_speech.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
@@ -45,19 +43,19 @@ final class EnjoyTtsCapability implements TtsCapability {
       );
     }
 
-    // Estimate duration for worker cost attribution: ~150 words per minute,
-    // ~5 chars per word → ~750 chars per minute → ~12.5 chars per second.
-    final estimatedSeconds = max(1, (text.length / 12.5).ceil());
+    // The worker-side cost signal for TTS is the character count of the
+    // text to synthesize (mirrors the web `@enjoy/ai` `textLength` field,
+    // and the `azureTokenBodySchema` Zod validator on the worker).
+    final textLength = text.length;
 
     log.info(
-      'Synthesizing ${text.length} chars in $azureLanguage'
-      '${request.voice != null ? ' voice=${request.voice}' : ''}'
-      ' (~${estimatedSeconds}s estimated)',
+      'Synthesizing $textLength chars in $azureLanguage'
+      '${request.voice != null ? ' voice=${request.voice}' : ''}',
     );
 
     final token = await _tokenCache.getToken(
-      durationSeconds: estimatedSeconds,
       purpose: 'tts',
+      textLength: textLength,
     );
 
     try {

--- a/test/features/ai/azure_token_cache_dedup_test.dart
+++ b/test/features/ai/azure_token_cache_dedup_test.dart
@@ -9,12 +9,14 @@ class _FakeAzureTokenApi extends AzureTokenApi {
 
   final Future<Map<String, dynamic>> Function() handler;
   int callCount = 0;
+  final List<Map<String, dynamic>?> lastUsages = <Map<String, dynamic>?>[];
 
   @override
   Future<Map<String, dynamic>> generateToken({
     Map<String, dynamic>? usage,
   }) async {
     callCount += 1;
+    lastUsages.add(usage == null ? null : Map<String, dynamic>.of(usage));
     return handler();
   }
 }
@@ -139,5 +141,50 @@ void main() {
         throwsA(isA<StateError>()),
       );
     });
+
+    test('assessment purpose sends usage.assessment.durationSeconds', () async {
+      final api = _FakeAzureTokenApi(
+        () async => <String, dynamic>{'token': 'tok', 'region': 'westus'},
+      );
+      final cache = AzureTokenCache(api: api);
+
+      await cache.getToken(durationSeconds: 30);
+
+      expect(api.lastUsages, hasLength(1));
+      final usage = api.lastUsages.single!;
+      expect(usage['purpose'], 'assessment');
+      expect(usage['assessment'], isA<Map<String, dynamic>>());
+      expect((usage['assessment'] as Map)['durationSeconds'], 30);
+      expect(usage.containsKey('tts'), isFalse);
+    });
+
+    test(
+      'tts purpose sends usage.tts.textLength (not durationSeconds)',
+      () async {
+        final api = _FakeAzureTokenApi(
+          () async => <String, dynamic>{'token': 'tok', 'region': 'westus'},
+        );
+        final cache = AzureTokenCache(api: api);
+
+        // Pass a nonsense durationSeconds to prove it is NOT forwarded for TTS.
+        await cache.getToken(
+          purpose: 'tts',
+          textLength: 42,
+          durationSeconds: 9999,
+        );
+
+        expect(api.lastUsages, hasLength(1));
+        final usage = api.lastUsages.single!;
+        expect(usage['purpose'], 'tts');
+        expect(usage['tts'], isA<Map<String, dynamic>>());
+        expect((usage['tts'] as Map)['textLength'], 42);
+        expect(
+          (usage['tts'] as Map).containsKey('durationSeconds'),
+          isFalse,
+          reason: 'TTS payload must not contain durationSeconds (issue #544).',
+        );
+        expect(usage.containsKey('assessment'), isFalse);
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #544

## Summary

The Enjoy worker `POST /azure/tokens` Zod schema (`azureTokenBodySchema`) requires `usage.tts.textLength` (character count) for `purpose: 'tts'`, matching the web `@enjoy/ai` contract. The Flutter client was forwarding `usage.tts.durationSeconds` (an estimated audio duration), which the new validation rejects with HTTP 400 — breaking Enjoy TTS (Craft from text) on the Flutter client (59/59 production calls failing over the last 24h, while the web client is unaffected).

## Root cause

`AzureTokenCache.getToken` sent the wrong field for TTS:

```dart
if (purpose == 'tts')
  'tts': <String, dynamic>{'durationSeconds': durationSeconds},
```

The worker contract (and the web reference in `packages/ai/src/capabilities/tts/enjoy.ts` — `tts: { textLength: params.text.length }`) requires `usage.tts.textLength`. Assessment correctly uses `assessment.durationSeconds`; TTS must use `tts.textLength` (character count). Pre-2026-08-08 the malformed Flutter body still minted a token and charged 0 credits (`textLength` → `NaN` → `0`); after worker PR #986 added Zod validation, the same body is rejected with 400.

## Changes

* **`lib/data/api/services/ai/azure_token_cache.dart`** — `getToken` now takes optional `durationSeconds` and `textLength`, sending the right field per `purpose`. The assessment path still forwards `usage.assessment.durationSeconds`; TTS now sends `usage.tts.textLength`.
* **`lib/features/ai/data/enjoy/enjoy_tts_capability.dart`** — passes `text.length` (post-trim) and drops the old ~12.5-chars-per-second duration estimate. ASR / assessment callers are untouched.
* **`test/features/ai/azure_token_cache_dedup_test.dart`** — captures the `usage` argument on the fake `AzureTokenApi` and adds two regression tests:
  * assessment purpose → `usage.assessment.durationSeconds` (and no `tts` key)
  * tts purpose → `usage.tts.textLength` (and asserts the tts payload does **not** contain a stray `durationSeconds` key, even when one is mistakenly passed)
* **`docs/features/craft.md`** — documents the corrected TTS contract (worker `azureTokenBodySchema` + web `@enjoy/ai`).

## Acceptance criteria

- [x] Flutter `POST /azure/tokens` with `purpose: 'tts'` includes `usage.tts.textLength` (int ≥ 0)
- [x] Craft / Enjoy TTS payload no longer contains a `durationSeconds` field under `tts` (test asserts this)
- [x] Assessment token path still sends `usage.assessment.durationSeconds` (test asserts this)
- [x] Tests cover both TTS and assessment payload shapes
- [x] Existing AI / Craft / Azure-token-cache tests pass (`flutter test test/features/ai test/features/craft test/data/api/services/ai` — 635 tests)
- [x] `dart format` clean; pre-push hook (`check_dart_format` + `check_codegen_drift`) passes

## Verification

```bash
flutter test test/features/ai/azure_token_cache_dedup_test.dart
# 7/7 pass (5 existing + 2 new payload-shape tests)

flutter test test/features/ai test/features/craft test/data/api/services/ai
# 635/635 pass
```

Production verification (Enjoy TTS on a free-tier account) will need to run against the worker after merge, since the worker 400 only reproduces in prod.

## Related

* Issue: #544
* Worker schema: `apps/worker/src/routes/azure.ts` (`azureTokenBodySchema`)
* Web reference: `packages/ai/src/capabilities/tts/enjoy.ts` (`tts: { textLength: params.text.length }`)
* Worker PR that added the Zod check: enjoy PR #986 (merged 2026-08-08)