### PR TITLE
style(test): apply dart format to media_resolver_test

### DIFF
--- a/test/data/files/media_resolver_test.dart
+++ b/test/data/files/media_resolver_test.dart
@@ -98,9 +98,9 @@ void main() {
       // If anyone ever accidentally duplicates an extension across the two
       // lists, the union still classifies it as one or the other — but we
       // want to keep them clean so callers can render the right kind icon.
-      final overlap = kFilePickerLocalVideoExtensions
-          .toSet()
-          .intersection(kFilePickerLocalAudioExtensions.toSet());
+      final overlap = kFilePickerLocalVideoExtensions.toSet().intersection(
+        kFilePickerLocalAudioExtensions.toSet(),
+      );
       expect(overlap, isEmpty);
     });
   });


### PR DESCRIPTION
## Summary
- Apply `dart format` to `test/data/files/media_resolver_test.dart` to clear the
  CI format gate that started failing on `main` after
  [ca3b0f17](https://github.com/baizhiheizi/enjoy_player/commit/ca3b0f17).

## What changed
- The `.intersection(...)` call in the extension-list overlap test had been
  wrapped across multiple lines without trailing commas, so `dart format`
  rewrote it to a single canonical layout.
- Also fixes a missing trailing newline at end of file.
- No semantic change.

## Verification
- `bash .github/scripts/check_dart_format.sh` → `check_dart_format: ok`
- Local run before pushing:

  ```
  Formatted 1519 files (0 changed) in 2.42 seconds.
  check_dart_format: ok
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)