### PR TITLE
fix(api): preserve non-ASCII keys in convertKeysToSnake

### DIFF
--- a/lib/data/api/case_conversion.dart
+++ b/lib/data/api/case_conversion.dart
@@ -5,20 +5,18 @@ String _camelToSnakeToken(String input) {
   // Walk the code units directly. Going via `input[i]` + `c.toLowerCase()`
   // allocates a fresh single-char String per iteration; for an API request
   // body with hundreds of keys this dominates the JSON-encode hot path.
-  // ASCII uppercase is folded inline; non-ASCII falls back to the original
-  // Unicode-aware path so non-English keys keep their previous shape.
+  // ASCII uppercase is folded inline; keys containing any non-ASCII
+  // character are returned unchanged so non-English keys keep their previous
+  // shape (e.g. `caféName` stays `caféName`, not `café_name`).
   final b = StringBuffer();
   for (var i = 0; i < input.length; i++) {
     final code = input.codeUnitAt(i);
+    if (code >= 0x80) return input;
     final isUpperAscii = code >= 0x41 && code <= 0x5A;
     if (isUpperAscii && i > 0) {
       b.write('_');
     }
-    if (code < 0x80) {
-      b.writeCharCode(isUpperAscii ? code + 0x20 : code);
-    } else {
-      b.write(input[i].toLowerCase());
-    }
+    b.writeCharCode(isUpperAscii ? code + 0x20 : code);
   }
   return b.toString();
 }


### PR DESCRIPTION
## Summary
- Bail out of `_camelToSnakeToken` as soon as a non-ASCII code unit is seen and return the input unchanged.
- Tightens the comment to match what the implementation now actually does.

## Why
The perf commit `5492cabf` introduced a code-unit fast path for `convertKeysToSnake` and shipped a test in the same commit that asserted non-ASCII keys should be preserved (`caféName` stays `caféName`). The implementation, however, only preserved individual non-ASCII *characters* via `input[i].toLowerCase()` — it still folded any ASCII uppercase letter that followed a non-ASCII char, so `caféName` became `café_name`. CI was failing on that test.

## Fix
Detect non-ASCII inside the same single walk and return the input as-is. The ASCII fast path remains allocation-free (still one pass, `writeCharCode` for the lowercase fold), so the original hot-path perf intent is preserved.

## Verification
- `flutter test` — 5488/5488 pass (was 5487/5488 before)
- `dart format` — clean
- `flutter analyze lib/data/api/case_conversion.dart` — No issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)