### PR TITLE
feat(craft): opt-in nested word/phone timings on save

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/038-alignment-spoken-reference"
+  "feature_directory": "specs/039-craft-timeline-enrichment"
 }

--- a/docs/decisions/0073-craft-timeline-enrichment.md
+++ b/docs/decisions/0073-craft-timeline-enrichment.md
@@ -1,0 +1,57 @@
+# ADR-0073: Craft timeline enrichment (first product caller)
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0070 stores optional nested word/phone spans on cues. ADR-0071 and
+ADR-0072 shipped `packages/forced_alignment` with spoken-reference
+`alignSegments`, still unused by product flows. Issue #540 slice 3 needs a
+**first caller** that can persist those nested spans without changing what
+learners see in the transcript panel.
+
+Craft already writes spec 030 synthesis-timing lines (or a blank transcript)
+on save. Alignment quality is not guaranteed on every clip, language, or
+host (missing eSpeak voice, extract failure, timeout). Save must not become
+more fragile than today.
+
+This ADR does **not** rewrite ADR-0070–0072.
+
+## Decision
+
+1. **First product caller is Craft save** — after `buildCraftPrimaryTimelineJson`
+   and before import/update. Caption import, YouTube, ASR, and auto-translate
+   stay line-only writers. Dedupe hits skip enrichment and do not rewrite the
+   existing item.
+2. **Default-off setting** — `transcript.timelineEnrichment` in `SettingsDao`
+   (`'true'`/`'false'`, missing ≡ off). Settings hub shows a Transcript
+   section with one switch. Settings Dart must not import
+   `package:forced_alignment/`. Turning the switch on does not backfill the
+   library.
+3. **Keep spec 030 lines** — enrichment attaches nested `TranscriptWord` /
+   `TranscriptPhone` onto the same line text/start/duration. Do not call
+   whole-clip `align()`. Segment `id` is the line index. Word times are
+   milliseconds relative to the line; phones stay in media-timeline seconds.
+   Craft may pass a primary tag (`en`); map it onto a focus alignment tag
+   (`en-US`) without swapping to a different language family.
+4. **Fail closed** — setting off, blank 030 JSON, extract failure, or
+   `AlignmentFailed` (including `spokenReferenceUnavailable`, unsupported
+   language, cancel, timeout) persist today’s line-only (or blank) JSON.
+   Alignment failure is never a blocking `CraftSaveFailure`. Quiet
+   `logNamed('craft.enrichment')` only. Never invent a transcript. Never
+   encode a duration-model stand-in as success. Honor the persisted setting
+   on the next save without treating a still-loading Settings read as off.
+5. **No karaoke / no reference playback** — the panel stays line-level.
+   Learners still hear Craft `previewAudioBytes` / saved WAV. The spoken
+   eSpeak reference is never played. No new `media_kit` `Player()`.
+
+## Consequences
+
+- Opt-in Craft items can store nested JSON that later karaoke / IPA slices
+  can read without a second alignment pass.
+- Default Craft/library behavior matches the pre-feature build.
+- Mapping and PCM live in `lib/data` so Craft does not import ASR.
+- Karaoke, IPA overlay, per-word tap, library backfill, first-play
+  alignment, and YouTube demux remain later slices.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -96,3 +96,4 @@ Trade-offs, follow-up work, risks.
 | [0070](0070-nested-transcript-timeline.md) | Additive nested word/phone spans on stored transcript cues, matching enjoy web `timeline`/`phones` (line identity unchanged; no UI yet) |
 | [0071](0071-on-device-alignment-engine.md) | On-device alignment engine (`packages/forced_alignment`) — Echogarden result interface, unused by product flows |
 | [0072](0072-spoken-alignment-reference.md) | Spoken alignment reference — eSpeak-NG `espeak_Synth` FFI, fail-closed, unused by product (supplements 0071) |
+| [0073](0073-craft-timeline-enrichment.md) | Craft timeline enrichment — opt-in Craft save is the first product caller of `alignSegments` (default off, fail-closed) |

--- a/docs/features/craft.md
+++ b/docs/features/craft.md
@@ -152,6 +152,8 @@ After synthesis, `wordBoundary` events from the Azure Speech SDK produce time-al
 
 **Solid timings only (ADR-0063)**: Craft writes a primary AI transcript (`source: 'ai'`) only when word boundaries are non-empty **and** the segmenter produces ≥1 non-empty line after punctuation merge. When word boundaries are missing (OpenAI BYOK TTS, or Linux which has no native TTS plugin), no transcript is saved — `primaryTimelineJson: null` is passed on import/update, which omits or deletes transcript rows. The audio file still saves successfully.
 
+**Opt-in nested word/phone spans (ADR-0073)**: Settings → Transcript → **Enrich Craft word timings** (`transcript.timelineEnrichment`, default **off**) may attach nested `timeline` / `phones` onto those same spec 030 lines at save time via on-device `alignSegments`. Off, blank 030 JSON, a dedupe hit, PCM extract failure, or alignment failure persist today’s line-only (or blank) transcript — never a blocking save error, never an invented cue list. Learners still hear the Azure/Craft WAV; the spoken alignment reference is not played. Karaoke / IPA overlay are later slices.
+
 - Items with a blank transcript open in the player with an empty transcript panel and a clear **Generate** affordance, allowing the learner to create cues via the existing player ASR flow (`launchAsrGeneration`) at any time.
 - No auto-STT runs on Craft save — the learner initiates ASR explicitly.
 - The `TranscriptTimestampEstimator` (duration-based proportional estimate) is no longer used on Craft save; the segmenter exclusively consumes live Azure word boundaries.
@@ -164,7 +166,7 @@ After synthesis, `wordBoundary` events from the Azure Speech SDK produce time-al
 | `Audios.source` | `'craft-express'` (Express mode), `'craft-translate'` (Advanced translate mode), or `'craft-direct'` (Advanced speak directly) |
 | `Audios.sourceText` | Original text (retained for re-generation). In Express mode this is the raw ASR transcript; in Advanced translate mode it is the source text; in speak directly it is empty. |
 | Audio file | WAV in app audio directory |
-| Transcript | One track (`source = 'ai'`) with word-boundary-segmented lines when solid timings are available; omitted (`null`) otherwise (see ADR-0063). Secondary source-text track in translate mode. Blank-transcript items show an ASR Generate affordance in the player. |
+| Transcript | One track (`source = 'ai'`) with word-boundary-segmented lines when solid timings are available; omitted (`null`) otherwise (see ADR-0063). When **Enrich Craft word timings** is on and alignment succeeds, those lines may also store nested word/phone spans (ADR-0073). Secondary source-text track in translate mode. Blank-transcript items show an ASR Generate affordance in the player. |
 
 ### Deduplication
 

--- a/docs/features/transcript.md
+++ b/docs/features/transcript.md
@@ -5,7 +5,7 @@
 - Primary transcript = `echo_sessions.transcript_id` for the latest session on `(targetType, targetId)` (same id as library media row).
 - **Track list stream** ([`TranscriptRepository.watchTracks`](../../lib/features/transcript/data/transcript_repository.dart)) exposes `List<TranscriptTrack>` per media id and is consumed through `allTranscriptsForMediaProvider`. Each `TranscriptTrack` defines **value equality** across its 7 fields (`id`, `targetType`, `targetId`, `language`, `source`, `label`, `trackIndex`), and the stream applies [`StreamDistinctExt.distinctBy`](../conventions.md#stream-dedupe-long-live-streams) with an element-wise list comparator so identical Drift re-emissions (e.g. an `echo_sessions` bump that doesn't change the resolved track list) never reach Riverpod listeners. Always-mounted consumers like `TransportCcButton` (the transport-bar CC indicator) only rebuild on real track changes — see `test/features/transcript/transcript_tracks_dedupe_test.dart` (9 pinning tests for skip-on-no-op and re-emit-on-real-change).
 - Import `.srt` / `.vtt` via `SubtitleParserFacade` storing JSON in `transcripts.timeline_json`. Imports use `source: user` and a user-chosen BCP-47 **language** (one row per `(target, source, language)` via deterministic id).
-- **Nested word/phone spans (storage only)** ([ADR-0070](../decisions/0070-nested-transcript-timeline.md)): a cue MAY include optional `timeline` (word spans) and each word MAY include `phones` (IPA + seconds), matching enjoy web `TranscriptLine` / `TranscriptWord`. Existing producers still write line-only `{text, start, duration}`. The transcript panel, current-line tracking, echo, lookup, and auto-translate ignore nested spans and keep using line text and line times. There is no Settings toggle in this slice. Karaoke / IPA overlay / Craft alignment land in later specs.
+- **Nested word/phone spans (storage only)** ([ADR-0070](../decisions/0070-nested-transcript-timeline.md), [ADR-0073](../decisions/0073-craft-timeline-enrichment.md)): a cue MAY include optional `timeline` (word spans) and each word MAY include `phones` (IPA + seconds), matching enjoy web `TranscriptLine` / `TranscriptWord`. Import, YouTube captions, and ASR still write line-only `{text, start, duration}`. Craft save may persist nested JSON when **Settings → Transcript → Enrich Craft word timings** is on and alignment succeeds; off or failure keeps today’s synthesis line timings (or a blank transcript). The transcript panel, current-line tracking, echo, lookup, and auto-translate ignore nested spans and keep using line text and line times. There is no karaoke / IPA overlay / per-word tap in this slice.
 - Tap line → seek + optional echo region update (via `PlayerInteractions`) **except** on the **active** cue and cues inside the **echo window**, where the row is **selectable** for dictionary lookup (no tap-to-seek on those rows). See [dictionary-lookup](dictionary-lookup.md).
 - **Track / import entry**: Use the player **CC** control (opens subtitle sheet). While cloud fetch runs and no tracks exist yet, the CC icon shows a **spinner**; when tracks exist, a **badge** appears. The transcript panel shows **Fetching subtitles…** during load, **friendly error + Retry** on failure, and the confirmed empty state only after resolution completes. Manual **Extract** / **Add subtitle** / **Refresh from cloud** actions show inline spinners (picker and empty state).
 - Subtitle track picker: **narrow** viewports use a draggable **Enjoy** bottom sheet; at **≥ `breakpointRail` (900px)** the same UI opens as a **centered dialog** (max width 560) for mouse-first layouts. The sheet body no longer nests an extra **SafeArea** (the modal already applies safe-area padding). **Loading** differs by presentation: the narrow sheet uses the shared scrollable `SkeletonTranscript`, while the wide dialog uses a bounded column of four `Skeleton.*` rows so it remains valid inside the dialog's `SingleChildScrollView`. **Error** / **empty** states: errors show **friendly** title + hint strings plus **Retry** (raw exception text is not surfaced in the primary message). Each track row is a **compact single-line tile**: leading radio, title, compact provider + language `MetaChip` pills on the same baseline, and a trailing delete `IconButton`; unselected rows are borderless with a 1px bottom divider, selected rows show a tinted card so many captions fit the picker viewport. Each track shows **provider** (`official` / `auto` / `ai` / `user`) and language. **Deleting** any transcript clears `echo_sessions` primary/secondary references when that track was selected, reassigns primary using **source priority** (`official` → `auto` → `ai` → `user`, then `createdAt`), and clears secondary if it would duplicate the new primary.
@@ -220,17 +220,19 @@ Coverage lives under
 - `transcript_blur_long_list_perf_test.dart` — 10 000-line smoke
   under `ImageFiltered`; per-frame budget assertion.
 
-## Alignment engine (unused)
+## Alignment engine (Craft save caller)
 
-`packages/forced_alignment` can map known text + 16 kHz extractable PCM to
+`packages/forced_alignment` maps known text + 16 kHz extractable PCM to
 word/phone timings (Echogarden-shaped result, flatten adapter for enjoy-web
 `WordTiming` / `PhoneTiming`). Production success requires a same-language
 **spoken** eSpeak-NG reference (waveform + word/phone events), not a
 duration-model tone stand-in. Missing voice → `spokenReferenceUnavailable`.
-**No product flow calls it yet** — Craft still saves synthesis line timings;
-the panel stays line-level; there is no Settings toggle or “reference voice”
-control; learners never hear the reference. Mapping onto nested cues is a
-later slice (issue #540). See [ADR-0071](../decisions/0071-on-device-alignment-engine.md)
+**Craft save** is the first product caller ([ADR-0073](../decisions/0073-craft-timeline-enrichment.md)):
+when **Settings → Transcript → Enrich Craft word timings** is on, a real
+(non-dedupe) Craft write may attach nested spans onto spec 030 lines via
+`alignSegments`. The panel stays line-level; there is no karaoke in this
+slice; learners never hear the reference. Import / YouTube / ASR remain
+line-only writers. See [ADR-0071](../decisions/0071-on-device-alignment-engine.md)
 and [ADR-0072](../decisions/0072-spoken-alignment-reference.md).
 
 ## Future

--- a/lib/data/audio/pcm16k_mono.dart
+++ b/lib/data/audio/pcm16k_mono.dart
@@ -1,0 +1,223 @@
+/// Decode Craft audio bytes to 16 kHz mono Float32 for forced alignment.
+library;
+
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:forced_alignment/forced_alignment.dart';
+
+import 'package:enjoy_player/data/files/ffmpeg_media_probe.dart';
+
+/// Thrown when Craft bytes cannot be decoded to 16 kHz mono PCM.
+final class Pcm16kDecodeException implements Exception {
+  const Pcm16kDecodeException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'Pcm16kDecodeException($message)';
+}
+
+/// Turns WAV (or other FFmpeg-decodable) bytes into 16 kHz mono [Float32List].
+///
+/// PCM WAV is decoded in-process. Other encodings fall back to a temp-file
+/// FFmpeg convert (`pcm_s16le -ar 16000 -ac 1`). Does not import ASR.
+Future<Float32List> decodeToPcm16kMono(Uint8List bytes) async {
+  final inProcess = decodePcmWavTo16kMono(bytes);
+  if (inProcess != null && inProcess.isNotEmpty) {
+    return inProcess;
+  }
+  return _ffmpegFallback(bytes);
+}
+
+/// In-process RIFF WAVE decode + mix-to-mono + resample. Returns null when
+/// the payload is not a supported PCM/float WAV.
+Float32List? decodePcmWavTo16kMono(Uint8List bytes) {
+  final parsed = _parseWav(bytes);
+  if (parsed == null || parsed.samples.isEmpty) return null;
+  return _resampleMono(parsed.samples, parsed.sampleRate, kAlignmentSampleRate);
+}
+
+Future<Float32List> _ffmpegFallback(Uint8List bytes) async {
+  final ffmpeg = await FfmpegMediaProbe.resolveFfmpegExecutable();
+  if (ffmpeg == null) {
+    throw const Pcm16kDecodeException('ffmpeg unavailable');
+  }
+  final dir = await Directory.systemTemp.createTemp('enjoy_pcm16k_');
+  try {
+    final input = File('${dir.path}${Platform.pathSeparator}in.bin');
+    final output = File('${dir.path}${Platform.pathSeparator}out.wav');
+    await input.writeAsBytes(bytes, flush: true);
+    final result = await Process.run(ffmpeg, [
+      '-hide_banner',
+      '-nostdin',
+      '-y',
+      '-i',
+      input.path,
+      '-ar',
+      '$kAlignmentSampleRate',
+      '-ac',
+      '1',
+      '-c:a',
+      'pcm_s16le',
+      output.path,
+    ]);
+    if (result.exitCode != 0 || !output.existsSync()) {
+      throw Pcm16kDecodeException('ffmpeg failed (exit ${result.exitCode})');
+    }
+    final outBytes = await output.readAsBytes();
+    final decoded = decodePcmWavTo16kMono(Uint8List.fromList(outBytes));
+    if (decoded == null || decoded.isEmpty) {
+      throw const Pcm16kDecodeException('ffmpeg output was not PCM WAV');
+    }
+    return decoded;
+  } finally {
+    try {
+      await dir.delete(recursive: true);
+    } on Object catch (_) {}
+  }
+}
+
+final class _ParsedWav {
+  const _ParsedWav({required this.sampleRate, required this.samples});
+  final int sampleRate;
+  final Float32List samples;
+}
+
+bool _fourCc(Uint8List bytes, int offset, String ascii) {
+  if (offset + 4 > bytes.length) return false;
+  for (var i = 0; i < 4; i++) {
+    if (bytes[offset + i] != ascii.codeUnitAt(i)) return false;
+  }
+  return true;
+}
+
+int _u16(Uint8List b, int o) => b[o] | (b[o + 1] << 8);
+int _u32(Uint8List b, int o) =>
+    b[o] | (b[o + 1] << 8) | (b[o + 2] << 16) | (b[o + 3] << 24);
+
+_ParsedWav? _parseWav(Uint8List bytes) {
+  if (bytes.length < 44) return null;
+  if (!_fourCc(bytes, 0, 'RIFF') || !_fourCc(bytes, 8, 'WAVE')) return null;
+
+  int? audioFormat;
+  int? numChannels;
+  int? sampleRate;
+  int? bitsPerSample;
+  int? blockAlign;
+  int? dataStart;
+  int? dataSize;
+
+  var offset = 12;
+  while (offset + 8 <= bytes.length) {
+    final chunkId = String.fromCharCodes(bytes.sublist(offset, offset + 4));
+    final chunkSize = _u32(bytes, offset + 4);
+    final chunkData = offset + 8;
+    final afterChunk = chunkData + chunkSize;
+    if (afterChunk > bytes.length) break;
+
+    if (chunkId == 'fmt ') {
+      if (chunkSize < 16) return null;
+      audioFormat = _u16(bytes, chunkData);
+      numChannels = _u16(bytes, chunkData + 2);
+      sampleRate = _u32(bytes, chunkData + 4);
+      blockAlign = _u16(bytes, chunkData + 12);
+      bitsPerSample = _u16(bytes, chunkData + 14);
+    } else if (chunkId == 'data') {
+      dataStart = chunkData;
+      dataSize = chunkSize;
+      break;
+    }
+
+    final padded = chunkSize + (chunkSize.isOdd ? 1 : 0);
+    offset += 8 + padded;
+  }
+
+  final format = audioFormat;
+  final channels = numChannels;
+  final rate = sampleRate;
+  final bits = bitsPerSample;
+  final align = blockAlign;
+  final start = dataStart;
+  final size = dataSize;
+  if (format == null ||
+      channels == null ||
+      channels <= 0 ||
+      rate == null ||
+      rate <= 0 ||
+      bits == null ||
+      align == null ||
+      align <= 0 ||
+      start == null ||
+      size == null ||
+      size <= 0) {
+    return null;
+  }
+
+  final end = math.min(start + size, bytes.length);
+  final data = bytes.sublist(start, end);
+  final frames = data.length ~/ align;
+  if (frames <= 0) return null;
+
+  final samples = Float32List(frames);
+  switch (format) {
+    case 1:
+      if (bits == 16 && align == 2 * channels) {
+        for (var i = 0; i < frames; i++) {
+          var sum = 0.0;
+          for (var ch = 0; ch < channels; ch++) {
+            final off = i * align + ch * 2;
+            final s = data[off] | (data[off + 1] << 8);
+            sum += (s > 32767 ? s - 65536 : s) / 32768.0;
+          }
+          samples[i] = sum / channels;
+        }
+        return _ParsedWav(sampleRate: rate, samples: samples);
+      }
+      if (bits == 32 && align == 4 * channels) {
+        final bd = ByteData.sublistView(data);
+        for (var i = 0; i < frames; i++) {
+          var sum = 0.0;
+          for (var ch = 0; ch < channels; ch++) {
+            final off = i * align + ch * 4;
+            sum += bd.getInt32(off, Endian.little) / 2147483648.0;
+          }
+          samples[i] = sum / channels;
+        }
+        return _ParsedWav(sampleRate: rate, samples: samples);
+      }
+      return null;
+    case 3:
+      if (bits == 32 && align == 4 * channels) {
+        final bd = ByteData.sublistView(data);
+        for (var i = 0; i < frames; i++) {
+          var sum = 0.0;
+          for (var ch = 0; ch < channels; ch++) {
+            final off = i * align + ch * 4;
+            sum += bd.getFloat32(off, Endian.little);
+          }
+          samples[i] = sum / channels;
+        }
+        return _ParsedWav(sampleRate: rate, samples: samples);
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+Float32List _resampleMono(Float32List input, int fromRate, int toRate) {
+  if (fromRate == toRate) return input;
+  final outLen = (input.length * toRate / fromRate).round();
+  if (outLen <= 0 || input.isEmpty) return Float32List(0);
+  final out = Float32List(outLen);
+  final last = input.length - 1;
+  for (var i = 0; i < outLen; i++) {
+    final srcPos = i * fromRate / toRate;
+    final i0 = srcPos.floor().clamp(0, last);
+    final i1 = math.min(i0 + 1, last);
+    final t = srcPos - i0;
+    out[i] = input[i0] * (1 - t) + input[i1] * t;
+  }
+  return out;
+}

--- a/lib/data/db/settings_keys.dart
+++ b/lib/data/db/settings_keys.dart
@@ -53,6 +53,11 @@ abstract final class SettingsKeys {
   /// When `true`, allowlisted diagnostic loggers write FINE records to the log file.
   static const String diagnosticsVerboseEnabled = 'diagnostics.verbose_enabled';
 
+  /// When `true`, Craft save may attach nested word/phone spans via on-device
+  /// alignment. Missing value ≡ off.
+  static const String transcriptTimelineEnrichment =
+      'transcript.timelineEnrichment';
+
   /// JSON blob: volume, rate, repeat, split width ([PlayerPreferencesCtrl]).
   static const String playerPreferencesV1 = 'player_preferences_v1';
 
@@ -98,6 +103,7 @@ abstract final class SettingsKeys {
     updateSnoozeUntil,
     updateSnoozeVersion,
     diagnosticsVerboseEnabled,
+    transcriptTimelineEnrichment,
     playerPreferencesV1,
     hotkeysCustomBindings,
     aiModalityConfigsV1,

--- a/lib/data/subtitle/attach_alignment_to_lines.dart
+++ b/lib/data/subtitle/attach_alignment_to_lines.dart
@@ -1,0 +1,163 @@
+/// Map a successful [AlignmentResult] onto spec 030 [TranscriptLine]s.
+library;
+
+import 'dart:math' as math;
+
+import 'package:forced_alignment/forced_alignment.dart';
+
+import 'package:enjoy_player/data/subtitle/transcript_line.dart';
+
+/// Attaches nested word/phone spans onto [lines] without changing line
+/// identity (`text`, `startMs`, `durationMs`, `sourceKey`, `confidence`).
+///
+/// Segment `id` is the line index. Word times become milliseconds relative
+/// to the parent line. Phone times stay in media-timeline seconds.
+/// `wordIndex` is rebased per line. Empty timelines are omitted (`null`).
+List<TranscriptLine> attachAlignmentToLines(
+  List<TranscriptLine> lines,
+  AlignmentResult result,
+) {
+  if (lines.isEmpty) return lines;
+
+  final segmentsById = <int, TimelineEntry>{};
+  for (final entry in result.timeline) {
+    if (entry.type != TimelineEntryType.segment) continue;
+    final id = entry.id;
+    if (id is int) {
+      segmentsById[id] = entry;
+    }
+  }
+
+  return [
+    for (var i = 0; i < lines.length; i++)
+      _attachOne(
+        line: lines[i],
+        isLast: i == lines.length - 1,
+        tagged: segmentsById[i],
+        result: result,
+      ),
+  ];
+}
+
+TranscriptLine _attachOne({
+  required TranscriptLine line,
+  required bool isLast,
+  required TimelineEntry? tagged,
+  required AlignmentResult result,
+}) {
+  final engineWords = tagged != null
+      ? _collectWords(tagged)
+      : _wordsInWindow(line, result, isLast: isLast);
+  if (engineWords.isEmpty) return line;
+
+  final words = <TranscriptWord>[];
+  for (final engineWord in engineWords) {
+    final text = engineWord.text.trim();
+    if (text.isEmpty) continue;
+    final startMs = math.max(
+      0,
+      ((engineWord.startTime - line.startSeconds) * 1000).round(),
+    );
+    final durationMs = math.max(
+      0,
+      ((engineWord.endTime - engineWord.startTime) * 1000).round(),
+    );
+    final wordIndex = words.length;
+    final phones = _phonesForWord(engineWord, wordIndex);
+    words.add(
+      TranscriptWord(
+        text: text,
+        startMs: startMs,
+        durationMs: durationMs,
+        phones: phones,
+      ),
+    );
+  }
+  if (words.isEmpty) return line;
+
+  return TranscriptLine(
+    text: line.text,
+    startMs: line.startMs,
+    durationMs: line.durationMs,
+    sourceKey: line.sourceKey,
+    confidence: line.confidence,
+    timeline: words,
+  );
+}
+
+List<TimelineEntry> _collectWords(TimelineEntry root) {
+  final out = <TimelineEntry>[];
+  void walk(TimelineEntry entry) {
+    if (entry.type == TimelineEntryType.word) {
+      if (entry.text.trim().isNotEmpty) {
+        out.add(entry);
+      }
+      return;
+    }
+    final children = entry.timeline;
+    if (children == null) return;
+    for (final child in children) {
+      walk(child);
+    }
+  }
+
+  walk(root);
+  return out;
+}
+
+List<TimelineEntry> _allWords(AlignmentResult result) {
+  final fromTree = [
+    for (final entry in result.timeline) ..._collectWords(entry),
+  ];
+  if (fromTree.isNotEmpty) return fromTree;
+  return [
+    for (final entry in result.wordTimeline)
+      if (entry.type == TimelineEntryType.word && entry.text.trim().isNotEmpty)
+        entry,
+  ];
+}
+
+List<TimelineEntry> _wordsInWindow(
+  TranscriptLine line,
+  AlignmentResult result, {
+  required bool isLast,
+}) {
+  final start = line.startSeconds;
+  final end = line.endSeconds;
+  return [
+    for (final word in _allWords(result))
+      if (_startInWindow(word.startTime, start, end, isLast: isLast)) word,
+  ];
+}
+
+bool _startInWindow(
+  double t,
+  double start,
+  double end, {
+  required bool isLast,
+}) {
+  if (t < start) return false;
+  if (isLast) return t <= end;
+  return t < end;
+}
+
+List<TranscriptPhone>? _phonesForWord(TimelineEntry word, int wordIndex) {
+  final children = word.timeline;
+  if (children == null || children.isEmpty) return null;
+  final phones = <TranscriptPhone>[];
+  for (final child in children) {
+    if (child.type != TimelineEntryType.phone) continue;
+    final label = child.text.trim();
+    if (label.isEmpty) continue;
+    phones.add(
+      TranscriptPhone(
+        phone: label,
+        text: label,
+        startTime: child.startTime,
+        endTime: child.endTime,
+        wordIndex: wordIndex,
+      ),
+    );
+  }
+  return phones.isEmpty ? null : phones;
+}

--- a/lib/features/craft/application/craft_controller.dart
+++ b/lib/features/craft/application/craft_controller.dart
@@ -16,6 +16,7 @@ import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/craft/data/craft_asr_service_transcriber.dart';
 import 'package:enjoy_player/features/craft/data/craft_translation_service_translator.dart';
 import 'package:enjoy_player/features/craft/data/craft_tts_service_synthesizer.dart';
+import 'package:enjoy_player/features/craft/application/craft_timeline_enricher.dart';
 import 'package:enjoy_player/features/craft/domain/azure_voice.dart';
 import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
@@ -224,11 +225,11 @@ class CraftController extends Notifier<CraftJobState> {
 
       // Solid word timings → timed AI transcript. Otherwise blank (null):
       // no fabricated duration estimates; learner generates via STT in player.
-      final timelineJson = buildCraftPrimaryTimelineJson(
+      final timelineJson030 = buildCraftPrimaryTimelineJson(
         state.previewWordBoundaries,
         language: state.synthLanguage,
       );
-      final wroteSolid = timelineJson != null;
+      final wroteSolid = timelineJson030 != null;
 
       // Determine if this is a translate-then-synthesize or direct synthesize.
       final hasSourceLang =
@@ -252,6 +253,7 @@ class CraftController extends Notifier<CraftJobState> {
       // identical text.
       final editingId = state.editingMediaId;
       if (editingId != null) {
+        final timelineJson = await _enrichTimeline(timelineJson030);
         final mediaId = await repo.updateCraftedFromText(
           mediaId: editingId,
           audioBytes: state.previewAudioBytes!,
@@ -286,6 +288,7 @@ class CraftController extends Notifier<CraftJobState> {
         );
       }
 
+      final timelineJson = await _enrichTimeline(timelineJson030);
       final mediaId = await repo.importCraftedFromText(
         audioBytes: state.previewAudioBytes!,
         audioFormat: state.previewFormat ?? 'wav',
@@ -312,6 +315,16 @@ class CraftController extends Notifier<CraftJobState> {
       );
       return null;
     }
+  }
+
+  Future<String?> _enrichTimeline(String? timelineJson) {
+    return ref
+        .read(craftTimelineEnricherProvider)
+        .enrich(
+          timelineJson: timelineJson,
+          audioBytes: state.previewAudioBytes!,
+          language: state.synthLanguage,
+        );
   }
 
   void clearResult() {

--- a/lib/features/craft/application/craft_timeline_enricher.dart
+++ b/lib/features/craft/application/craft_timeline_enricher.dart
@@ -1,0 +1,181 @@
+/// Opt-in Craft-save hook: attach nested word/phone spans via alignSegments.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forced_alignment/forced_alignment.dart';
+
+import 'package:enjoy_player/core/application/app_language_catalog.dart';
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/data/audio/pcm16k_mono.dart';
+import 'package:enjoy_player/data/subtitle/attach_alignment_to_lines.dart';
+import 'package:enjoy_player/data/subtitle/transcript_line.dart';
+import 'package:enjoy_player/features/settings/application/timeline_enrichment_settings.dart';
+
+typedef DecodePcm16k = Future<Float32List> Function(Uint8List bytes);
+
+typedef AlignSegmentsFn =
+    Future<AlignmentOutcome> Function({
+      required Float32List sourcePcm16k,
+      required String language,
+      required List<AlignmentSegment> segments,
+      required AlignmentGranularity granularity,
+    });
+
+/// Maps a Craft synth language (`en`, `en-GB`, `ja`) onto an alignment
+/// catalog tag. Returns null when the language is not in the focus map —
+/// callers must fail closed, not swap to English.
+String? alignmentLanguageForCraft(String language) {
+  final trimmed = language.trim();
+  if (trimmed.isEmpty) return null;
+  if (isSupportedAlignmentLanguage(trimmed)) return trimmed;
+  final focus = canonicalFocusLanguageTag(trimmed);
+  if (!isSupportedAlignmentLanguage(focus)) return null;
+  if (primaryLanguageSubtag(trimmed) != primaryLanguageSubtag(focus)) {
+    return null;
+  }
+  return focus;
+}
+
+/// Extract + [alignSegments] + [attachAlignmentToLines] for Craft save.
+///
+/// When enrichment is off, [timelineJson] is null, or extract/alignment
+/// fails, returns the original spec 030 JSON unchanged.
+final class CraftTimelineEnricher {
+  CraftTimelineEnricher({
+    required this.enabled,
+    Future<bool> Function()? resolveEnabled,
+    DecodePcm16k? decodePcm,
+    AlignSegmentsFn? alignSegmentsFn,
+  }) : // Named [resolveEnabled] so tests outside this library can pass it.
+       // ignore: prefer_initializing_formals
+       _resolveEnabled = resolveEnabled,
+       _decodePcm = decodePcm ?? decodeToPcm16kMono,
+       _alignSegments = alignSegmentsFn ?? _productionAlignSegments;
+
+  /// Explicit on/off used when [resolveEnabled] is omitted (tests).
+  final bool enabled;
+  final Future<bool> Function()? _resolveEnabled;
+  final DecodePcm16k _decodePcm;
+  final AlignSegmentsFn _alignSegments;
+
+  Future<bool> _isEnabled() async {
+    final resolve = _resolveEnabled;
+    if (resolve != null) return resolve();
+    return enabled;
+  }
+
+  Future<String?> enrich({
+    required String? timelineJson,
+    required Uint8List audioBytes,
+    required String language,
+  }) async {
+    if (!await _isEnabled()) return timelineJson;
+    if (timelineJson == null) return null;
+
+    final lines = _decodeLines(timelineJson);
+    if (lines == null) {
+      return _fallback(timelineJson, 'invalid timeline JSON');
+    }
+    if (lines.isEmpty) {
+      return _fallback(timelineJson, 'empty timeline JSON');
+    }
+
+    final alignmentLanguage = alignmentLanguageForCraft(language);
+    if (alignmentLanguage == null) {
+      return _fallback(timelineJson, 'unsupportedLanguage');
+    }
+
+    late final Float32List pcm;
+    try {
+      pcm = await _decodePcm(audioBytes);
+    } on Object catch (e, st) {
+      logNamed('craft.enrichment').warning('PCM extract failed: $e', e, st);
+      return timelineJson;
+    }
+    if (pcm.isEmpty) {
+      return _fallback(timelineJson, 'empty PCM');
+    }
+
+    final segments = [
+      for (var i = 0; i < lines.length; i++)
+        AlignmentSegment(
+          text: lines[i].text,
+          startTime: lines[i].startSeconds,
+          endTime: lines[i].endSeconds,
+          id: i,
+        ),
+    ];
+
+    late final AlignmentOutcome outcome;
+    try {
+      outcome = await _alignSegments(
+        sourcePcm16k: pcm,
+        language: alignmentLanguage,
+        segments: segments,
+        granularity: AlignmentGranularity.medium,
+      );
+    } on Object catch (e, st) {
+      logNamed('craft.enrichment').warning('alignSegments threw: $e', e, st);
+      return timelineJson;
+    }
+
+    switch (outcome) {
+      case AlignmentFailed(:final failure):
+        return _fallback(timelineJson, failure.reason.name);
+      case AlignmentSuccess(:final result):
+        try {
+          final attached = attachAlignmentToLines(lines, result);
+          if (attached.length != lines.length) {
+            return _fallback(timelineJson, 'line count changed');
+          }
+          return jsonEncode([for (final line in attached) line.toJson()]);
+        } on Object catch (e, st) {
+          logNamed('craft.enrichment').warning('mapping failed: $e', e, st);
+          return timelineJson;
+        }
+    }
+  }
+
+  String _fallback(String original, String reason) {
+    logNamed('craft.enrichment').warning('fallback: $reason');
+    return original;
+  }
+}
+
+List<TranscriptLine>? _decodeLines(String json) {
+  try {
+    final decoded = jsonDecode(json);
+    if (decoded is! List) return null;
+    return [
+      for (final item in decoded)
+        if (item is Map)
+          TranscriptLine.fromJson(Map<String, dynamic>.from(item)),
+    ];
+  } on Object catch (_) {
+    return null;
+  }
+}
+
+Future<AlignmentOutcome> _productionAlignSegments({
+  required Float32List sourcePcm16k,
+  required String language,
+  required List<AlignmentSegment> segments,
+  required AlignmentGranularity granularity,
+}) {
+  return alignSegments(
+    sourcePcm16k: sourcePcm16k,
+    language: language,
+    segments: segments,
+    granularity: granularity,
+  );
+}
+
+final craftTimelineEnricherProvider = Provider<CraftTimelineEnricher>((ref) {
+  return CraftTimelineEnricher(
+    enabled: false,
+    resolveEnabled: () => ref.read(timelineEnrichmentSettingsProvider.future),
+  );
+});

--- a/lib/features/settings/application/settings_registry_localizer.dart
+++ b/lib/features/settings/application/settings_registry_localizer.dart
@@ -55,6 +55,18 @@ _Localized _localize(SettingsEntryDescriptor d, AppLocalizations l10n) {
       return _Localized(l10n.settingsSectionRecording, [
         l10n.settingsSectionRecordingHint,
       ]);
+    case SettingsSectionIds.transcript:
+      if (d.rowId == 'timelineEnrichment') {
+        return _Localized(l10n.settingsTranscriptEnrichmentTitle, [
+          'enrichment',
+          'alignment',
+          'timeline',
+          l10n.settingsTranscriptEnrichmentSubtitle,
+        ]);
+      }
+      return _Localized(l10n.settingsSectionTranscript, [
+        l10n.settingsSectionTranscriptHint,
+      ]);
     case SettingsSectionIds.keyboardShortcuts:
       switch (d.rowId) {
         case 'openCheatsheet':

--- a/lib/features/settings/application/timeline_enrichment_settings.dart
+++ b/lib/features/settings/application/timeline_enrichment_settings.dart
@@ -1,0 +1,42 @@
+/// Persisted Craft timeline-enrichment preference (default off).
+library;
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/db/settings_keys.dart';
+
+part 'timeline_enrichment_settings.g.dart';
+
+Future<bool> readTimelineEnrichmentEnabledFromDb(AppDatabase db) async {
+  final raw = await db.settingsDao.getValue(
+    SettingsKeys.transcriptTimelineEnrichment,
+  );
+  return raw == 'true';
+}
+
+Future<void> writeTimelineEnrichmentEnabledToDb(
+  AppDatabase db, {
+  required bool enabled,
+}) async {
+  await db.settingsDao.setValue(
+    SettingsKeys.transcriptTimelineEnrichment,
+    enabled ? 'true' : 'false',
+  );
+}
+
+@Riverpod(keepAlive: true)
+class TimelineEnrichmentSettings extends _$TimelineEnrichmentSettings {
+  @override
+  Future<bool> build() async {
+    final db = ref.watch(deviceGlobalAppDatabaseProvider);
+    return readTimelineEnrichmentEnabledFromDb(db);
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    final db = ref.read(deviceGlobalAppDatabaseProvider);
+    await writeTimelineEnrichmentEnabledToDb(db, enabled: enabled);
+    state = AsyncData(enabled);
+  }
+}

--- a/lib/features/settings/application/timeline_enrichment_settings.g.dart
+++ b/lib/features/settings/application/timeline_enrichment_settings.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'timeline_enrichment_settings.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(TimelineEnrichmentSettings)
+final timelineEnrichmentSettingsProvider =
+    TimelineEnrichmentSettingsProvider._();
+
+final class TimelineEnrichmentSettingsProvider
+    extends $AsyncNotifierProvider<TimelineEnrichmentSettings, bool> {
+  TimelineEnrichmentSettingsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'timelineEnrichmentSettingsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$timelineEnrichmentSettingsHash();
+
+  @$internal
+  @override
+  TimelineEnrichmentSettings create() => TimelineEnrichmentSettings();
+}
+
+String _$timelineEnrichmentSettingsHash() =>
+    r'848b9a534f8f717ee8cbfb85b1adde6ce0bd9e80';
+
+abstract class _$TimelineEnrichmentSettings extends $AsyncNotifier<bool> {
+  FutureOr<bool> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<bool>, bool>,
+              AsyncValue<bool>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/settings/domain/settings_search_entry.dart
+++ b/lib/features/settings/domain/settings_search_entry.dart
@@ -15,6 +15,7 @@ abstract final class SettingsSectionIds {
   static const appearanceLanguage = 'appearanceLanguage';
   static const aiProviders = 'aiProviders';
   static const recording = 'recording';
+  static const transcript = 'transcript';
   static const keyboardShortcuts = 'keyboardShortcuts';
   static const developer = 'developer';
   static const about = 'about';
@@ -120,6 +121,11 @@ const List<SettingsEntryDescriptor> kSettingsRegistry = [
   SettingsEntryDescriptor(
     sectionId: SettingsSectionIds.recording,
     rowId: 'micPicker',
+  ),
+  SettingsEntryDescriptor(sectionId: SettingsSectionIds.transcript),
+  SettingsEntryDescriptor(
+    sectionId: SettingsSectionIds.transcript,
+    rowId: 'timelineEnrichment',
   ),
   SettingsEntryDescriptor(sectionId: SettingsSectionIds.keyboardShortcuts),
   SettingsEntryDescriptor(

--- a/lib/features/settings/presentation/widgets/sections/transcript_section.dart
+++ b/lib/features/settings/presentation/widgets/sections/transcript_section.dart
@@ -1,0 +1,47 @@
+/// Transcript options (Craft timeline enrichment).
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:enjoy_player/core/riverpod/async_value_x.dart';
+import 'package:enjoy_player/features/settings/application/timeline_enrichment_settings.dart';
+import 'package:enjoy_player/features/settings/presentation/widgets/settings_row.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+
+class TranscriptSectionBody extends ConsumerWidget {
+  const TranscriptSectionBody({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    final enabled =
+        ref.watch(timelineEnrichmentSettingsProvider).valueOrNull ?? false;
+
+    return SettingsRow(
+      leadingIcon: Icons.subtitles_outlined,
+      title: l10n.settingsTranscriptEnrichmentTitle,
+      subtitle: l10n.settingsTranscriptEnrichmentSubtitle,
+      showChevron: false,
+      trailing: Switch.adaptive(
+        value: enabled,
+        onChanged: (value) {
+          unawaited(
+            ref
+                .read(timelineEnrichmentSettingsProvider.notifier)
+                .setEnabled(value),
+          );
+        },
+      ),
+      onTap: () {
+        unawaited(
+          ref
+              .read(timelineEnrichmentSettingsProvider.notifier)
+              .setEnabled(!enabled),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/settings/presentation/widgets/settings_layout_single_column.dart
+++ b/lib/features/settings/presentation/widgets/settings_layout_single_column.dart
@@ -24,6 +24,7 @@ import 'package:enjoy_player/features/settings/presentation/widgets/sections/clo
 import 'package:enjoy_player/features/settings/presentation/widgets/sections/developer_section.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/sections/keyboard_shortcuts_section.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/sections/recording_section.dart';
+import 'package:enjoy_player/features/settings/presentation/widgets/sections/transcript_section.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_collapsible_section.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_no_results.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_section_card.dart';
@@ -99,6 +100,16 @@ class SettingsLayoutSingleColumn extends ConsumerWidget {
             icon: visual(SettingsSectionIds.recording).icon,
             padding: EdgeInsets.zero,
             child: const RecordingSectionBody(),
+          ),
+          SizedBox(height: t.space8),
+        ],
+        if (visible(SettingsSectionIds.transcript)) ...[
+          SettingsSectionCard(
+            title: visual(SettingsSectionIds.transcript).title,
+            hint: visual(SettingsSectionIds.transcript).hint,
+            icon: visual(SettingsSectionIds.transcript).icon,
+            padding: EdgeInsets.zero,
+            child: const TranscriptSectionBody(),
           ),
           SizedBox(height: t.space8),
         ],

--- a/lib/features/settings/presentation/widgets/settings_layout_two_pane.dart
+++ b/lib/features/settings/presentation/widgets/settings_layout_two_pane.dart
@@ -26,6 +26,7 @@ import 'package:enjoy_player/features/settings/presentation/widgets/sections/clo
 import 'package:enjoy_player/features/settings/presentation/widgets/sections/developer_section.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/sections/keyboard_shortcuts_section.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/sections/recording_section.dart';
+import 'package:enjoy_player/features/settings/presentation/widgets/sections/transcript_section.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_no_results.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_section_card.dart';
 import 'package:enjoy_player/features/settings/presentation/widgets/settings_section_rail_item.dart';
@@ -40,6 +41,7 @@ List<String> _railSectionIds() {
     SettingsSectionIds.appearanceLanguage,
     SettingsSectionIds.aiProviders,
     SettingsSectionIds.recording,
+    SettingsSectionIds.transcript,
     if (isDesktop) SettingsSectionIds.keyboardShortcuts,
     if (!kReleaseMode) SettingsSectionIds.developer,
     SettingsSectionIds.about,
@@ -56,6 +58,8 @@ Widget _sectionBody(String sectionId) {
       return const AiProvidersSectionBody();
     case SettingsSectionIds.recording:
       return const RecordingSectionBody();
+    case SettingsSectionIds.transcript:
+      return const TranscriptSectionBody();
     case SettingsSectionIds.keyboardShortcuts:
       return const KeyboardShortcutsSectionBody();
     case SettingsSectionIds.developer:

--- a/lib/features/settings/presentation/widgets/settings_section_visuals.dart
+++ b/lib/features/settings/presentation/widgets/settings_section_visuals.dart
@@ -57,6 +57,12 @@ SettingsSectionVisual settingsSectionVisual(
         title: l10n.settingsSectionRecording,
         hint: l10n.settingsSectionRecordingHint,
       );
+    case SettingsSectionIds.transcript:
+      return SettingsSectionVisual(
+        icon: Icons.subtitles_outlined,
+        title: l10n.settingsSectionTranscript,
+        hint: l10n.settingsSectionTranscriptHint,
+      );
     case SettingsSectionIds.keyboardShortcuts:
       return SettingsSectionVisual(
         icon: Icons.keyboard_outlined,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -561,6 +561,22 @@
   "@settingsSectionRecordingHint": {
     "description": "Subtitle under the recording section header."
   },
+  "settingsSectionTranscript": "Transcript",
+  "@settingsSectionTranscript": {
+    "description": "Header for the transcript settings section."
+  },
+  "settingsSectionTranscriptHint": "Options for practice transcript timing.",
+  "@settingsSectionTranscriptHint": {
+    "description": "Subtitle under the transcript section header."
+  },
+  "settingsTranscriptEnrichmentTitle": "Enrich Craft word timings",
+  "@settingsTranscriptEnrichmentTitle": {
+    "description": "Settings switch title for opt-in Craft timeline enrichment."
+  },
+  "settingsTranscriptEnrichmentSubtitle": "When on, Craft save stores word and phone times from on-device alignment. Off (default) keeps today’s synthesis line timings.",
+  "@settingsTranscriptEnrichmentSubtitle": {
+    "description": "Settings switch subtitle explaining Craft timeline enrichment."
+  },
   "settingsRecordingMicTitle": "Microphone",
   "@settingsRecordingMicTitle": {
     "description": "Title of the microphone picker tile in settings."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1893,6 +1893,30 @@ abstract class AppLocalizations {
   /// **'Microphone used for shadow-reading takes.'**
   String get settingsSectionRecordingHint;
 
+  /// Header for the transcript settings section.
+  ///
+  /// In en, this message translates to:
+  /// **'Transcript'**
+  String get settingsSectionTranscript;
+
+  /// Subtitle under the transcript section header.
+  ///
+  /// In en, this message translates to:
+  /// **'Options for practice transcript timing.'**
+  String get settingsSectionTranscriptHint;
+
+  /// Settings switch title for opt-in Craft timeline enrichment.
+  ///
+  /// In en, this message translates to:
+  /// **'Enrich Craft word timings'**
+  String get settingsTranscriptEnrichmentTitle;
+
+  /// Settings switch subtitle explaining Craft timeline enrichment.
+  ///
+  /// In en, this message translates to:
+  /// **'When on, Craft save stores word and phone times from on-device alignment. Off (default) keeps today’s synthesis line timings.'**
+  String get settingsTranscriptEnrichmentSubtitle;
+
   /// Title of the microphone picker tile in settings.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1000,6 +1000,20 @@ class AppLocalizationsEn extends AppLocalizations {
       'Microphone used for shadow-reading takes.';
 
   @override
+  String get settingsSectionTranscript => 'Transcript';
+
+  @override
+  String get settingsSectionTranscriptHint =>
+      'Options for practice transcript timing.';
+
+  @override
+  String get settingsTranscriptEnrichmentTitle => 'Enrich Craft word timings';
+
+  @override
+  String get settingsTranscriptEnrichmentSubtitle =>
+      'When on, Craft save stores word and phone times from on-device alignment. Off (default) keeps today’s synthesis line timings.';
+
+  @override
   String get settingsRecordingMicTitle => 'Microphone';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -955,6 +955,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsSectionRecordingHint => '跟读录音所使用的麦克风。';
 
   @override
+  String get settingsSectionTranscript => '字幕';
+
+  @override
+  String get settingsSectionTranscriptHint => '练习字幕时间轴选项。';
+
+  @override
+  String get settingsTranscriptEnrichmentTitle => '对齐词级时间轴';
+
+  @override
+  String get settingsTranscriptEnrichmentSubtitle =>
+      '开启后，保存 Craft 条目时用本地对齐补上词和音素时间。关闭（默认）保持现在的合成行时间轴。';
+
+  @override
   String get settingsRecordingMicTitle => '麦克风';
 
   @override
@@ -4409,6 +4422,19 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get settingsSectionRecordingHint => '跟读录音所使用的麦克风';
+
+  @override
+  String get settingsSectionTranscript => '字幕';
+
+  @override
+  String get settingsSectionTranscriptHint => '练习字幕时间轴选项。';
+
+  @override
+  String get settingsTranscriptEnrichmentTitle => '对齐词级时间轴';
+
+  @override
+  String get settingsTranscriptEnrichmentSubtitle =>
+      '开启后，保存 Craft 条目时用本地对齐补上词和音素时间。关闭（默认）保持现在的合成行时间轴。';
 
   @override
   String get settingsRecordingMicTitle => '麦克风';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -381,6 +381,22 @@
   "@settingsSectionRecordingHint": {
     "description": "Subtitle under the recording section header."
   },
+  "settingsSectionTranscript": "字幕",
+  "@settingsSectionTranscript": {
+    "description": "Header for the transcript settings section."
+  },
+  "settingsSectionTranscriptHint": "练习字幕时间轴选项。",
+  "@settingsSectionTranscriptHint": {
+    "description": "Subtitle under the transcript section header."
+  },
+  "settingsTranscriptEnrichmentTitle": "对齐词级时间轴",
+  "@settingsTranscriptEnrichmentTitle": {
+    "description": "Settings switch title for opt-in Craft timeline enrichment."
+  },
+  "settingsTranscriptEnrichmentSubtitle": "开启后，保存 Craft 条目时用本地对齐补上词和音素时间。关闭（默认）保持现在的合成行时间轴。",
+  "@settingsTranscriptEnrichmentSubtitle": {
+    "description": "Settings switch subtitle explaining Craft timeline enrichment."
+  },
   "settingsRecordingMicTitle": "麦克风",
   "@settingsRecordingMicTitle": {
     "description": "Title of the microphone picker tile in settings."

--- a/lib/l10n/app_zh_CN.arb
+++ b/lib/l10n/app_zh_CN.arb
@@ -302,6 +302,22 @@
   "@settingsSectionRecordingHint": {
     "description": "Subtitle under the recording section header."
   },
+  "settingsSectionTranscript": "字幕",
+  "@settingsSectionTranscript": {
+    "description": "Header for the transcript settings section."
+  },
+  "settingsSectionTranscriptHint": "练习字幕时间轴选项。",
+  "@settingsSectionTranscriptHint": {
+    "description": "Subtitle under the transcript section header."
+  },
+  "settingsTranscriptEnrichmentTitle": "对齐词级时间轴",
+  "@settingsTranscriptEnrichmentTitle": {
+    "description": "Settings switch title for opt-in Craft timeline enrichment."
+  },
+  "settingsTranscriptEnrichmentSubtitle": "开启后，保存 Craft 条目时用本地对齐补上词和音素时间。关闭（默认）保持现在的合成行时间轴。",
+  "@settingsTranscriptEnrichmentSubtitle": {
+    "description": "Settings switch subtitle explaining Craft timeline enrichment."
+  },
   "settingsRecordingMicTitle": "麦克风",
   "@settingsRecordingMicTitle": {
     "description": "Title of the microphone picker tile in settings."

--- a/specs/039-craft-timeline-enrichment/checklists/requirements.md
+++ b/specs/039-craft-timeline-enrichment/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Craft Timeline Enrichment
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated 2026-08-16: all items pass. Setting key `transcript.timelineEnrichment` is recorded in Assumptions (same name as issue #540 / slices 1–2b), not as an API design.
+- Ready for `/speckit-clarify` (optional) or `/speckit-plan`.

--- a/specs/039-craft-timeline-enrichment/contracts/README.md
+++ b/specs/039-craft-timeline-enrichment/contracts/README.md
@@ -1,0 +1,9 @@
+# Contracts: Craft Timeline Enrichment
+
+| Contract | Purpose |
+|----------|---------|
+| [settings-toggle.md](./settings-toggle.md) | Default-off key, Settings Transcript section, persist without restart |
+| [craft-save-enrichment.md](./craft-save-enrichment.md) | When Craft save calls `alignSegments` and what it persists |
+| [nested-mapping.md](./nested-mapping.md) | Alignment result → slice 1 cue JSON |
+| [fallback.md](./fallback.md) | Fail closed to spec 030; quiet; no stand-in nested spans |
+| [inert-consumers.md](./inert-consumers.md) | Panel/import/ASR/YouTube still line-level; no karaoke |

--- a/specs/039-craft-timeline-enrichment/contracts/craft-save-enrichment.md
+++ b/specs/039-craft-timeline-enrichment/contracts/craft-save-enrichment.md
@@ -1,0 +1,45 @@
+# Contract: Craft save enrichment
+
+**Caller**: `CraftController.saveToLibrary`  
+**Engine**: `alignSegments` from `package:forced_alignment` (production synthesizer; no duration-model)
+
+## Preconditions (all required)
+
+1. Enrichment setting is on.
+2. `buildCraftPrimaryTimelineJson` returned non-null (solid synthesis lines).
+3. This save is a real write (`importCraftedFromText` or `updateCraftedFromText`), not a dedupe hit.
+4. `previewAudioBytes` can be decoded to 16 kHz mono Float32.
+
+If any precondition fails, persist the spec 030 `timelineJson` (or `null`) unchanged.
+
+## Call
+
+```text
+alignSegments(
+  sourcePcm16k: extracted,
+  language: synthLanguage,
+  segments: [
+    for (i, line) AlignmentSegment(
+      text: line.text,
+      startTime: line.startSeconds,
+      endTime: line.endSeconds,
+      id: i,
+    )
+  ],
+  granularity: AlignmentGranularity.medium,
+)
+```
+
+Do not call `align()` whole-clip for this path. Do not synthesize a spoken reference of the entire multi-line script as one utterance when line windows exist.
+
+## Persist
+
+- Success → `jsonEncode` of `attachAlignmentToLines` output (same line count/order).
+- Failure → original spec 030 JSON.
+- Partial → nested spans only on lines that received a tagged successful segment.
+
+## Non-goals
+
+- Playing the spoken reference.
+- Writing nested spans onto import / YouTube / ASR tracks.
+- Changing `sourceFlag`, dedupe key, or audio bytes.

--- a/specs/039-craft-timeline-enrichment/contracts/fallback.md
+++ b/specs/039-craft-timeline-enrichment/contracts/fallback.md
@@ -1,0 +1,27 @@
+# Contract: Enrichment fallback
+
+Craft save MUST complete with today’s transcript when enrichment cannot succeed.
+
+## Fallback (persist spec 030 JSON, no nested spans)
+
+| Cause | Engine / extract reason |
+|-------|-------------------------|
+| Setting off | skipped |
+| Blank 030 transcript | skipped (do not invent lines) |
+| Dedupe hit | skipped (do not rewrite) |
+| PCM extract failed | audio unavailable |
+| Spoken reference missing | `spokenReferenceUnavailable` |
+| Language not in focus map | `unsupportedLanguage` (or skip before call) |
+| Cancel / timeout | `cancelled` / `timedOut` |
+| Mapping threw / empty unexpected payload | treat as failed |
+
+## Forbidden
+
+- Encoding failure as `AlignmentSuccess` with a duration-model or letter-split timeline.
+- Blocking `CraftSaveFailure` solely because alignment failed.
+- Required learner-facing error chrome on fallback.
+- Extra AI credits or a network call beyond the synthesis the learner already ran.
+
+## Logging
+
+`logNamed('craft.enrichment')` (or `alignment.enrichment`) at warning for fallback reason. No `print()`.

--- a/specs/039-craft-timeline-enrichment/contracts/inert-consumers.md
+++ b/specs/039-craft-timeline-enrichment/contracts/inert-consumers.md
@@ -1,0 +1,36 @@
+# Contract: Inert consumers (this slice)
+
+Nested spans may exist on **new/re-saved Craft** items. Nothing else changes.
+
+## Must stay line-only writers
+
+- Caption import
+- YouTube captions
+- Speech-to-text / ASR grouping
+- Auto-translate overlay tracks
+- Craft save with enrichment **off**
+- Craft save with enrichment on but fallback
+
+## Must stay line-level readers
+
+- Transcript panel render (no karaoke, IPA, word chips)
+- Current-line tracking, tap-to-seek line
+- Echo region, blur practice, dictionary lookup
+- Auto-translate fingerprint / `cueIdFor` (line text + line times)
+
+## Import pins
+
+| Root | `package:forced_alignment/` |
+|------|-----------------------------|
+| `lib/features/craft` | **allowed** (save enricher only) |
+| `lib/data/subtitle`, `lib/data/audio` | allowed for mapper / PCM helper |
+| `lib/features/transcript` | forbidden |
+| `lib/features/player` | forbidden |
+| `lib/features/asr` | forbidden |
+| `lib/features/lookup` | forbidden |
+| `lib/features/settings` | forbidden |
+| `lib/l10n` | forbidden |
+
+## Playback
+
+Learner hears Craft `previewAudioBytes` / saved WAV. Never the spoken reference.

--- a/specs/039-craft-timeline-enrichment/contracts/nested-mapping.md
+++ b/specs/039-craft-timeline-enrichment/contracts/nested-mapping.md
@@ -1,0 +1,24 @@
+# Contract: Alignment result → stored cue
+
+**Function**: `attachAlignmentToLines(lines, result) → lines'`  
+**Layer**: `lib/data/subtitle` (no Flutter widgets, no Drift)
+
+## Rules
+
+1. Output length and order equal input `lines`.
+2. Each output line keeps `text`, `startMs`, `durationMs`, `sourceKey`, `confidence`.
+3. Match engine `timeline` entries with `type == segment` and `id == lineIndex` first. Fallback: words whose `startTime` lies in the line window (last line includes `endTime`).
+4. For each matched word:  
+   `startMs = max(0, round((word.startTime − line.startSeconds) × 1000))`  
+   `durationMs = max(0, round((word.endTime − word.startTime) × 1000))`
+5. Child phones become `TranscriptPhone` with media-timeline seconds; `wordIndex` is the index in **that line’s** word list (rebased, not the flatten-global index).
+6. Empty `timeline` is omitted (`null`), not `[]`.
+7. Words with empty text are dropped. Phones without a parent word on that line are dropped.
+8. Do not rewrite the caller’s line text to match alignment word concatenation.
+
+## Tests
+
+- Two-line fixture: each line’s words stay inside its window ±50 ms pad; line starts unchanged.
+- Phone `wordIndex` in range for that line.
+- Failed/missing segment → that line remains line-only; siblings may be nested.
+- Round-trip `TranscriptLine.toJson` / `fromJson` preserves nested fields (slice 1 tests still apply).

--- a/specs/039-craft-timeline-enrichment/contracts/settings-toggle.md
+++ b/specs/039-craft-timeline-enrichment/contracts/settings-toggle.md
@@ -1,0 +1,20 @@
+# Contract: Enrichment setting
+
+**Key**: `transcript.timelineEnrichment` (`SettingsKeys.transcriptTimelineEnrichment`)  
+**Store**: `SettingsDao` string `'true'` / `'false'`; missing ≡ `false`  
+**Default**: off
+
+## Behavior
+
+1. Fresh profile and wiped DB read **off**.
+2. `setEnabled` persists immediately. The next `saveToLibrary` honors the new value without an app restart.
+3. Settings hub shows a **Transcript** section with one switch row (title + subtitle from ARB). The row is in the section registry (spec 004): `sectionId = transcript`, `rowId = timelineEnrichment`.
+4. Search matches localized title and keywords (e.g. “enrichment”, “alignment”, “timeline”).
+5. Settings Dart sources MUST NOT import `package:forced_alignment/`. They only read/write the bool.
+
+## Tests
+
+- Key is allowlisted in `SettingsKeys.isKnown`.
+- Provider defaults false; `setEnabled(true)` round-trips.
+- Registry / layout include the new section and row.
+- Inert-import pin no longer forbids the key; it asserts the key exists.

--- a/specs/039-craft-timeline-enrichment/data-model.md
+++ b/specs/039-craft-timeline-enrichment/data-model.md
@@ -1,0 +1,101 @@
+# Data Model: Craft Timeline Enrichment
+
+**Feature**: `039-craft-timeline-enrichment` | **Date**: 2026-08-16
+
+No Drift schema change. Nested spans stay inside existing `transcripts.timeline_json` (ADR-0070). The new persisted fact is one SettingsDao row.
+
+## Entities
+
+### Enrichment setting
+
+| Field | Type | Rules |
+|-------|------|--------|
+| key | `transcript.timelineEnrichment` | `SettingsKeys` static allowlist |
+| value | `'true'` \| `'false'` \| missing | Missing ≡ off |
+| default | off | Fresh profile / wiped DB |
+
+Riverpod notifier exposes `AsyncValue<bool>`. `setEnabled` writes immediately; next Craft save reads the current value (no restart).
+
+### Synthesis-timing transcript (unchanged)
+
+Output of `buildCraftPrimaryTimelineJson`: JSON array of line-only cues `{text, start, duration}` (ms). `null` means blank primary transcript (spec 030).
+
+### Enriched Craft cue
+
+A `TranscriptLine` that still has required line fields plus optional `timeline`:
+
+| Field | Storage | Rules |
+|-------|---------|--------|
+| text, start, duration | line ms | Unchanged from spec 030 |
+| timeline[] | `TranscriptWord` | Omitted when empty |
+| timeline[].text | string | From alignment word text |
+| timeline[].start / duration | ms **relative to line** | `round((srcSec − lineStartSec) × 1000)` |
+| timeline[].phones[] | `TranscriptPhone` | Omitted when empty / `low` |
+| phones[].phone, text | string | Pronunciation label |
+| phones[].startTime, endTime | seconds on **media** | Not relative to the line |
+| phones[].wordIndex | int? | Index in **this line’s** `timeline` |
+
+### Alignment request (Craft save)
+
+| Input | Source |
+|-------|--------|
+| source PCM | 16 kHz mono Float32 from Craft `previewAudioBytes` |
+| language | `state.synthLanguage` (must be a focus / alignment tag) |
+| segments | one `AlignmentSegment` per line: `text`, `startTime`/`endTime` seconds, `id` = line index |
+| granularity | `medium` (words + phones) |
+| timeout | package per-cue default; overall save must still finish (fallback if exceeded) |
+
+### Enrichment outcome (internal)
+
+| Variant | Persist |
+|---------|---------|
+| skipped (setting off, blank 030 JSON, dedupe) | original `timelineJson` |
+| success (all or some lines) | JSON of lines with nested spans on winners |
+| failed (typed alignment failure or extract failure) | original line-only `timelineJson` |
+
+## Validation
+
+- Line `text` / `start` / `duration` MUST equal the pre-enrichment synthesis cue.
+- Word starts MUST fall inside the parent window except a 50 ms pad.
+- Negative duration after rounding → 0.
+- Phone without a parent word on that line → drop the phone.
+- Unmapped language or missing spoken reference → failed outcome, not a swapped voice.
+- Deduped create → skipped (existing row untouched).
+
+## State transitions
+
+```text
+Craft preview (audio + wordBoundaries)
+        │
+        ▼
+buildCraftPrimaryTimelineJson
+        │
+   ┌────┴────┐
+   │ null    │ non-null lines
+   ▼         ▼
+ blank     setting off? ──yes──► persist line-only
+   save              │
+                     no
+                     ▼
+              extract PCM
+                     │
+                fail? ──yes──► persist line-only
+                     no
+                     ▼
+              alignSegments
+                     │
+         fail / timeout ──► persist line-only
+                     │
+                  success
+                     ▼
+         attachAlignmentToLines
+                     ▼
+         persist enriched JSON
+```
+
+## Relationships
+
+- Enrichment setting → gates the Craft save branch only.
+- Enriched cue → stored on the Craft item’s primary `source: 'ai'` transcript row.
+- Secondary / translation tracks are not enriched this slice.
+- Panel / echo / lookup continue to key off line fields only.

--- a/specs/039-craft-timeline-enrichment/plan.md
+++ b/specs/039-craft-timeline-enrichment/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Craft Timeline Enrichment
+
+**Branch**: `039-craft-timeline-enrichment` | **Date**: 2026-08-16 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/039-craft-timeline-enrichment/spec.md`
+
+**Note**: `/speckit-clarify` was skipped; defaults locked in [research.md](./research.md) (enrich on Craft save only, spec 030 still builds lines, quiet fail-closed fallback, new Settings Transcript section, mapping in `lib/data/subtitle`).
+
+## Summary
+
+Slice 3 of issue #540: first **product caller** of `packages/forced_alignment`. A default-**off** Settings toggle (`transcript.timelineEnrichment`) lets Craft save attach nested word/phone spans onto the existing synthesis-timing lines via `alignSegments` (spoken reference from slice 2b). Off, blank, dedupe, extract failure, or alignment failure → today’s spec 030 transcript. The panel stays line-level (no karaoke). Learners still hear Craft audio. ADR-0073; docs for craft + transcript.
+
+## Technical Context
+
+**Language/Version**: Dart 3.x / Flutter (stable channel per repo)
+
+**Primary Dependencies**: `packages/forced_alignment` (`alignSegments`, flatten/types, fail-closed spoken reference). Existing Craft line builder (`buildCraftPrimaryTimelineJson`). Drift `SettingsDao` + Settings hub registry (spec 004). FFmpeg only as a PCM fallback via a new `lib/data/audio` helper — **not** `AsrAudioExtractor`. Riverpod notifiers; ARB / `flutter gen-l10n`.
+
+**Storage**: No new Drift table. Nested spans in existing `transcripts.timeline_json`. One SettingsDao key `transcript.timelineEnrichment` (`'true'`/`'false'`, missing = off).
+
+**Testing**: Unit tests for mapper, setting provider, Craft save branches (off / fail / success / blank / dedupe). Retarget `test/features/alignment` inert pins. Settings registry widget coverage. `flutter analyze`; `dart run build_runner build` after `@Riverpod`; `bash .github/scripts/validate_ci_gates.sh --fix`.
+
+**Target Platform**: Android, iOS, macOS, Windows, Linux (no web)
+
+**Project Type**: Cross-platform Flutter app (product flow) + existing UI-free path package
+
+**Performance Goals**: Typical ≤60 s Craft clip: extract + spoken-reference `alignSegments` completes in **<10 s** on a current mid-range device without blocking playback/UI (DSP already off the UI isolate). If it cannot, save still finishes via line-only fallback (SC-008). Per-cue jobs, not one whole-file align.
+
+**Constraints**: Offline alignment; no extra credits; no `print()`; no new `media_kit` `Player`; no Flutter web; no YouTube demux; do not play the reference; do not change `cueIdFor` / spec 030 line breaks; feature↔feature: Craft must not import ASR. Quiet fallback — no blocking save error. Stack on slice 2b if #556 is unmerged.
+
+**Scale/Scope**: One Settings section/row, one Craft save hook, one mapper, one PCM helper, ADR-0073, two feature-doc updates. No Worker, no panel chrome, no library backfill.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Plan response |
+|-----------|--------|---------------|
+| I. Architecture | Pass | Mapping + PCM in `lib/data`. Setting provider + Craft enricher in application layers. Persistence via `SettingsDao` / existing transcript DAO. No Craft→ASR import. Package stays UI-free. |
+| II. Testing | Pass | Mapper, setting, Craft save matrix, retargeted inert pins, Settings registry. Existing 030 / panel tests stay green. |
+| III. UX consistency | Pass | `SettingsRow` + `Switch.adaptive` (diagnostics pattern). ARB strings. No new tappable panel chrome. `EnjoyPage` not required (hub section). |
+| IV. Performance | Pass | Extract + align off UI isolate; <10 s or fallback; per-cue; cancel/timeout from package. |
+| V. Documentation | Pass | ADR-0073; `docs/features/craft.md` + `transcript.md`; ADR-0070–0072 left intact. |
+| Flutter Quality Gates | Pass | format + codegen + analyze + test; no web; no new `Player()`; `build_runner` for the setting notifier; `flutter gen-l10n` |
+
+**Post-design re-check**: Pass — contracts keep line identity, fail closed, and inert panel/import/ASR/YouTube. New Settings section is required discoverability (spec US4), not a second settings system. Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/039-craft-timeline-enrichment/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── README.md
+│   ├── settings-toggle.md
+│   ├── craft-save-enrichment.md
+│   ├── nested-mapping.md
+│   ├── fallback.md
+│   └── inert-consumers.md
+└── tasks.md             # /speckit-tasks (not this command)
+```
+
+### Source Code (repository root)
+
+```text
+lib/data/db/settings_keys.dart              # + transcriptTimelineEnrichment
+lib/data/subtitle/attach_alignment_to_lines.dart
+lib/data/audio/pcm16k_mono.dart             # Craft WAV/bytes → Float32 16 kHz
+lib/features/craft/application/
+  craft_controller.dart                     # hook after buildCraftPrimaryTimelineJson
+  craft_timeline_enricher.dart              # extract + alignSegments + attach
+lib/features/settings/
+  application/timeline_enrichment_settings.dart   # @Riverpod SettingsDao bool
+  domain/settings_search_entry.dart         # Transcript section + row
+  presentation/…                            # section body, both layouts, visuals
+lib/l10n/*.arb                              # settingsTranscript* strings
+test/data/subtitle/attach_alignment_to_lines_test.dart
+test/features/craft/…                       # save off/fail/success/blank/dedupe
+test/features/alignment/                    # retarget inert + key-exists pins
+test/features/settings/                     # registry + default off
+docs/decisions/0073-craft-timeline-enrichment.md
+docs/features/craft.md
+docs/features/transcript.md
+```
+
+**Structure Decision**: Do not add `lib/features/alignment`. Craft is the only product caller; shared mapping/PCM live in `lib/data`. Settings owns the switch chrome and the persisted bool. `packages/forced_alignment` is unchanged except as an imported API.
+
+## Complexity Tracking
+
+> None. No constitution violations.

--- a/specs/039-craft-timeline-enrichment/quickstart.md
+++ b/specs/039-craft-timeline-enrichment/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart: Craft Timeline Enrichment
+
+**Feature**: `039-craft-timeline-enrichment`  
+**Contracts**: [contracts/README.md](./contracts/README.md) · **Model**: [data-model.md](./data-model.md)
+
+## Prerequisites
+
+- Flutter toolchain per repo README
+- Slice 2b (`038-alignment-spoken-reference` / ADR-0072) on the branch — production `alignSegments` requires a spoken reference
+- After Riverpod / ARB edits: `dart run build_runner build` and `flutter gen-l10n`; commit generated files
+
+## Automated checks
+
+```bash
+flutter test test/features/craft test/features/alignment test/features/settings test/data/subtitle
+flutter test packages/forced_alignment/test
+flutter analyze
+bash .github/scripts/validate_ci_gates.sh --fix
+```
+
+Expected:
+
+- Mapper: two-line attach keeps line text/start/duration; word ms relative to line; phone seconds + in-range `wordIndex`
+- Setting defaults off; persist true/false; Settings registry includes Transcript / `timelineEnrichment`
+- Craft save with setting **off** → line-only JSON (existing spec 030 tests stay green)
+- Craft save with setting **on** + injected/forced alignment failure → same line-only JSON; save succeeds
+- Craft save with setting **on** + successful `alignSegments` (test double or FFI) → nested spans on lines; audio bytes unchanged
+- Blank 030 path still `primaryTimelineJson: null`
+- Dedupe path does not rewrite the existing item
+- Inert pins: transcript/player/ASR/lookup/Settings/l10n do not import `forced_alignment`; Craft may
+- Import / YouTube / ASR still write line-only cues
+- Existing Craft / transcript panel tests still pass (line-level chrome)
+
+## Manual validation (E2E)
+
+### A. Default off (P1)
+
+1. Fresh profile (or leave the new switch off).
+2. Craft a short paragraph with Enjoy TTS; save; open in the player.
+3. **Expect**: Same line breaks/times as before this slice; no word highlight / IPA / per-word chips.
+4. Open Settings → Transcript.
+5. **Expect**: Enrichment switch is off.
+
+### B. Opt-in save (P1)
+
+1. Turn enrichment **on**. Do not restart.
+2. Craft a two-sentence English item; save; reopen.
+3. **Expect**: Same visible lines. (Optional debug: stored `timeline_json` has `timeline` + `phones` on cues.)
+4. Play the item.
+5. **Expect**: Hear Craft TTS audio, not a synthetic reference voice.
+
+### C. Fallback (P1)
+
+1. Leave enrichment on. Save a Craft item on a path with no extractable audio or an unsupported alignment language (or disable native eSpeak in a debug build).
+2. **Expect**: Save succeeds; transcript matches today’s line-only or blank result; no blocking error.
+
+### D. Library unchanged (P1)
+
+1. Open a pre-existing import, YouTube, ASR, and old Craft item.
+2. **Expect**: Cues unchanged until a Craft **re-save** with the setting on.

--- a/specs/039-craft-timeline-enrichment/research.md
+++ b/specs/039-craft-timeline-enrichment/research.md
@@ -1,0 +1,128 @@
+# Research: Craft Timeline Enrichment
+
+**Feature**: `039-craft-timeline-enrichment` | **Date**: 2026-08-16
+
+Slices 1–2b already persist optional nested cues, expose `align` / `alignSegments`, and require a spoken reference for production success. This research locks how Craft becomes the first product caller without changing default save/playback.
+
+## Decisions
+
+### 1. Enrich on Craft save / re-save only
+
+**Decision**: When `transcript.timelineEnrichment` is on, run alignment inside `CraftController.saveToLibrary` **after** `buildCraftPrimaryTimelineJson` succeeds and **before** `importCraftedFromText` / `updateCraftedFromText`. Deduped creates that skip synthesis skip enrichment (no silent rewrite). Already-saved library items are not backfilled. First-play alignment is out of scope.
+
+**Rationale**: Spec US4 / FR-010. Save is the only moment we already have in-memory `previewAudioBytes`, known line windows, and a language. First-play would delay opening old items (rejected in the spec).
+
+**Alternatives considered**:
+- First-play for ≤60 s (issue #540 open question) — surprises playback; harder to test independently; rejected for this slice.
+- Library-wide backfill job — rewrite risk; out of scope.
+
+### 2. Spec 030 still builds lines; alignment only attaches nested spans
+
+**Decision**: Keep `buildCraftPrimaryTimelineJson` as the line source (wording, breaks, solid-timings-or-blank). On success, decode those lines, call `alignSegments` with each line’s text + `[startSeconds, endSeconds]`, then attach `TranscriptWord` / `TranscriptPhone` onto the **same** lines. On any hard failure, persist the original line-only JSON unchanged.
+
+Do **not** use `align()` whole-clip to invent a transcript when spec 030 returns `null`.
+
+**Rationale**: FR-003 / FR-008 / SC-007. Line identity and shadow-friendly breaks stay ADR-0063 / spec 030.
+
+**Alternatives considered**:
+- Replace line builder with alignment segments — would change breaks and violate spec 030.
+- Whole-clip `align` then re-segment — extra mapping dialect; rejected.
+
+### 3. Fail closed to today’s Craft transcript (quiet)
+
+**Decision**: `AlignmentFailed` for `spokenReferenceUnavailable`, `unsupportedLanguage`, `audioUnavailable`, `tooShort`, `cancelled`, `timedOut`, or `internal` → save the spec 030 JSON as-is. Partial cue success (some lines aligned) MAY attach nested spans only on successful lines; failed lines stay line-only. Log the reason with `logNamed`; no blocking Craft error chrome or required toast.
+
+**Rationale**: FR-007 / SC-004. Slice 2b already made fake success impossible. Quiet fallback keeps Craft save no more fragile than today.
+
+**Alternatives considered**:
+- Block save on alignment failure — violates “save always works.”
+- Diagnostic toast — not required; can wait for a later polish slice.
+
+### 4. Mapping lives in `lib/data/subtitle`; Craft owns the call
+
+**Decision**: Pure function (no `BuildContext`, no Drift):
+
+```text
+attachAlignmentToLines(
+  lines: List<TranscriptLine>,
+  result: AlignmentResult,
+) → List<TranscriptLine>
+```
+
+Rules (ADR-0070 / 037 flatten contract):
+
+1. Prefer `TimelineEntry.id` matching the line index (pass `AlignmentSegment.id = lineIndex`).
+2. Else assign words whose start falls in `[line.startSeconds, line.endSeconds)` (last line inclusive at end).
+3. Word `startMs` / `durationMs` = round((sourceSeconds − line.startSeconds) × 1000), duration ≥ 0.
+4. Phones copy `phone` / `text` / `startTime` / `endTime` (seconds on the **media** timeline) and `wordIndex` **within that line’s word list**.
+5. Never change line `text` / `startMs` / `durationMs` / `sourceKey`.
+6. Empty word list → omit `timeline` (line-only).
+
+`flattenToWordPhoneTimings` remains available for tests; production mapping should walk tagged segment entries so phones stay per-line.
+
+**Rationale**: Constitution I — lift shared mapping out of features. Craft is the only caller this slice.
+
+**Alternatives considered**:
+- Import `TranscriptLine` into `packages/forced_alignment` — rejected in 037 (cycle / package purity).
+- New `lib/features/alignment` product module — unnecessary third home; Settings + Craft already exist.
+
+### 5. PCM from Craft preview bytes; do not import ASR from Craft
+
+**Decision**: Add a UI-free helper under `lib/data/audio/` that turns Craft `previewAudioBytes` (WAV) into 16 kHz mono `Float32List`. Prefer a small WAV decode + existing package resample when the file is already PCM; otherwise write a temp file and FFmpeg `pcm_s16le -ar 16000 -ac 1` (same family as ASR / assessment), then convert int16 → float32 in `[-1, 1]`. Do **not** have `lib/features/craft` import `AsrAudioExtractor`.
+
+**Rationale**: Feature↔feature ban. Craft audio is local and extractable. Extract + `alignSegments` must stay off the UI isolate (FFmpeg already isolates on Windows; alignment already uses a worker + serial synth host).
+
+**Alternatives considered**:
+- Call `AsrAudioExtractor` from Craft — feature shortcut; rejected.
+- Decode only in the alignment package — package is PCM-in by design (037).
+
+### 6. Settings key + new Transcript section
+
+**Decision**:
+
+- `SettingsKeys.transcriptTimelineEnrichment = 'transcript.timelineEnrichment'` (string `'true'` / `'false'`, missing = off). Add to `_staticKeys`.
+- Keep-alive Riverpod notifier (same shape as `DiagnosticsVerbose`) reading `SettingsDao`.
+- New Settings hub section `SettingsSectionIds.transcript` with one `SettingsRow` + `Switch.adaptive` (same pattern as diagnostic logging). Register the section/row in the 004 registry, both layouts, visuals, localizer, and search keywords.
+- ARB strings via `flutter gen-l10n`. Toggle honored on the next save without restart.
+
+**Rationale**: Spec US4 / FR-001. Issue #540 named the key. A dedicated Transcript section is discoverable without overloading About or Appearance.
+
+**Alternatives considered**:
+- Hide the toggle under Developer — not learner-facing.
+- Profile/cloud setting — this is a device preference like diagnostics; local `SettingsDao` is enough for v1.
+
+### 7. Retarget inert pins; panel stays inert
+
+**Decision**: Update `forced_alignment_inert_import_test.dart`:
+
+- **Allow** `lib/features/craft` (and the new `lib/data/audio` / `lib/data/subtitle` mapper) to import `package:forced_alignment/`.
+- **Keep forbidding** transcript panel, player, ASR, lookup, Settings, and l10n from importing the package (Settings talks to the bool provider only).
+- **Invert** the “no `transcript.timelineEnrichment` key” pin: the key MUST exist and default off.
+- Add pins: import / YouTube / ASR builders still emit line-only cues; Craft save with setting off emits line-only; panel tests still ignore `timeline` for chrome.
+
+**Rationale**: Slice 2b’s unused-engine pins would otherwise fail the first legitimate caller.
+
+### 8. ADR-0073; docs; no karaoke
+
+**Decision**: New ADR-0073 (first product caller, default-off setting, fail-closed save, mapping rules, no panel chrome). Do not rewrite ADR-0070–0072. Update `docs/features/craft.md` and `docs/features/transcript.md`. No new `media_kit` `Player`. No playback of the spoken reference.
+
+**Rationale**: Constitution V. Slice 4 owns karaoke.
+
+## Open items resolved (no spec change)
+
+| Topic | Resolution |
+|-------|------------|
+| When to run | Craft save / re-save only |
+| Blank 030 transcript | Skip alignment; stay blank |
+| Deduped create | Skip enrichment |
+| Partial line success | Nested on winners; line-only on losers |
+| Failure UX | Quiet fallback + log |
+| Settings IA | New Transcript section, one switch |
+| PCM | `lib/data/audio` helper; no Craft→ASR import |
+| Mapping | `lib/data/subtitle`; segment `id` = line index |
+
+## Dependencies
+
+- Slice 2b (`038`, ADR-0072) must be on the branch (spoken reference + `EspeakSynthHost`). Stack on `038-alignment-spoken-reference` if #556 is not merged.
+- Slice 1 nested JSON (ADR-0070) and spec 030 line builder (ADR-0063).
+- Settings hub registry (spec 004 / ADR-style section list).

--- a/specs/039-craft-timeline-enrichment/spec.md
+++ b/specs/039-craft-timeline-enrichment/spec.md
@@ -1,0 +1,204 @@
+# Feature Specification: Craft Timeline Enrichment
+
+**Feature Branch**: `039-craft-timeline-enrichment`
+
+**Created**: 2026-08-16
+
+**Status**: Draft
+
+**Input**: User description: "continue to next follow-up spec"
+
+**Source**: [GitHub issue #540](https://github.com/baizhiheizi/enjoy_player/issues/540). This specification is **slice 3** of that program. Slice 1 ([036-transcript-nested-timeline](../036-transcript-nested-timeline/spec.md)) lets a stored cue hold optional word/phone spans. Slices 2 and 2b ([037-alignment-engine](../037-alignment-engine/spec.md), [038-alignment-spoken-reference](../038-alignment-spoken-reference/spec.md)) can produce those timings from known text and extractable audio, comparing the clip to a same-language spoken reference. This slice is the **first product caller**: opt-in Craft save may store those nested timings. It does **not** add karaoke, IPA overlay, or per-word tap.
+
+## Program split (issue #540)
+
+Each slice MUST be independently shippable: existing transcript, playback, Craft, import, speech-to-text, YouTube captions, echo, lookup, and translation behavior stay intact unless that slice’s opt-in path is explicitly on.
+
+| Slice | Spec | What ships | Why it does not break existing features |
+|-------|------|------------|----------------------------------------|
+| **1** | [Nested transcript timeline](../036-transcript-nested-timeline/spec.md) | A cue MAY carry optional word/phone spans. No new UI. | Additive storage. Nested data ignored until a consumer slice. |
+| **2** | [Alignment engine](../037-alignment-engine/spec.md) | Standalone capability: known text + extractable audio → word/phone timings. Not wired into Craft or the panel. | Unused by product flows. |
+| **2b** | [Spoken alignment reference](../038-alignment-spoken-reference/spec.md) | Production alignment compares the clip to a same-language spoken rendering. Still unused by product. | Unused. Learners see no change. |
+| **3 (this spec)** | Craft timeline enrichment | Opt-in: Craft items may store nested timings from this engine. Default remains today’s synthesis-timing transcript. | Off by default. On failure, Craft save and playback match pre-feature behavior. |
+| **4** | Karaoke word highlight | Opt-in word highlight while media plays, when the cue has word timings. | Off by default; inactive on line-only cues. |
+| **5** | Word-level practice | Opt-in later: tap/loop/inspect a word. | No nested data → today’s line-level interactions. |
+| **Related** | IPA overlay ([#527](https://github.com/baizhiheizi/enjoy_player/issues/527)) | Display pronunciation spelling per word. | Own toggle and own spec. |
+
+**Out of the #540 program (all slices):** aligning YouTube WebView playback (no extractable audio), aligning the learner’s own shadow-reading recording, replacing Craft’s high-quality playback audio with a synthetic reference voice, real-time/streaming alignment, and cross-language alignment (audio in one language, transcript in another).
+
+## Scope (this slice only)
+
+### In scope
+
+- Add one learner-facing **opt-in** setting (default **off**) that allows Craft to store nested word/phone timings from the alignment capability.
+- When that setting is **on** and Craft already has a solid synthesis-built line transcript plus extractable audio, run alignment against those **existing line windows** and persist nested spans on those cues. Line text, line start, and line duration stay the [spec 030](../030-craft-tts-transcript/spec.md) synthesis-timing transcript.
+- When the setting is **off**, or alignment cannot succeed, Craft save MUST match today’s path: line-only cues from synthesis timings, or a blank transcript when synthesis timings are not solid.
+- Keep the transcript panel, playback tracking, echo, lookup, blur, and auto-translate on **line-level** fields. Nested spans are stored; they are not shown as karaoke, IPA, or per-word targets in this slice.
+- Keep Craft/library playback as today’s high-quality Craft audio. The spoken reference used for alignment is never what the learner hears.
+
+### Out of scope (this slice)
+
+- Karaoke word highlight (slice 4), per-word tap/loop/inspect (slice 5), IPA overlay ([#527](https://github.com/baizhiheizi/enjoy_player/issues/527)).
+- Enriching import, YouTube captions, or speech-to-text tracks. Those producers stay line-only.
+- Retroactive background rewrite of the existing library. Already-saved items are unchanged until the learner **re-saves** a Craft item with the setting on.
+- First-play or mid-playback alignment that delays opening or seeking an existing item.
+- Using alignment to invent a transcript when Craft save would otherwise leave the transcript blank ([spec 030](../030-craft-tts-transcript/spec.md) / no solid synthesis timings).
+- Replacing Craft playback audio with a spoken-reference voice.
+- YouTube WebView demux, learner-recording alignment, streaming alignment, cross-language alignment.
+- Changing cue identity (`cueIdFor`, auto-translate fingerprint) or [spec 030](../030-craft-tts-transcript/spec.md) line-break rules.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Default off: Craft and library behave as today (Priority: P1)
+
+A learner who never turns the new setting on (the shipped default) crafts, saves, and practices exactly as before. Craft still builds line-only cues from synthesis timings when those timings are solid, or leaves the transcript blank when they are not. Imported captions, YouTube captions, and speech-to-text tracks are unchanged. They still hear Craft’s high-quality audio.
+
+**Why this priority**: Slice 3 is only shippable if the default path is byte-for-byte today’s Craft and library experience.
+
+**Independent Test**: Leave the new setting at default. Run the same curated set as slices 1–2b (import, YouTube captions, speech-to-text, Craft with synthesis transcript, Craft with blank transcript). Confirm line text, order, times, interactions, and that new Craft saves stay line-only (or blank per spec 030).
+
+**Acceptance Scenarios**:
+
+1. **Given** the enrichment setting at its default (off), **When** the learner saves a Craft item that has solid synthesis timings, **Then** stored cues are line-only and match today’s synthesis-timing transcript (same wording, line breaks, and line times).
+2. **Given** that same default, **When** synthesis cannot produce a solid timed transcript, **Then** Craft still saves playable audio with a blank transcript; the learner can still generate cues later with speech-to-text.
+3. **Given** a library item created before this slice, **When** the learner opens and plays it, **Then** visible lines, start times, tap-to-seek, current-line, echo, lookup, and auto-translate match the pre-feature record.
+4. **Given** Craft or library playback with the setting off, **When** the item plays, **Then** the learner hears the existing high-quality audio, not a spoken-reference rendering.
+
+---
+
+### User Story 2 - Opt-in Craft save stores nested word and phone timings (Priority: P1)
+
+A learner turns enrichment on, then crafts a short practice item whose synthesis path already produces a solid line transcript. After save and reopen, each line still looks and seeks like today’s cue, but the stored cue now also remembers ordered word spans (and default-quality phone spans) that came from aligning that line’s text to that line’s audio window.
+
+**Why this priority**: This is the entire product value of slice 3: nested timings exist on Craft items so later karaoke/IPA can consume them, without changing what the learner sees yet.
+
+**Independent Test**: Turn the setting on. Craft a short multi-word, multi-line item on a path that already saves a synthesis transcript. Reopen the item. Confirm line text/start/duration match the synthesis-timing transcript, and that stored cues now include word spans in transcript order (and phones at default quality) whose times sit on the source audio / parent line.
+
+**Acceptance Scenarios**:
+
+1. **Given** enrichment is on and Craft has solid synthesis line cues plus extractable audio, **When** the learner saves, **Then** each saved line keeps the same text, start, and duration as the synthesis-timing transcript, and successful lines also store ordered word spans.
+2. **Given** that same save at default alignment quality, **When** the transcript is loaded again, **Then** at least one word on a successful line has a non-empty phone list, and every phone names a parent word that exists.
+3. **Given** a successful enriched cue, **When** word times are inspected, **Then** they lie inside that cue’s line window except for the published pad (50 ms); line start/duration are not rewritten.
+4. **Given** the same practice text, audio, language, and setting, **When** Craft save runs twice, **Then** line order and counts match; nested word counts match; start times stay within the published tolerance.
+5. **Given** a Craft item saved with nested spans, **When** the learner opens it in the player, **Then** the panel still shows today’s line-level presentation (no karaoke, IPA, or per-word chips in this slice).
+
+---
+
+### User Story 3 - Alignment failure keeps today’s Craft transcript (Priority: P1)
+
+A learner has enrichment on, but this save cannot produce a spoken-reference alignment (unsupported language, spoken reference unavailable on the device, missing extractable audio, cancel, or timeout). Craft save still succeeds. The stored transcript is the same line-only (or blank) result they would have gotten before this slice. They are not blocked, and they do not get a fake nested timeline.
+
+**Why this priority**: A failed or fake enrichment would either break Craft save or write bad word times that later karaoke would trust.
+
+**Independent Test**: Turn the setting on and drive each failure class (spoken reference unavailable, unsupported language, no extractable audio, timeout). Confirm save completes, the transcript matches the pre-feature Craft result for that path, and no nested spans are invented from a stand-in.
+
+**Acceptance Scenarios**:
+
+1. **Given** enrichment is on but a spoken reference cannot be produced, **When** the learner saves a Craft item that has solid synthesis timings, **Then** save succeeds with the same line-only synthesis-timing transcript as today (no nested spans).
+2. **Given** enrichment is on and the language has no alignment voice, **When** the learner saves, **Then** the result is today’s Craft transcript for that path; timings MUST NOT be written as if another language’s voice was used.
+3. **Given** enrichment is on and audio is not extractable, **When** the learner saves, **Then** Craft still stores today’s synthesis-timing (or blank) transcript; save is not refused.
+4. **Given** enrichment is on and alignment is cancelled or times out, **When** save finishes, **Then** the stored transcript is today’s line-only (or blank) result; the rest of the app stays usable.
+5. **Given** any of these fallbacks, **When** the learner is in Craft or the player, **Then** they are not shown a blocking error that prevents save or playback (quiet fallback; no new required error chrome).
+
+---
+
+### User Story 4 - The setting is discoverable, persists, and does not rewrite the library (Priority: P1)
+
+A learner can find the enrichment control under Settings, see that it is off by default, turn it on or off, and have that choice remembered. Turning it on does not rewrite items they already saved. Import, YouTube, and speech-to-text flows never start writing nested spans in this slice. Changing the setting does not require restarting the app.
+
+**Why this priority**: Opt-in is the program’s hard constraint. A hidden or sticky-on toggle, or a silent library rewrite, would break “default remains today’s transcript.”
+
+**Independent Test**: Confirm the Settings row exists, defaults off, and persists across relaunch. With it on, save one new Craft item (enriched or fallback). Confirm pre-existing library items still have their previous cues. Confirm an import / YouTube / speech-to-text save still writes line-only cues.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh profile, **When** the learner opens Settings, **Then** they can find a transcript-enrichment control that is **off**.
+2. **Given** they turn it on (or off), **When** they leave Settings and return or relaunch the app, **Then** the control still shows their choice; they do not need to restart for the next Craft save to honor it.
+3. **Given** enrichment is on, **When** they open a Craft or library item saved before this slice (or saved while the setting was off), **Then** that item’s cues are unchanged until they **re-save** that Craft item.
+4. **Given** enrichment is on, **When** they import captions, open YouTube captions, or generate a speech-to-text transcript, **Then** those tracks remain line-only (this slice does not enrich them).
+
+---
+
+### Edge Cases
+
+- **Blank Craft transcript**: If synthesis timings are not solid, Craft still saves audio without a primary timed transcript. This slice MUST NOT invent lines or nested spans from alignment in that case. Speech-to-text remains the way to get cues later.
+- **Setting off on re-save**: A re-save with enrichment off writes today’s line-only synthesis transcript (or blank). It MUST NOT invent nested spans. Previously stored nested spans on that item MAY be replaced by the new line-only save (same as any Craft re-save replacing the transcript).
+- **Partial cue success**: If some line windows align and others fail, the save MUST still succeed. Successful lines MAY store nested spans; failed lines stay line-only. Line text/start/duration stay the synthesis transcript for every line.
+- **Reference length ≠ clip length**: Spoken-reference duration may differ from the Craft audio. Stored word/phone times MUST still sit on the Craft audio / parent-line timeline; practice text is not rewritten.
+- **Text/audio mismatch**: Best-effort nested times are allowed; do not replace the learner’s crafted wording.
+- **Punctuation-only or empty line**: That line stays valid as today; it does not require a spoken reference.
+- **Secondary / translation track**: Alignment enriches the **practice** (primary) Craft transcript only. Translation overlays stay line-level and keep today’s identity rules.
+- **Deduped Craft create**: Re-pasting identical text that returns an existing item without a new synthesis MUST NOT silently rewrite that item’s transcript in the background.
+- **Long Craft audio with line windows**: Prefer per-line alignment of existing cue windows. Do not run one unbounded whole-file alignment over a multi-minute file.
+- **Learner never hears the reference**: The spoken rendering is an internal alignment input only.
+- **Incomplete nested data**: Words or phones without times still load; the panel uses line-level fields (slice 1 rules).
+- **Malformed nested write**: A failed mapping MUST degrade to line-only for that cue, not fail the whole save.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The product MUST add one learner-facing transcript-enrichment setting, default **off**, persisted with the rest of Settings, and honored on the next Craft save without requiring an app restart.
+- **FR-002**: While that setting is off, Craft save, library playback, import, YouTube captions, and speech-to-text MUST match pre-feature behavior (line-only or blank per [spec 030](../030-craft-tts-transcript/spec.md)).
+- **FR-003**: While that setting is on, Craft save MUST still build line cues with [spec 030](../030-craft-tts-transcript/spec.md) rules (wording, sentence/phrase breaks, solid-timings-or-blank). Alignment MUST NOT replace that line-building step.
+- **FR-004**: While that setting is on and a solid line transcript plus extractable audio exist, Craft save MUST request per-line alignment of those cue windows (known line text + that line’s time window) and, on success, persist nested word spans (and default-quality phone spans) on those cues.
+- **FR-005**: Successful nested times MUST lie on the Craft source-audio timeline and MUST be stored in the slice 1 meaning (word start/duration relative to the parent line; phones as pronunciation + seconds). Line text, line start, and line duration MUST NOT change.
+- **FR-006**: Synthesis word-boundary events remain valid for **line building**. They MUST NOT be the stored source of nested word/phone spans when enrichment succeeds. A non-speech stand-in MUST NOT be stored as nested success.
+- **FR-007**: If alignment cannot succeed (spoken reference unavailable, unsupported language, audio unavailable, too short, cancel, timeout, or mapping failure), Craft save MUST still succeed with today’s synthesis-timing or blank transcript and MUST NOT write a fake nested timeline.
+- **FR-008**: A Craft save that would be blank under spec 030 MUST stay blank. Alignment MUST NOT invent a primary transcript.
+- **FR-009**: Import, YouTube captions, speech-to-text, auto-translate overlays, echo, lookup, and blur MUST NOT start calling alignment or requiring nested spans in this slice.
+- **FR-010**: Already-saved items MUST NOT be rewritten in the background. Enrichment applies to a Craft save (or re-save) while the setting is on.
+- **FR-011**: The spoken reference MUST NOT be played to the learner and MUST NOT replace Craft or library playback audio.
+- **FR-012**: This slice MUST NOT add karaoke, IPA overlay, or per-word tap/loop/inspect. Nested data remains inert in the transcript panel (slice 1 consumer rules).
+- **FR-013**: Cue identity used for current line, echo, blur, and translation fingerprinting MUST stay based on line-level fields.
+- **FR-014**: Failures and fallbacks MUST NOT spend extra learner credits and MUST NOT require a network round-trip beyond the Craft synthesis the learner already requested.
+- **FR-015**: YouTube WebView remains without extractable audio; this slice MUST NOT add a YouTube download/demux path.
+- **FR-016**: Supported alignment languages remain the app’s current focus learning languages. An unmapped language MUST fall back (FR-007), not silently swap voice.
+
+### Key Entities
+
+- **Enrichment setting**: A single opt-in learner control (default off) that allows Craft save to persist nested timings from the alignment capability.
+- **Synthesis-timing transcript**: Today’s Craft primary transcript: line cues built from synthesis word timings ([spec 030](../030-craft-tts-transcript/spec.md)). Still the line source when enrichment is on, and the entire stored transcript when enrichment is off or alignment fails.
+- **Enriched Craft cue**: A synthesis-timing line that also stores optional word/phone spans from a successful same-language spoken-reference alignment of that line’s window.
+- **Alignment fallback**: Save completed with the synthesis-timing or blank transcript and no nested spans, after alignment could not succeed.
+- **Spoken reference**: Internal same-language voice rendering used by the alignment capability (slices 2b). Never the learner’s playback audio.
+- **Transcript cue / word span / phone span / line identity**: Same meaning as [slice 1](../036-transcript-nested-timeline/spec.md).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With enrichment at default (off), on the same curated regression set as slices 1–2b (at least 10 existing transcripts: import, YouTube captions, speech-to-text, Craft synthesis, plus at least one blank-transcript Craft path), 100% of cues keep the same line text, order, start, and duration; 0 new Craft saves gain nested spans.
+- **SC-002**: Learners can find the enrichment control in Settings; a fresh profile shows it **off**; a changed value is still there after relaunch; the next Craft save honors it without restart.
+- **SC-003**: With enrichment on and a short Craft item (at least 2 lines, at least 2 words) that already gets a solid synthesis transcript, 100% of lines keep synthesis text/start/duration; 100% of successful lines store word spans in order; each word start is within **50 ms** of that line window except for the published pad; at least one word has phones that are not a letter-split of the spelling.
+- **SC-004**: With enrichment on and alignment forced unavailable (or unsupported language, or no extractable audio, or timeout), 100% of Craft saves still complete; the stored transcript matches the pre-feature result for that path; 0 nested spans from a non-speech stand-in.
+- **SC-005**: With enrichment on, 0 import / YouTube / speech-to-text saves gain nested spans from this slice; 0 already-saved library items change until a Craft re-save.
+- **SC-006**: Side-by-side with the pre-feature build, the transcript panel shows no karaoke, IPA, or per-word chrome; 0 playback substitutions of a spoken-reference voice.
+- **SC-007**: A Craft save that is blank under spec 030 stays blank (0 invented lines or nested spans) even when enrichment is on.
+- **SC-008**: While a typical Craft clip (about **60 s** or less) is being enriched, the rest of the app remains usable. If alignment cannot finish in time a save can wait (**under 10 s** on a current mid-range device, documented if slower on a given platform), the save still completes via SC-004 fallback rather than hanging.
+
+## Assumptions
+
+- This slice is the first **product caller** of the unused alignment capability. Shipping with inert nested data in the panel is intended; karaoke is slice 4.
+- Enrichment runs on **Craft save / re-save**, not on first play and not as a library-wide backfill. That keeps save/playback independently testable and avoids delaying open of old items.
+- Line windows already exist from spec 030 when timings are solid. Per-line alignment is the calling pattern. Whole-clip alignment is not required for this Craft path.
+- Spec 030 remains the contract for “solid timings → lines” vs “no solid timings → blank + later speech-to-text.” Alignment does not become a third way to create a transcript.
+- Synthesis word-boundary events stay the **line** source. They are no longer the stored source of **nested** word/phone spans when enrichment succeeds.
+- The setting key remains `transcript.timelineEnrichment` (default off), as named in issue #540 and slices 1–2b. Exact Settings copy belongs in localization during implementation.
+- Quiet fallback (no blocking error chrome) is the default when alignment fails so Craft save cannot become more fragile than today. Diagnostic logging may record the reason; a toast is not required in this slice.
+- Word-start tolerance remains **±50 ms** vs the spoken reference / line window pad from slices 2–2b. Bit-identical timestamps are not required.
+- Focus learning languages remain the v1 alignment language bar.
+- Offline/on-device alignment. Extra learner credits are not spent.
+- Deduped Craft creates that skip synthesis also skip enrichment (no silent rewrite).
+- Secondary translation tracks are not aligned in this slice.
+- Slice 1 nested storage, slice 2 calling patterns, and slice 2b spoken-reference / fail-closed rules remain dependencies.
+
+## Dependencies
+
+- Relies on slice 1 nested cue meaning ([036](../036-transcript-nested-timeline/spec.md), [ADR-0070](../../docs/decisions/0070-nested-transcript-timeline.md)).
+- Relies on the callable alignment capability ([037](../037-alignment-engine/spec.md)) and spoken-reference production path ([038](../038-alignment-spoken-reference/spec.md), [ADR-0072](../../docs/decisions/0072-spoken-alignment-reference.md)).
+- Relies on Craft line-building and blank-transcript rules ([030](../030-craft-tts-transcript/spec.md), ADR-0063).
+- Relies on existing extractable-audio paths for **Craft** files. Does not rely on YouTube WebView PCM.
+- Does not depend on slice 4 karaoke, slice 5 word practice, or [#527](https://github.com/baizhiheizi/enjoy_player/issues/527) IPA overlay.
+- Must not change auto-translate fingerprinting or transcript panel behavior documented in [docs/features/transcript.md](../../docs/features/transcript.md) beyond storing optional nested fields on Craft saves.
+- Must update [docs/features/craft.md](../../docs/features/craft.md) and [docs/features/transcript.md](../../docs/features/transcript.md) when this behavior ships.

--- a/specs/039-craft-timeline-enrichment/tasks.md
+++ b/specs/039-craft-timeline-enrichment/tasks.md
@@ -1,0 +1,265 @@
+# Tasks: Craft Timeline Enrichment
+
+**Input**: Design documents from `specs/039-craft-timeline-enrichment/`
+
+**Note**: Slice 3 of issue #540. First product caller of `packages/forced_alignment`: opt-in Craft save may store nested word/phone spans on spec 030 lines. Default remains today’s transcript. See [plan.md](./plan.md), [research.md](./research.md). ADR-0073 is written in polish. Stack this branch on `038-alignment-spoken-reference` if PR #556 is not merged.
+
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Required for changed contracts (constitution + plan + spec independent tests). Manual checks per [quickstart.md](./quickstart.md) §§A–D.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Setting key**: `lib/data/db/settings_keys.dart`
+- **Mapper**: `lib/data/subtitle/attach_alignment_to_lines.dart`
+- **PCM**: `lib/data/audio/pcm16k_mono.dart`
+- **Enricher**: `lib/features/craft/application/craft_timeline_enricher.dart`
+- **Craft save**: `lib/features/craft/application/craft_controller.dart`
+- **Setting notifier**: `lib/features/settings/application/timeline_enrichment_settings.dart`
+- **Settings hub**: `lib/features/settings/domain/settings_search_entry.dart`, `lib/features/settings/presentation/widgets/`
+- **ARB**: `lib/l10n/app_en.arb`, `lib/l10n/app_zh.arb`, `lib/l10n/app_zh_CN.arb`
+- **Pins**: `test/features/alignment/forced_alignment_inert_import_test.dart`
+- **Docs**: `docs/decisions/0073-craft-timeline-enrichment.md`, `docs/features/craft.md`, `docs/features/transcript.md`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Feature branch on top of spoken-reference alignment so Craft can call `alignSegments`
+
+- [X] T001 Create git branch `039-craft-timeline-enrichment` from current `main`, or from `038-alignment-spoken-reference` if [PR #556](https://github.com/baizhiheizi/enjoy_player/pull/556) is not merged
+- [X] T002 Confirm production `alignSegments` / `spokenReferenceUnavailable` / `EspeakSynthHost` exist in `packages/forced_alignment/lib/src/alignment_service.dart` and `packages/forced_alignment/lib/src/synth/` (slice 2b). Do **not** add a second path package or import `AsrAudioExtractor` from Craft
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Setting key (default off), pure mapper, PCM helper, and a Craft enricher that no-ops when the setting is off so stories can fill success/fallback/UI without a second save API
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T003 [P] Add `SettingsKeys.transcriptTimelineEnrichment = 'transcript.timelineEnrichment'` to the `_staticKeys` allowlist in `lib/data/db/settings_keys.dart` per [contracts/settings-toggle.md](./contracts/settings-toggle.md) (missing value ≡ off)
+- [X] T004 [P] Implement `attachAlignmentToLines` in `lib/data/subtitle/attach_alignment_to_lines.dart` per [contracts/nested-mapping.md](./contracts/nested-mapping.md) and [data-model.md](./data-model.md) (segment `id` = line index; word ms relative to line; phones in media seconds; never change line text/start/duration)
+- [X] T005 [P] Add `lib/data/audio/pcm16k_mono.dart` to turn Craft WAV/`Uint8List` into 16 kHz mono `Float32List` (decode PCM WAV in-process when possible; otherwise temp file + FFmpeg `pcm_s16le -ar 16000 -ac 1`). Do **not** import `lib/features/asr/`
+- [X] T006 Add keep-alive `@Riverpod` notifier `TimelineEnrichmentSettings` in `lib/features/settings/application/timeline_enrichment_settings.dart` (read/write `SettingsDao` like `lib/core/diagnostics/diagnostics_verbose_provider.dart`); run `dart run build_runner build` and commit `timeline_enrichment_settings.g.dart`
+- [X] T007 Add `lib/features/craft/application/craft_timeline_enricher.dart` that returns the spec 030 JSON unchanged when the setting is off, JSON is null, or the save is a dedupe skip per [contracts/craft-save-enrichment.md](./contracts/craft-save-enrichment.md) and [contracts/fallback.md](./contracts/fallback.md); log with `logNamed` (never `print()`)
+- [X] T008 Retarget `test/features/alignment/forced_alignment_inert_import_test.dart` per [contracts/inert-consumers.md](./contracts/inert-consumers.md): **allow** `lib/features/craft`, `lib/data/subtitle`, `lib/data/audio` to import `package:forced_alignment/`; **forbid** transcript, player, ASR, lookup, Settings, l10n; **assert** `transcript.timelineEnrichment` exists in `lib/data/db/settings_keys.dart`
+
+**Checkpoint**: App analyzes; setting defaults off; mapper/PCM/enricher compile; inert pins match the first-caller rules
+
+---
+
+## Phase 3: User Story 1 - Default off: Craft and library behave as today (Priority: P1) 🎯 MVP
+
+**Goal**: With the setting at default (off), Craft save, blank-transcript path, library playback, and panel interactions match the pre-feature build. Learners never hear a spoken-reference voice.
+
+**Independent Test**: Leave the switch off. Curated set from slices 1–2b (import, YouTube captions, speech-to-text, Craft synthesis, blank Craft). Line text/order/times unchanged. New Craft saves stay line-only or blank per spec 030 ([spec.md](./spec.md) US1, [quickstart.md](./quickstart.md) §A).
+
+### Tests for User Story 1
+
+> Write these tests FIRST, ensure they FAIL before the controller hook if save already writes nested spans
+
+- [X] T009 [US1] Extend `test/features/craft/application/craft_controller_test.dart` (and/or `test/features/craft/application/craft_timeline_enricher_test.dart`): setting missing/off + solid word boundaries → `primaryTimelineJson` is line-only (no `timeline` arrays); blank 030 path still persists `null`
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Call the enricher from `lib/features/craft/application/craft_controller.dart` `saveToLibrary` **after** `buildCraftPrimaryTimelineJson` and **before** `importCraftedFromText` / `updateCraftedFromText`; skip on `wasDedupe`
+- [X] T011 [P] [US1] Confirm no karaoke / IPA / per-word chips and no new `media_kit` `Player()` in `lib/features/transcript/` and `lib/features/player/`; Craft playback still uses `previewAudioBytes` / saved WAV, not reference PCM
+- [X] T012 [US1] Run existing regression: `flutter test test/features/craft test/data/subtitle/transcript_line_test.dart test/features/transcript/transcript_repository_test.dart test/features/transcript/transcript_lines_provider_dedupe_test.dart test/features/transcript/auto_translate_controller_test.dart test/features/alignment`
+
+**Checkpoint**: US1 MVP — default Craft/library behavior unchanged; enrichment API exists but is inert when off
+
+---
+
+## Phase 4: User Story 2 - Opt-in Craft save stores nested word and phone timings (Priority: P1)
+
+**Goal**: With the setting on and extractable Craft audio, save attaches ordered word spans (and default-quality phones) onto the **same** spec 030 lines via `alignSegments`. Panel still shows line-level chrome.
+
+**Independent Test**: Setting on. Short multi-line Craft item with solid synthesis timings. Reopen: line text/start/duration match spec 030; stored cues include word spans in order and at least one phone list; times on the parent line ±50 ms pad ([spec.md](./spec.md) US2, [quickstart.md](./quickstart.md) §B).
+
+### Tests for User Story 2
+
+- [X] T013 [P] [US2] Add `test/data/subtitle/attach_alignment_to_lines_test.dart`: two-line fixture keeps line fields; word ms relative to line; phones in seconds; `wordIndex` in range for **that** line; missing segment → that line stays line-only
+- [X] T014 [P] [US2] Add `test/data/audio/pcm16k_mono_test.dart` for a tiny PCM WAV fixture → non-empty 16 kHz `Float32List` (skip or stub FFmpeg fallback if the runner has no binary)
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] When the setting is on and JSON/PCM exist, `lib/features/craft/application/craft_timeline_enricher.dart` must call `alignSegments` with `AlignmentSegment(id: lineIndex, …)` and `AlignmentGranularity.medium`, then `attachAlignmentToLines` — do **not** call whole-clip `align()` or rewrite line text
+- [X] T016 [US2] Extend `test/features/craft/application/craft_controller_test.dart` / `craft_timeline_enricher_test.dart`: setting on + injected spoken double (or FFI) → persisted JSON has `timeline` + `phones` on successful lines; line `text`/`start`/`duration` unchanged; audio bytes unchanged
+- [X] T017 [US2] Confirm transcript panel tests still pass with a nested-cue fixture (line-level render only) via `flutter test test/features/transcript`
+
+**Checkpoint**: Opt-in save can persist slice 1 nested JSON; UI still ignores it for chrome
+
+---
+
+## Phase 5: User Story 3 - Alignment failure keeps today’s Craft transcript (Priority: P1)
+
+**Goal**: Setting on + spoken-reference unavailable, unsupported language, extract failure, cancel, or timeout → save still succeeds with spec 030 line-only (or blank) JSON. No fake nested timeline. No blocking `CraftSaveFailure`.
+
+**Independent Test**: Drive each fallback class. Save completes. Transcript matches pre-feature Craft for that path. 0 nested spans from a stand-in ([spec.md](./spec.md) US3, [contracts/fallback.md](./contracts/fallback.md), [quickstart.md](./quickstart.md) §C).
+
+### Tests for User Story 3
+
+- [X] T018 [US3] Extend `test/features/craft/application/craft_timeline_enricher_test.dart`: setting on + `spokenReferenceUnavailable` / `unsupportedLanguage` / extract throw / timeout → original line-only JSON; save not `CraftSaveFailure`; 0 duration-model nested spans; blank 030 JSON stays `null` (do not invent lines)
+
+### Implementation for User Story 3
+
+- [X] T019 [US3] Map extract and `AlignmentFailed` outcomes to quiet fallback in `lib/features/craft/application/craft_timeline_enricher.dart` (`logNamed` warning, no learner-required error chrome) per [contracts/fallback.md](./contracts/fallback.md)
+- [X] T020 [US3] Partial cue success: attach nested spans only on lines whose tagged segment succeeded; failed lines stay line-only; line fields unchanged — cover in `test/data/subtitle/attach_alignment_to_lines_test.dart` and the enricher test
+
+**Checkpoint**: Slice 3 can trust fallback; Craft save is no more fragile than today
+
+---
+
+## Phase 6: User Story 4 - Setting is discoverable, persists, and does not rewrite the library (Priority: P1)
+
+**Goal**: Settings → Transcript shows the switch, default off, persists without restart. Turning it on does not backfill old items. Import / YouTube / ASR stay line-only writers.
+
+**Independent Test**: Fresh profile: switch off. Toggle survives relaunch. Pre-existing library cues unchanged until Craft re-save. Import/YouTube/ASR tracks remain line-only ([spec.md](./spec.md) US4, [quickstart.md](./quickstart.md) §D).
+
+### Tests for User Story 4
+
+- [X] T021 [P] [US4] Add `test/features/settings/application/timeline_enrichment_settings_test.dart`: missing key → false; `setEnabled(true)` round-trips via `SettingsDao`
+- [X] T022 [P] [US4] Extend `test/features/settings/domain/settings_search_entry_test.dart` and hub tests (`test/features/settings/presentation/settings_screen_test.dart`, `test/features/settings/application/settings_section_collapse_provider_test.dart`) so the Transcript section / `timelineEnrichment` row is registered
+
+### Implementation for User Story 4
+
+- [X] T023 [P] [US4] Add ARB strings in `lib/l10n/app_en.arb`, `lib/l10n/app_zh.arb`, and `lib/l10n/app_zh_CN.arb` (section title/hint, switch title/subtitle, search keywords); run `flutter gen-l10n`
+- [X] T024 [US4] Add `SettingsSectionIds.transcript` and registry descriptors in `lib/features/settings/domain/settings_search_entry.dart`; wire `lib/features/settings/application/settings_registry_localizer.dart`, `lib/features/settings/presentation/widgets/settings_section_visuals.dart`, `lib/features/settings/presentation/widgets/settings_layout_single_column.dart`, and `lib/features/settings/presentation/widgets/settings_layout_two_pane.dart`
+- [X] T025 [US4] Add `lib/features/settings/presentation/widgets/sections/transcript_section.dart`: `SettingsRow` + `Switch.adaptive` bound to `timelineEnrichmentSettingsProvider` (diagnostics pattern); Settings Dart must **not** import `package:forced_alignment/`
+- [X] T026 [US4] Pin inert writers: import / YouTube / ASR paths still omit nested `timeline` (existing tests under `test/features/` plus a note in `test/features/alignment/`); confirm dedupe in `test/features/craft/application/craft_controller_test.dart` does not rewrite the existing item when the setting is on
+
+**Checkpoint**: Opt-in is visible and sticky; the rest of the library is untouched
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Traceability, docs, and CI gates
+
+- [X] T027 [P] Write ADR-0073 in `docs/decisions/0073-craft-timeline-enrichment.md` (first product caller, default-off setting, spec 030 lines + `alignSegments`, fail-closed save, mapping rules, no karaoke / no reference playback). Do **not** rewrite ADR-0070–0072
+- [X] T028 [P] Index ADR-0073 in `docs/decisions/README.md`
+- [X] T029 [P] Update `docs/features/craft.md`: opt-in nested spans on save; fallback; blank 030 unchanged; audio still Azure/Craft WAV
+- [X] T030 [P] Update `docs/features/transcript.md`: unused-engine note → Craft may persist nested JSON when the setting is on; panel still line-level; no karaoke in this slice
+- [X] T031 Run `dart run build_runner build` and `flutter gen-l10n` if needed; commit `*.g.dart` / generated l10n
+- [X] T032 Run [quickstart.md](./quickstart.md) automated checks: `flutter test test/features/craft test/features/alignment test/features/settings test/data/subtitle`, `flutter test packages/forced_alignment/test`, `flutter analyze`, `bash .github/scripts/validate_ci_gates.sh --fix` (do not mix unrelated format files). Document SC-008 if a platform is slower than 10 s for ≤60 s Craft enrichment
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately (needs slice 2b on the branch)
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **User Stories (Phase 3–6)**: All depend on Foundational
+  - US1 can ship as a no-behavior-change MVP once the hook is inert when off
+  - US2–US3 share `craft_timeline_enricher.dart` (implement success then fallback, or both in one pass)
+  - US4 Settings chrome can start after T003/T006 (key + notifier) even in parallel with US2 if the switch only reads the bool
+- **Polish (Phase 7)**: Depends on US1–US4
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: After Phase 2 — default-off hook
+- **User Story 2 (P1)**: After Phase 2 — needs mapper + PCM + enricher; independently testable with a spoken test double
+- **User Story 3 (P1)**: After US2’s `alignSegments` call exists (or the same enricher PR)
+- **User Story 4 (P1)**: After T003/T006 — UI + registry; does not require a successful alignment to prove default off / persist / no backfill
+
+### Within Each User Story
+
+- Tests first where marked; confirm they fail before the hook writes nested JSON
+- Mapper/PCM before enricher success path
+- Enricher before Craft controller wiring (US1 can wire a no-op enricher first)
+- Story complete before calling the slice done
+
+### Parallel Opportunities
+
+- T003, T004, T005 in parallel (different files)
+- T013 and T014 in parallel
+- T021/T022/T023 in parallel with US2 implementation if the switch only binds the notifier
+- T027–T030 docs in parallel during polish
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After Phase 2:
+Task: "craft_controller_test.dart setting-off line-only / blank"
+Task: "confirm no karaoke / no new Player() in transcript + player"
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# After Phase 2 mapper + PCM exist:
+Task: "attach_alignment_to_lines_test.dart"
+Task: "pcm16k_mono_test.dart"
+# Then enricher + controller success path (same files as US3 — do not split across two people)
+```
+
+---
+
+## Parallel Example: User Story 4
+
+```bash
+# After T006 notifier exists:
+Task: "timeline_enrichment_settings_test.dart"
+Task: "ARB strings in app_en.arb / app_zh.arb / app_zh_CN.arb"
+Task: "settings_search_entry_test.dart + hub registry tests"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL — blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Craft save still line-only/blank; existing Craft/transcript tests green
+5. This MVP is safe as a no-behavior-change **but does not ship nested Craft JSON** — continue US2–US4 before calling slice 3 done
+
+### Incremental Delivery
+
+1. Setup + Foundational → key, mapper, PCM, skip-when-off enricher, retargeted pins
+2. US1 → default Craft/library unchanged → merge-safe
+3. US2 → opt-in nested spans on save
+4. US3 → fail-closed fallback
+5. US4 → Settings Transcript switch + no library rewrite
+6. Polish → ADR-0073 + craft/transcript docs + CI gates
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Developer A: US1 hook + US2/US3 enricher (owns `craft_timeline_enricher.dart` / `craft_controller.dart`)
+3. Developer B: US4 Settings section + ARB + registry tests (owns settings presentation; must not import `forced_alignment`)
+4. Developer C: mapper/PCM unit tests + docs (T004/T005/T013/T014/T027–T030)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to spec user stories US1–US4
+- Do not add karaoke, IPA overlay, per-word tap, YouTube demux, library backfill, or first-play alignment
+- Do not invent a transcript when spec 030 returns blank
+- Do not import `AsrAudioExtractor` from Craft; do not import `TranscriptLine` into `packages/forced_alignment`
+- Do not play the spoken reference or replace Craft playback audio
+- Do not rewrite ADR-0070–0072
+- Verify setting-off and fallback tests fail before wiring nested writes
+- Commit after each task or logical group (setup, foundation, US1, US2, US3, US4, polish)
+- Avoid: `print()`, new `media_kit` `Player()`, Flutter web, extra AI credits, blocking save errors on alignment failure

--- a/test/data/audio/pcm16k_mono_test.dart
+++ b/test/data/audio/pcm16k_mono_test.dart
@@ -1,0 +1,81 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forced_alignment/forced_alignment.dart';
+
+import 'package:enjoy_player/data/audio/pcm16k_mono.dart';
+
+Uint8List _pcm16Wav({
+  required int sampleRate,
+  required int channels,
+  required Int16List samples,
+}) {
+  final dataBytes = samples.length * 2;
+  final bytes = Uint8List(44 + dataBytes);
+  final bd = ByteData.sublistView(bytes);
+  void ascii(int o, String s) {
+    for (var i = 0; i < s.length; i++) {
+      bytes[o + i] = s.codeUnitAt(i);
+    }
+  }
+
+  ascii(0, 'RIFF');
+  bd.setUint32(4, 36 + dataBytes, Endian.little);
+  ascii(8, 'WAVE');
+  ascii(12, 'fmt ');
+  bd.setUint32(16, 16, Endian.little);
+  bd.setUint16(20, 1, Endian.little);
+  bd.setUint16(22, channels, Endian.little);
+  bd.setUint32(24, sampleRate, Endian.little);
+  bd.setUint32(28, sampleRate * channels * 2, Endian.little);
+  bd.setUint16(32, channels * 2, Endian.little);
+  bd.setUint16(34, 16, Endian.little);
+  ascii(36, 'data');
+  bd.setUint32(40, dataBytes, Endian.little);
+  var o = 44;
+  for (final s in samples) {
+    bd.setInt16(o, s, Endian.little);
+    o += 2;
+  }
+  return bytes;
+}
+
+void main() {
+  test('16 kHz mono PCM WAV decodes to non-empty Float32List', () {
+    final samples = Int16List(kAlignmentSampleRate);
+    for (var i = 0; i < samples.length; i++) {
+      samples[i] = (i % 64) * 200;
+    }
+    final wav = _pcm16Wav(sampleRate: 16000, channels: 1, samples: samples);
+    final pcm = decodePcmWavTo16kMono(wav);
+    expect(pcm, isNotNull);
+    expect(pcm!.length, kAlignmentSampleRate);
+    expect(pcm.any((s) => s != 0), isTrue);
+  });
+
+  test('8 kHz stereo PCM WAV resamples to 16 kHz mono', () {
+    final frames = 800;
+    final samples = Int16List(frames * 2);
+    for (var i = 0; i < frames; i++) {
+      samples[i * 2] = 1000;
+      samples[i * 2 + 1] = 3000;
+    }
+    final wav = _pcm16Wav(sampleRate: 8000, channels: 2, samples: samples);
+    final pcm = decodePcmWavTo16kMono(wav);
+    expect(pcm, isNotNull);
+    expect(pcm!.length, closeTo(1600, 2));
+    expect(pcm.first, closeTo((1000 + 3000) / 2 / 32768.0, 0.001));
+  });
+
+  test('non-WAV bytes return null in-process', () {
+    expect(decodePcmWavTo16kMono(Uint8List.fromList([1, 2, 3, 4])), isNull);
+  });
+
+  test('decodeToPcm16kMono succeeds for a PCM WAV fixture', () async {
+    final samples = Int16List(800);
+    final wav = _pcm16Wav(sampleRate: 8000, channels: 1, samples: samples);
+    final pcm = await decodeToPcm16kMono(wav);
+    expect(pcm, isNotEmpty);
+    expect(pcm.length, closeTo(1600, 2));
+  });
+}

--- a/test/data/db/settings_keys_test.dart
+++ b/test/data/db/settings_keys_test.dart
@@ -41,6 +41,13 @@ void main() {
       expect(SettingsKeys.updateSnoozeVersion, 'update.snooze_version');
     });
 
+    test('transcript timeline enrichment key', () {
+      expect(
+        SettingsKeys.transcriptTimelineEnrichment,
+        'transcript.timelineEnrichment',
+      );
+    });
+
     test('diagnostics / hotkeys / ai / youtube keys', () {
       expect(
         SettingsKeys.diagnosticsVerboseEnabled,
@@ -105,6 +112,7 @@ void main() {
         SettingsKeys.updateSnoozeUntil,
         SettingsKeys.updateSnoozeVersion,
         SettingsKeys.diagnosticsVerboseEnabled,
+        SettingsKeys.transcriptTimelineEnrichment,
         SettingsKeys.playerPreferencesV1,
         SettingsKeys.hotkeysCustomBindings,
         SettingsKeys.aiModalityConfigsV1,

--- a/test/data/subtitle/attach_alignment_to_lines_test.dart
+++ b/test/data/subtitle/attach_alignment_to_lines_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forced_alignment/forced_alignment.dart';
+
+import 'package:enjoy_player/data/subtitle/attach_alignment_to_lines.dart';
+import 'package:enjoy_player/data/subtitle/transcript_line.dart';
+
+TimelineEntry _word({
+  required String text,
+  required double start,
+  required double end,
+  List<TimelineEntry>? phones,
+}) {
+  return TimelineEntry(
+    type: TimelineEntryType.word,
+    text: text,
+    startTime: start,
+    endTime: end,
+    timeline: phones,
+  );
+}
+
+TimelineEntry _phone({
+  required String phone,
+  required double start,
+  required double end,
+}) {
+  return TimelineEntry(
+    type: TimelineEntryType.phone,
+    text: phone,
+    startTime: start,
+    endTime: end,
+  );
+}
+
+void main() {
+  const line0 = TranscriptLine(
+    text: 'Hello world',
+    startMs: 0,
+    durationMs: 1000,
+  );
+  const line1 = TranscriptLine(text: 'Goodbye', startMs: 1200, durationMs: 800);
+
+  AlignmentResult resultWith(List<TimelineEntry> timeline) {
+    return AlignmentResult(
+      timeline: timeline,
+      wordTimeline: const [],
+      transcript: 'Hello world Goodbye',
+      language: 'en-US',
+      durationSeconds: 2.0,
+    );
+  }
+
+  test('keeps line fields and maps word ms relative to each line', () {
+    final result = resultWith([
+      TimelineEntry(
+        type: TimelineEntryType.segment,
+        text: 'Hello world',
+        startTime: 0,
+        endTime: 1.0,
+        id: 0,
+        timeline: [
+          _word(
+            text: 'Hello',
+            start: 0.05,
+            end: 0.40,
+            phones: [
+              _phone(phone: 'h', start: 0.05, end: 0.12),
+              _phone(phone: 'ə', start: 0.12, end: 0.40),
+            ],
+          ),
+          _word(text: 'world', start: 0.45, end: 0.90),
+        ],
+      ),
+      TimelineEntry(
+        type: TimelineEntryType.segment,
+        text: 'Goodbye',
+        startTime: 1.2,
+        endTime: 2.0,
+        id: 1,
+        timeline: [
+          _word(
+            text: 'Goodbye',
+            start: 1.25,
+            end: 1.90,
+            phones: [_phone(phone: 'g', start: 1.25, end: 1.40)],
+          ),
+        ],
+      ),
+    ]);
+
+    final out = attachAlignmentToLines([line0, line1], result);
+    expect(out, hasLength(2));
+    expect(out[0].text, line0.text);
+    expect(out[0].startMs, line0.startMs);
+    expect(out[0].durationMs, line0.durationMs);
+    expect(out[1].text, line1.text);
+    expect(out[1].startMs, line1.startMs);
+    expect(out[1].durationMs, line1.durationMs);
+
+    final hello = out[0].timeline!;
+    expect(hello.map((w) => w.text), ['Hello', 'world']);
+    expect(hello[0].startMs, 50);
+    expect(hello[0].durationMs, 350);
+    expect(hello[1].startMs, 450);
+
+    final helloPhones = hello[0].phones!;
+    expect(helloPhones, hasLength(2));
+    expect(helloPhones[0].phone, 'h');
+    expect(helloPhones[0].startTime, 0.05);
+    expect(helloPhones[0].endTime, 0.12);
+    expect(helloPhones[0].wordIndex, 0);
+    expect(helloPhones[1].wordIndex, 0);
+
+    final byePhones = out[1].timeline!.single.phones!;
+    expect(byePhones.single.wordIndex, 0);
+    expect(byePhones.single.startTime, 1.25);
+  });
+
+  test('missing segment leaves that line line-only; siblings may nest', () {
+    final result = resultWith([
+      TimelineEntry(
+        type: TimelineEntryType.segment,
+        text: 'Hello world',
+        startTime: 0,
+        endTime: 1.0,
+        id: 0,
+        timeline: [_word(text: 'Hello', start: 0.0, end: 0.5)],
+      ),
+    ]);
+
+    final out = attachAlignmentToLines([line0, line1], result);
+    expect(out[0].timeline, isNotNull);
+    expect(out[1].timeline, isNull);
+    expect(out[1].text, line1.text);
+    expect(out[1].startMs, line1.startMs);
+  });
+
+  test('wordIndex is rebased per line, not flatten-global', () {
+    final result = resultWith([
+      TimelineEntry(
+        type: TimelineEntryType.segment,
+        text: 'Hello world',
+        startTime: 0,
+        endTime: 1.0,
+        id: 0,
+        timeline: [
+          _word(
+            text: 'Hello',
+            start: 0.0,
+            end: 0.4,
+            phones: [_phone(phone: 'h', start: 0.0, end: 0.1)],
+          ),
+          _word(
+            text: 'world',
+            start: 0.4,
+            end: 0.9,
+            phones: [_phone(phone: 'w', start: 0.4, end: 0.5)],
+          ),
+        ],
+      ),
+      TimelineEntry(
+        type: TimelineEntryType.segment,
+        text: 'Goodbye',
+        startTime: 1.2,
+        endTime: 2.0,
+        id: 1,
+        timeline: [
+          _word(
+            text: 'Goodbye',
+            start: 1.3,
+            end: 1.8,
+            phones: [_phone(phone: 'g', start: 1.3, end: 1.4)],
+          ),
+        ],
+      ),
+    ]);
+
+    final out = attachAlignmentToLines([line0, line1], result);
+    expect(out[0].timeline![0].phones!.single.wordIndex, 0);
+    expect(out[0].timeline![1].phones!.single.wordIndex, 1);
+    expect(out[1].timeline!.single.phones!.single.wordIndex, 0);
+  });
+
+  test('round-trip JSON preserves nested fields', () {
+    final result = resultWith([
+      TimelineEntry(
+        type: TimelineEntryType.segment,
+        text: 'Hello world',
+        startTime: 0,
+        endTime: 1.0,
+        id: 0,
+        timeline: [
+          _word(
+            text: 'Hello',
+            start: 0.1,
+            end: 0.4,
+            phones: [_phone(phone: 'h', start: 0.1, end: 0.2)],
+          ),
+        ],
+      ),
+    ]);
+    final attached = attachAlignmentToLines([line0], result).single;
+    final roundTripped = TranscriptLine.fromJson(attached.toJson());
+    expect(roundTripped, attached);
+  });
+}

--- a/test/features/alignment/forced_alignment_inert_import_test.dart
+++ b/test/features/alignment/forced_alignment_inert_import_test.dart
@@ -1,13 +1,13 @@
 import 'dart:io';
 
+import 'package:enjoy_player/data/db/settings_keys.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test(
-    'Craft, transcript, player, ASR, lookup, and Settings do not import forced_alignment',
+    'transcript, player, ASR, lookup, Settings, and l10n do not import forced_alignment',
     () {
       const roots = [
-        'lib/features/craft',
         'lib/features/transcript',
         'lib/features/player',
         'lib/features/asr',
@@ -31,9 +31,40 @@ void main() {
     },
   );
 
-  test('no transcript.timelineEnrichment settings key', () {
+  test(
+    'Craft, subtitle mapper, and PCM helper may import forced_alignment',
+    () {
+      const allowed = [
+        'lib/features/craft',
+        'lib/data/subtitle',
+        'lib/data/audio',
+      ];
+      var anyImport = false;
+      for (final root in allowed) {
+        final dir = Directory(root);
+        if (!dir.existsSync()) continue;
+        for (final entity in dir.listSync(recursive: true)) {
+          if (entity is! File || !entity.path.endsWith('.dart')) continue;
+          final text = entity.readAsStringSync();
+          if (text.contains('package:forced_alignment/')) {
+            anyImport = true;
+          }
+        }
+      }
+      expect(anyImport, isTrue);
+    },
+  );
+
+  test('transcript.timelineEnrichment settings key is allowlisted', () {
+    expect(
+      SettingsKeys.transcriptTimelineEnrichment,
+      'transcript.timelineEnrichment',
+    );
+    expect(
+      SettingsKeys.isKnown(SettingsKeys.transcriptTimelineEnrichment),
+      isTrue,
+    );
     final settings = File('lib/data/db/settings_keys.dart').readAsStringSync();
-    expect(settings.contains('timelineEnrichment'), isFalse);
-    expect(settings.contains('transcript.timeline'), isFalse);
+    expect(settings.contains('transcript.timelineEnrichment'), isTrue);
   });
 }

--- a/test/features/craft/application/craft_controller_test.dart
+++ b/test/features/craft/application/craft_controller_test.dart
@@ -14,6 +14,7 @@ import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
+import 'package:enjoy_player/features/craft/application/craft_timeline_enricher.dart';
 import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
 import 'package:enjoy_player/features/craft/domain/craft_synthesizer.dart';
@@ -25,6 +26,7 @@ import 'package:enjoy_player/features/craft/domain/craft_stage.dart';
 import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
 import 'package:enjoy_player/features/library/data/library_repository.dart';
 import 'package:enjoy_player/features/library/domain/craft_edit_source.dart';
+import 'package:forced_alignment/forced_alignment.dart';
 
 // === Fakes ===
 
@@ -289,6 +291,9 @@ void main() {
         craftSynthesizerProvider.overrideWithValue(synthesizer),
         craftTranscriberProvider.overrideWithValue(transcriber),
         mediaLibraryRepositoryProvider.overrideWithValue(repo),
+        craftTimelineEnricherProvider.overrideWithValue(
+          CraftTimelineEnricher(enabled: false),
+        ),
         if (profile == null)
           authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new)
         else
@@ -777,6 +782,9 @@ void main() {
           craftTranslatorProvider.overrideWithValue(translator),
           craftSynthesizerProvider.overrideWithValue(synthesizer),
           mediaLibraryRepositoryProvider.overrideWithValue(repo),
+          craftTimelineEnricherProvider.overrideWithValue(
+            CraftTimelineEnricher(enabled: false),
+          ),
           authCtrlProvider.overrideWith(() => auth),
         ],
       );
@@ -850,6 +858,7 @@ void main() {
       final timeline = jsonDecode(repo.lastImportTimelineJson!) as List;
       expect(timeline, isNotEmpty);
       expect(timeline.first['text'], 'Hello world.');
+      expect(timeline.first.containsKey('timeline'), isFalse);
     });
 
     test(
@@ -867,6 +876,141 @@ void main() {
         expect(result?.mediaId, 'media-new');
         expect(result?.wroteSolidTranscript, isFalse);
         expect(repo.importCalls, 1);
+        expect(repo.lastImportTimelineJson, isNull);
+      },
+    );
+
+    test(
+      'opt-in enrichment persists nested spans and leaves audio unchanged',
+      () async {
+        synthesizer = _FakeSynthesizer(
+          wordBoundaries: const [
+            CraftWordBoundary(text: 'Hello', audioOffsetMs: 0, durationMs: 300),
+            CraftWordBoundary(
+              text: 'world.',
+              audioOffsetMs: 300,
+              durationMs: 400,
+            ),
+          ],
+        );
+        repo.importResultId = 'media-123';
+        final originalAudio = synthesizer.audioBytes;
+        final enricher = CraftTimelineEnricher(
+          enabled: true,
+          decodePcm: (_) async => Float32List(16000),
+          alignSegmentsFn:
+              ({
+                required sourcePcm16k,
+                required language,
+                required segments,
+                required granularity,
+              }) async {
+                expect(language, 'en-US');
+                return AlignmentSuccess(
+                  AlignmentResult(
+                    timeline: [
+                      for (final s in segments)
+                        TimelineEntry(
+                          type: TimelineEntryType.segment,
+                          text: s.text,
+                          startTime: s.startTime,
+                          endTime: s.endTime,
+                          id: s.id,
+                          timeline: [
+                            TimelineEntry(
+                              type: TimelineEntryType.word,
+                              text: 'Hello',
+                              startTime: s.startTime,
+                              endTime: s.endTime,
+                              timeline: [
+                                TimelineEntry(
+                                  type: TimelineEntryType.phone,
+                                  text: 'h',
+                                  startTime: s.startTime,
+                                  endTime: s.endTime,
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                    ],
+                    wordTimeline: const [],
+                    transcript: 'Hello',
+                    language: language,
+                    durationSeconds: 1,
+                  ),
+                );
+              },
+        );
+        final c = ProviderContainer(
+          overrides: [
+            craftTranslatorProvider.overrideWithValue(translator),
+            craftSynthesizerProvider.overrideWithValue(synthesizer),
+            craftTranscriberProvider.overrideWithValue(transcriber),
+            mediaLibraryRepositoryProvider.overrideWithValue(repo),
+            craftTimelineEnricherProvider.overrideWithValue(enricher),
+            authCtrlProvider.overrideWith(() => _SignedInAuthCtrl(_profile)),
+          ],
+        );
+        addTearDown(c.dispose);
+        await c.read(authCtrlProvider.future);
+        final n = notifierOf(c);
+        n.setScreenMode(CraftScreenMode.advanced);
+        n.setSelectedVoice('en-US-JennyNeural');
+        n.setSynthText('Hello world.');
+        await n.synthesize();
+
+        final result = await n.saveToLibrary();
+        expect(result?.wroteSolidTranscript, isTrue);
+        expect(repo.importCalls, 1);
+        expect(repo.lastImportAudioBytes, originalAudio);
+        final timeline = jsonDecode(repo.lastImportTimelineJson!) as List;
+        expect(timeline.first['text'], 'Hello world.');
+        expect(timeline.first['timeline'], isNotEmpty);
+        expect(
+          (timeline.first['timeline'] as List).first['phones'],
+          isNotEmpty,
+        );
+      },
+    );
+
+    test(
+      'dedupe skip does not rewrite the existing item when enrichment is on',
+      () async {
+        repo.existingId = 'media-existing';
+        final enricher = CraftTimelineEnricher(
+          enabled: true,
+          decodePcm: (_) async => Float32List(16000),
+          alignSegmentsFn:
+              ({
+                required sourcePcm16k,
+                required language,
+                required segments,
+                required granularity,
+              }) async {
+                fail('dedupe must not call alignSegments');
+              },
+        );
+        final c = ProviderContainer(
+          overrides: [
+            craftTranslatorProvider.overrideWithValue(translator),
+            craftSynthesizerProvider.overrideWithValue(synthesizer),
+            craftTranscriberProvider.overrideWithValue(transcriber),
+            mediaLibraryRepositoryProvider.overrideWithValue(repo),
+            craftTimelineEnricherProvider.overrideWithValue(enricher),
+            authCtrlProvider.overrideWith(() => _SignedInAuthCtrl(_profile)),
+          ],
+        );
+        addTearDown(c.dispose);
+        await c.read(authCtrlProvider.future);
+        final n = notifierOf(c);
+        n.setSynthText('long enough text');
+        await n.synthesize();
+
+        final result = await n.saveToLibrary();
+        expect(result?.wasDedupe, isTrue);
+        expect(repo.importCalls, 0);
+        expect(repo.updateCalls, 0);
         expect(repo.lastImportTimelineJson, isNull);
       },
     );

--- a/test/features/craft/application/craft_timeline_enricher_test.dart
+++ b/test/features/craft/application/craft_timeline_enricher_test.dart
@@ -1,0 +1,374 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forced_alignment/forced_alignment.dart';
+
+import 'package:enjoy_player/data/audio/pcm16k_mono.dart';
+import 'package:enjoy_player/features/craft/application/craft_timeline_enricher.dart';
+
+const _lineOnlyJson = '[{"text":"Hello world.","start":0,"duration":700}]';
+
+AlignmentSuccess _successFor(List<AlignmentSegment> segments) {
+  return AlignmentSuccess(
+    AlignmentResult(
+      timeline: [
+        for (final s in segments)
+          TimelineEntry(
+            type: TimelineEntryType.segment,
+            text: s.text,
+            startTime: s.startTime,
+            endTime: s.endTime,
+            id: s.id,
+            timeline: [
+              TimelineEntry(
+                type: TimelineEntryType.word,
+                text: s.text.split(' ').first,
+                startTime: s.startTime,
+                endTime: s.endTime,
+                timeline: [
+                  TimelineEntry(
+                    type: TimelineEntryType.phone,
+                    text: 'ə',
+                    startTime: s.startTime,
+                    endTime: s.endTime,
+                  ),
+                ],
+              ),
+            ],
+          ),
+      ],
+      wordTimeline: const [],
+      transcript: segments.map((s) => s.text).join(' '),
+      language: 'en-US',
+      durationSeconds: 2,
+    ),
+  );
+}
+
+Future<Float32List> _dummyPcm(Uint8List _) async =>
+    Float32List(kAlignmentSampleRate);
+
+void main() {
+  test(
+    'alignmentLanguageForCraft expands primary tags without swapping families',
+    () {
+      expect(alignmentLanguageForCraft('en'), 'en-US');
+      expect(alignmentLanguageForCraft('en-US'), 'en-US');
+      expect(alignmentLanguageForCraft('en-GB'), 'en-GB');
+      expect(alignmentLanguageForCraft('ja'), 'ja-JP');
+      expect(alignmentLanguageForCraft('xx'), isNull);
+      expect(alignmentLanguageForCraft(''), isNull);
+    },
+  );
+
+  final audio = Uint8List.fromList(const [1, 2, 3, 4]);
+
+  test('setting off returns spec 030 JSON unchanged', () async {
+    var aligned = false;
+    final enricher = CraftTimelineEnricher(
+      enabled: false,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async {
+            aligned = true;
+            return _successFor(segments);
+          },
+    );
+    final out = await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'en-US',
+    );
+    expect(out, _lineOnlyJson);
+    expect(aligned, isFalse);
+  });
+
+  test('blank 030 JSON stays null and does not invent lines', () async {
+    var aligned = false;
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async {
+            aligned = true;
+            return _successFor(segments);
+          },
+    );
+    final out = await enricher.enrich(
+      timelineJson: null,
+      audioBytes: audio,
+      language: 'en-US',
+    );
+    expect(out, isNull);
+    expect(aligned, isFalse);
+  });
+
+  test('setting on attaches nested timeline and phones', () async {
+    AlignmentGranularity? seenGranularity;
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async {
+            seenGranularity = granularity;
+            expect(segments, hasLength(1));
+            expect(segments.single.id, 0);
+            return _successFor(segments);
+          },
+    );
+    final out = await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'en-US',
+    );
+    expect(seenGranularity, AlignmentGranularity.medium);
+    final decoded = jsonDecode(out!) as List;
+    expect(decoded.single['text'], 'Hello world.');
+    expect(decoded.single['start'], 0);
+    expect(decoded.single['duration'], 700);
+    final words = decoded.single['timeline'] as List;
+    expect(words, isNotEmpty);
+    expect(words.first['phones'], isNotEmpty);
+  });
+
+  test('spokenReferenceUnavailable falls back to original JSON', () async {
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async => const AlignmentFailed(
+            AlignmentFailure(
+              reason: AlignmentFailureReason.spokenReferenceUnavailable,
+            ),
+          ),
+    );
+    final out = await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'en-US',
+    );
+    expect(out, _lineOnlyJson);
+  });
+
+  test('unsupportedLanguage falls back to original JSON', () async {
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async => const AlignmentFailed(
+            AlignmentFailure(
+              reason: AlignmentFailureReason.unsupportedLanguage,
+            ),
+          ),
+    );
+    final out = await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'xx-YY',
+    );
+    expect(out, _lineOnlyJson);
+  });
+
+  test('PCM extract throw falls back to original JSON', () async {
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: (_) async =>
+          throw const Pcm16kDecodeException('extract failed'),
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async => _successFor(segments),
+    );
+    final out = await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'en-US',
+    );
+    expect(out, _lineOnlyJson);
+  });
+
+  test('timeout falls back to original JSON', () async {
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async => const AlignmentFailed(
+            AlignmentFailure(reason: AlignmentFailureReason.timedOut),
+          ),
+    );
+    final out = await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'en-US',
+    );
+    expect(out, _lineOnlyJson);
+  });
+
+  test('partial cue success nests only winning lines', () async {
+    const twoLines =
+        '[{"text":"Hello","start":0,"duration":1000},'
+        '{"text":"World","start":1200,"duration":800}]';
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async => _successFor([segments.first]),
+    );
+    final out = await enricher.enrich(
+      timelineJson: twoLines,
+      audioBytes: audio,
+      language: 'en-US',
+    );
+    final decoded = jsonDecode(out!) as List;
+    expect(decoded, hasLength(2));
+    expect(decoded[0]['text'], 'Hello');
+    expect(decoded[0]['timeline'], isNotEmpty);
+    expect(decoded[1]['text'], 'World');
+    expect(decoded[1]['start'], 1200);
+    expect(decoded[1]['duration'], 800);
+    expect(decoded[1].containsKey('timeline'), isFalse);
+  });
+
+  test('maps Craft primary tag en to en-US', () async {
+    String? seenLanguage;
+    final enricher = CraftTimelineEnricher(
+      enabled: true,
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async {
+            seenLanguage = language;
+            return _successFor(segments);
+          },
+    );
+    await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'en',
+    );
+    expect(seenLanguage, 'en-US');
+  });
+
+  test(
+    'keeps en-GB and does not call align for an unmapped language',
+    () async {
+      String? seenLanguage;
+      final gb = CraftTimelineEnricher(
+        enabled: true,
+        decodePcm: _dummyPcm,
+        alignSegmentsFn:
+            ({
+              required sourcePcm16k,
+              required language,
+              required segments,
+              required granularity,
+            }) async {
+              seenLanguage = language;
+              return _successFor(segments);
+            },
+      );
+      await gb.enrich(
+        timelineJson: _lineOnlyJson,
+        audioBytes: audio,
+        language: 'en-GB',
+      );
+      expect(seenLanguage, 'en-GB');
+
+      var aligned = false;
+      final unknown = CraftTimelineEnricher(
+        enabled: true,
+        decodePcm: _dummyPcm,
+        alignSegmentsFn:
+            ({
+              required sourcePcm16k,
+              required language,
+              required segments,
+              required granularity,
+            }) async {
+              aligned = true;
+              return _successFor(segments);
+            },
+      );
+      final out = await unknown.enrich(
+        timelineJson: _lineOnlyJson,
+        audioBytes: audio,
+        language: 'xx',
+      );
+      expect(out, _lineOnlyJson);
+      expect(aligned, isFalse);
+    },
+  );
+
+  test('awaits resolveEnabled instead of treating loading as off', () async {
+    var aligned = false;
+    final enricher = CraftTimelineEnricher(
+      enabled: false,
+      resolveEnabled: () async {
+        await Future<void>.delayed(Duration.zero);
+        return true;
+      },
+      decodePcm: _dummyPcm,
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+          }) async {
+            aligned = true;
+            return _successFor(segments);
+          },
+    );
+    final out = await enricher.enrich(
+      timelineJson: _lineOnlyJson,
+      audioBytes: audio,
+      language: 'en',
+    );
+    expect(aligned, isTrue);
+    final decoded = jsonDecode(out!) as List;
+    expect(decoded.single['timeline'], isNotEmpty);
+  });
+}

--- a/test/features/settings/application/settings_section_collapse_provider_test.dart
+++ b/test/features/settings/application/settings_section_collapse_provider_test.dart
@@ -16,6 +16,7 @@ void main() {
       expect(state[SettingsSectionIds.about], isTrue);
       expect(state[SettingsSectionIds.cloudSync], isFalse);
       expect(state[SettingsSectionIds.appearanceLanguage], isFalse);
+      expect(state[SettingsSectionIds.transcript], isFalse);
     });
 
     test('toggle flips only the targeted section', () {

--- a/test/features/settings/application/timeline_enrichment_settings_test.dart
+++ b/test/features/settings/application/timeline_enrichment_settings_test.dart
@@ -1,0 +1,70 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/db/settings_keys.dart';
+import 'package:enjoy_player/features/settings/application/timeline_enrichment_settings.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(executor: NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('readTimelineEnrichmentEnabledFromDb', () {
+    test('returns false when key is missing', () async {
+      expect(await readTimelineEnrichmentEnabledFromDb(db), isFalse);
+    });
+
+    test('returns true when stored value is "true"', () async {
+      await db.settingsDao.setValue(
+        SettingsKeys.transcriptTimelineEnrichment,
+        'true',
+      );
+      expect(await readTimelineEnrichmentEnabledFromDb(db), isTrue);
+    });
+
+    test('returns false when stored value is "false"', () async {
+      await db.settingsDao.setValue(
+        SettingsKeys.transcriptTimelineEnrichment,
+        'false',
+      );
+      expect(await readTimelineEnrichmentEnabledFromDb(db), isFalse);
+    });
+  });
+
+  test('setEnabled round-trips via SettingsDao', () async {
+    final container = ProviderContainer(
+      overrides: [deviceGlobalAppDatabaseProvider.overrideWithValue(db)],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      await container.read(timelineEnrichmentSettingsProvider.future),
+      isFalse,
+    );
+    await container
+        .read(timelineEnrichmentSettingsProvider.notifier)
+        .setEnabled(true);
+    expect(
+      await container.read(timelineEnrichmentSettingsProvider.future),
+      isTrue,
+    );
+    expect(
+      await db.settingsDao.getValue(SettingsKeys.transcriptTimelineEnrichment),
+      'true',
+    );
+
+    await container
+        .read(timelineEnrichmentSettingsProvider.notifier)
+        .setEnabled(false);
+    expect(await readTimelineEnrichmentEnabledFromDb(db), isFalse);
+  });
+}

--- a/test/features/settings/domain/settings_search_entry_test.dart
+++ b/test/features/settings/domain/settings_search_entry_test.dart
@@ -59,4 +59,24 @@ void main() {
       expect(filterSettingsEntries('nonexistent-xyz', entries), isEmpty);
     });
   });
+
+  group('kSettingsRegistry', () {
+    test('includes Transcript section and timelineEnrichment row', () {
+      expect(
+        kSettingsRegistry.any(
+          (d) =>
+              d.sectionId == SettingsSectionIds.transcript && d.rowId == null,
+        ),
+        isTrue,
+      );
+      expect(
+        kSettingsRegistry.any(
+          (d) =>
+              d.sectionId == SettingsSectionIds.transcript &&
+              d.rowId == 'timelineEnrichment',
+        ),
+        isTrue,
+      );
+    });
+  });
 }

--- a/test/features/settings/presentation/settings_screen_test.dart
+++ b/test/features/settings/presentation/settings_screen_test.dart
@@ -215,6 +215,11 @@ void main() {
         );
         expect(find.text(l10n.settingsAiProvidersTileTitle), findsOneWidget);
 
+        expect(
+          find.text(l10n.settingsTranscriptEnrichmentTitle),
+          findsOneWidget,
+        );
+
         expect(find.text(l10n.settingsApiBaseUrl), findsOneWidget);
         expect(find.text(l10n.appTitle), findsWidgets);
         expect(tester.takeException(), isNull);


### PR DESCRIPTION
## Summary

Craft save can now persist nested word/phone timings on the primary timeline when the user opts in. Settings → Transcript exposes a default-off `transcript.timelineEnrichment` toggle; when it is on, save keeps spec 030 line JSON and attaches `alignSegments` cues (Craft tags like `en` map onto focus locales such as `en-US`). Failures stay fail-closed: line-only JSON or `null`, never a blocking `CraftSaveFailure`. Related to #540 (slice 3: first product caller; karaoke / IPA / backfill stay later).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / chore (no user-visible change)
- [x] Documentation / ADR

## Platform tested

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [ ] Linux

## Checklist

- [x] `bash .github/scripts/validate_ci_gates.sh` passes (Dart format + codegen drift)
- [x] `flutter analyze` is clean
- [x] `flutter test` passes for affected areas
- [x] If Drift / Riverpod / Freezed annotations changed: regenerated `*.g.dart` / `*.freezed.dart` are committed
- [x] No new `print()` calls (use `logNamed` from `lib/core/logging/log.dart`)
- [x] No new `kIsWeb` branches (AGENTS.md hard rule)
- [x] No new SQL outside Drift DAOs (AGENTS.md hard rule)
- [x] No new `Player()` instances outside `PlayerController` (AGENTS.md hard rule)
- [x] If behavior changed: `docs/features/<feature>.md` updated
- [x] If architectural: new ADR in `docs/decisions/`
- [x] New public API symbols have doc comments (if applicable)

## Test plan

- [ ] Craft save with the toggle **off** still writes today's line-only primary timeline (or `null` when blank).
- [ ] Craft save with the toggle **on** and language `en` attaches nested word/phone spans; line text/start/duration do not change.
- [ ] Alignment / PCM / unsupported-language failures persist line-only JSON quietly (no `CraftSaveFailure`).
- [ ] Settings → Transcript shows **Enrich Craft word timings**; switching it updates `transcript.timelineEnrichment`.
- [ ] `flutter test test/features/craft test/features/alignment test/features/settings test/data/subtitle test/data/audio/pcm16k_mono_test.dart test/data/db/settings_keys_test.dart`

## Out of scope / follow-up

- Karaoke highlight, IPA overlay, per-word tap
- Library backfill / first-play alignment
- YouTube demux, playing the eSpeak reference, Craft → ASR import

## Human / owner follow-up

- None
