### PR TITLE
fix(android): move extractNativeLibs to AGP packaging option

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -80,6 +80,16 @@ android {
         abortOnError = false
     }
 
+    // Extract native libraries to disk at install time so the vendored
+    // libespeak-ng.so is dlopen-able from applicationInfo.nativeLibraryDir.
+    // AGP 9 rejects the manifest's extractNativeLibs attribute; this is the
+    // build-script replacement.
+    packaging {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+
     // Vendored eSpeak-NG per-ABI libraries (packages/forced_alignment); the
     // directory layout <abi>/libespeak-ng.so is exactly the jniLibs shape.
     sourceSets {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,8 +4,7 @@
     <application
         android:label="Enjoy Player"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher"
-        android:extractNativeLibs="true">
+        android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
- `android_apk_smoke` failed on main (#568's follow-through): AGP 9 fails `:app:packageStoreDebug` when `android:extractNativeLibs` is set explicitly in `AndroidManifest.xml` ("Avoid setting android:extractNativeLibs=\"true\" explicitly ... set android.packagingOptions.jniLibs.useLegacyPackaging to true in the build script").
- Remove the manifest attribute and set `packaging { jniLibs { useLegacyPackaging = true } }` in `android/app/build.gradle.kts`. Runtime behavior is identical: native libs still extract to disk at install, so the vendored `libespeak-ng.so` remains `dlopen`-able from `applicationInfo.nativeLibraryDir` for the eSpeak provisioner.

Fixes the `android_apk_smoke` failure from the #568 merge.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Platform tested
- [x] Linux — Dart gates green; the change is Android-build-only (no Android SDK on this host, CI builds prove the Gradle DSL)

## Checklist
- [x] `bash .github/scripts/validate_ci_gates.sh` passes (Dart format + codegen drift)
- [x] No Dart changes (analyze/test unaffected)
- [x] No new `print()` / `kIsWeb` / raw SQL / `Player()` changes

## Test plan
- [ ] `android_apk_smoke` passes: debug build packages, eSpeak lib + data assertions hold; release split-per-abi and AAB build
- [ ] On a device: alignment still provisions (extraction + `nativeLibraryDir` path unchanged)

## Out of scope / follow-up
- None

## Human / owner follow-up
- None