### PR TITLE
fix(android): ship eSpeak lang/ voices so YouTube IPA works

### DIFF
--- a/.github/scripts/check_bundled_espeak_data.sh
+++ b/.github/scripts/check_bundled_espeak_data.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Assert a packaged espeak-ng-data directory has phoneme tables + focus voices.
+# Keep the voice list in sync with kEspeakVoiceByLanguageTag.
+#
+# Usage: check_bundled_espeak_data.sh <path/to/espeak-ng-data>
+set -euo pipefail
+
+data="${1:-}"
+if [ -z "${data}" ] || [ ! -d "${data}" ]; then
+  echo "usage: $0 <path/to/espeak-ng-data>" >&2
+  echo "missing directory: ${data:-<(empty)>}" >&2
+  exit 1
+fi
+
+voices=(en-us en-gb ja ko es es-419 fr-fr fr-ca)
+
+if [ ! -f "${data}/phontab" ]; then
+  echo "::error::missing ${data}/phontab" >&2
+  exit 1
+fi
+
+for voice in "${voices[@]}"; do
+  if [ ! -f "${data}/lang/${voice}" ]; then
+    echo "::error::missing ${data}/lang/${voice} (espeak_SetVoiceByName will fail)" >&2
+    exit 1
+  fi
+done
+
+echo "bundled eSpeak data ok: ${data}"

--- a/.github/workflows/android_apk_smoke.yml
+++ b/.github/workflows/android_apk_smoke.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Assert eSpeak-NG artifacts in split-per-abi release APK
         run: |
           set -euo pipefail
-          apk="build/app/outputs/flutter-apk/app-direct-arm64-v8a-release.apk"
+          apk="build/app/outputs/flutter-apk/app-arm64-v8a-direct-release.apk"
           listing="$(unzip -l "$apk")"
           echo "$listing" | grep -q "lib/arm64-v8a/libespeak-ng.so" || {
             echo "::error::libespeak-ng.so missing from $apk"; exit 1; }

--- a/.github/workflows/android_apk_smoke.yml
+++ b/.github/workflows/android_apk_smoke.yml
@@ -68,13 +68,15 @@ jobs:
           set -euo pipefail
           apk="build/app/outputs/flutter-apk/app-store-debug.apk"
           listing="$(unzip -l "$apk")"
+          # Here-string, not `echo | grep -q`: grep -q closes early and
+          # `set -o pipefail` then treats SIGPIPE as a missing-file failure.
           for abi in arm64-v8a armeabi-v7a x86_64; do
-            echo "$listing" | grep -q "lib/$abi/libespeak-ng.so" || {
+            grep -F -q -- "lib/$abi/libespeak-ng.so" <<<"$listing" || {
               echo "::error::lib/$abi/libespeak-ng.so missing from $apk"; exit 1; }
           done
-          echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/phontab" || {
+          grep -F -q -- "flutter_assets/packages/forced_alignment/native/espeak-ng-data/phontab" <<<"$listing" || {
             echo "::error::espeak-ng-data assets missing from $apk"; exit 1; }
-          echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/lang/en-us" || {
+          grep -F -q -- "flutter_assets/packages/forced_alignment/native/espeak-ng-data/lang/en-us" <<<"$listing" || {
             echo "::error::espeak-ng-data/lang/en-us missing from $apk (SetVoiceByName will fail)"; exit 1; }
 
       - name: Flutter build apk (release, compile-only, split per ABI)
@@ -85,11 +87,11 @@ jobs:
           set -euo pipefail
           apk="build/app/outputs/flutter-apk/app-arm64-v8a-direct-release.apk"
           listing="$(unzip -l "$apk")"
-          echo "$listing" | grep -q "lib/arm64-v8a/libespeak-ng.so" || {
+          grep -F -q -- "lib/arm64-v8a/libespeak-ng.so" <<<"$listing" || {
             echo "::error::libespeak-ng.so missing from $apk"; exit 1; }
-          echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/phontab" || {
+          grep -F -q -- "flutter_assets/packages/forced_alignment/native/espeak-ng-data/phontab" <<<"$listing" || {
             echo "::error::espeak-ng-data assets missing from $apk"; exit 1; }
-          echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/lang/en-us" || {
+          grep -F -q -- "flutter_assets/packages/forced_alignment/native/espeak-ng-data/lang/en-us" <<<"$listing" || {
             echo "::error::espeak-ng-data/lang/en-us missing from $apk (SetVoiceByName will fail)"; exit 1; }
 
       - name: Flutter build appbundle (release, compile-only)

--- a/.github/workflows/android_apk_smoke.yml
+++ b/.github/workflows/android_apk_smoke.yml
@@ -74,6 +74,8 @@ jobs:
           done
           echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/phontab" || {
             echo "::error::espeak-ng-data assets missing from $apk"; exit 1; }
+          echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/lang/en-us" || {
+            echo "::error::espeak-ng-data/lang/en-us missing from $apk (SetVoiceByName will fail)"; exit 1; }
 
       - name: Flutter build apk (release, compile-only, split per ABI)
         run: flutter build apk --release --split-per-abi --flavor direct --dart-define=DISTRIBUTION_CHANNEL=direct
@@ -87,6 +89,8 @@ jobs:
             echo "::error::libespeak-ng.so missing from $apk"; exit 1; }
           echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/phontab" || {
             echo "::error::espeak-ng-data assets missing from $apk"; exit 1; }
+          echo "$listing" | grep -q "flutter_assets/packages/forced_alignment/native/espeak-ng-data/lang/en-us" || {
+            echo "::error::espeak-ng-data/lang/en-us missing from $apk (SetVoiceByName will fail)"; exit 1; }
 
       - name: Flutter build appbundle (release, compile-only)
         run: flutter build appbundle --release --flavor store

--- a/.github/workflows/build_apple.yml
+++ b/.github/workflows/build_apple.yml
@@ -17,6 +17,7 @@ on:
       - ".github/scripts/apple_spm_hygiene.sh"
       - ".github/scripts/build_ios_ci.sh"
       - ".github/scripts/build_macos_ci.sh"
+      - ".github/scripts/check_bundled_espeak_data.sh"
       - ".github/workflows/build_apple.yml"
   push:
     branches: main
@@ -56,6 +57,16 @@ jobs:
       - name: Flutter build ios (release, compile-only)
         run: bash .github/scripts/build_ios_ci.sh Release
 
+      - name: Assert eSpeak data in iOS Runner.app
+        run: |
+          set -euo pipefail
+          found=0
+          while IFS= read -r app; do
+            bash .github/scripts/check_bundled_espeak_data.sh "${app}/espeak-ng-data"
+            found=1
+          done < <(find build/ios/DerivedData/Build/Products -name Runner.app -type d)
+          test "$found" -eq 1
+
   macos:
     name: macOS smoke
     runs-on: [self-hosted, macos]
@@ -80,3 +91,14 @@ jobs:
 
       - name: Flutter build macos (release, compile-only)
         run: bash .github/scripts/build_macos_ci.sh Release
+
+      - name: Assert eSpeak data in macOS app bundle
+        run: |
+          set -euo pipefail
+          found=0
+          while IFS= read -r app; do
+            bash .github/scripts/check_bundled_espeak_data.sh \
+              "${app}/Contents/Resources/espeak-ng-data"
+            found=1
+          done < <(find build/macos/Build/Products -name 'Enjoy Player.app' -type d)
+          test "$found" -eq 1

--- a/docs/features/transcript.md
+++ b/docs/features/transcript.md
@@ -243,8 +243,10 @@ capability gating allows it; they do not run alignment on open/play/seek.
 Learners never hear the spoken reference. Import / YouTube / ASR remain
 line-only writers until enrich. macOS and iOS app bundles embed
 `libespeak-ng` plus the trimmed voice data (see
-[packaging.md](../packaging.md#espeak-ng-alignment-reference)); a missing
-lib on other packaged hosts still fail-closes. See
+[packaging.md](../packaging.md#espeak-ng-alignment-reference)). Android
+extracts the same tree from Flutter assets and must include `espeak-ng-data/lang/`
+(Flutter does not recurse directory assets) or `espeak_SetVoiceByName`
+fails; a missing lib on other packaged hosts still fail-closes. See
 [ADR-0071](../decisions/0071-on-device-alignment-engine.md)
 and [ADR-0072](../decisions/0072-spoken-alignment-reference.md).
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -595,8 +595,17 @@ played to the learner and does not replace Craft/library audio.
   so packaged `align` / `alignSegments` can `DynamicLibrary.open` without
   the source tree. Android ships the per-ABI `.so` through jniLibs and
   `espeak-ng-data` as Flutter assets extracted at startup
-  (`lib/core/platform/espeak_android_provisioner.dart`). Windows/Linux
-  desktop app bundles remain a follow-up.
+  (`lib/core/platform/espeak_android_provisioner.dart`). Flutter does **not**
+  recurse directory assets — `pubspec.yaml` must list `espeak-ng-data/` **and**
+  `espeak-ng-data/lang/` or `espeak_SetVoiceByName(en-us)` fails on device
+  while Windows (source-tree files) still works. Windows/Linux desktop app
+  bundles remain a follow-up.
+- **CI gates**: unit tests assert iOS (`Runner.app/espeak-ng-data`) and macOS
+  (`Contents/Resources/espeak-ng-data`) layouts include every mapped `lang/`
+  voice and can phonemize `en-US`. [Build Apple](../.github/workflows/build_apple.yml)
+  runs `.github/scripts/check_bundled_espeak_data.sh` on the compiled `.app`.
+  [Android APK smoke](../.github/workflows/android_apk_smoke.yml) greps the
+  APK for `lang/en-us`, not only `phontab`.
 - `packages/forced_alignment`'s eSpeak FFI tests run unconditionally on
   vendored host platforms — a load failure is a regression, not a skip.
 - eSpeak-NG is GPL-3.0; linking into this AGPL-3.0 app is recorded in

--- a/lib/core/platform/espeak_android_provisioner.dart
+++ b/lib/core/platform/espeak_android_provisioner.dart
@@ -2,7 +2,11 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:forced_alignment/forced_alignment.dart'
-    show setEspeakNativePathOverrides;
+    show
+        kEspeakAndroidSoname,
+        kEspeakRequiredDataRelativePaths,
+        missingEspeakRequiredDataFiles,
+        setEspeakNativePathOverrides;
 import 'package:path_provider/path_provider.dart';
 
 import '../logging/log.dart';
@@ -11,7 +15,7 @@ final _log = logNamed('espeak.provision');
 
 /// Bump when the vendored `espeak-ng-data` tree changes so installed apps
 /// re-extract on next launch.
-const kEspeakDataRevision = '1.52.0-1';
+const kEspeakDataRevision = '1.52.0-2';
 
 const _channelName = 'ai.enjoy.player/espeak';
 const _assetPrefix = 'packages/forced_alignment/native/espeak-ng-data/';
@@ -58,10 +62,21 @@ Future<bool> ensureAndroidEspeakRuntime({
       _log.warning('native library dir unavailable; eSpeak stays disabled');
       return false;
     }
-    final libPath = '$nativeLibDir${Platform.pathSeparator}libespeak-ng.so';
+    var libPath = '$nativeLibDir${Platform.pathSeparator}libespeak-ng.so';
     if (!File(libPath).existsSync()) {
-      _log.warning('vendored libespeak-ng.so missing at $libPath');
-      return false;
+      // MIUI / uncompressed-in-APK installs often have no regular file
+      // under nativeLibraryDir even though dlopen(soname) works.
+      var listing = 'unreadable';
+      try {
+        listing = Directory(nativeLibDir).existsSync()
+            ? Directory(nativeLibDir).listSync().map((e) => e.path).join(', ')
+            : 'dir missing';
+      } on Object catch (_) {}
+      _log.warning(
+        'libespeak-ng.so not a regular file at $libPath '
+        '(listing: $listing); pinning Android soname for dlopen',
+      );
+      libPath = kEspeakAndroidSoname;
     }
 
     final sep = Platform.pathSeparator;
@@ -74,8 +89,11 @@ Future<bool> ensureAndroidEspeakRuntime({
 
     if (!_isProvisioned(revisionDir)) {
       final files = await (loadData ?? loadEspeakDataAssets)();
-      if (!files.containsKey('phontab')) {
-        _log.warning('espeak-ng-data assets missing from the bundle');
+      if (!_hasRequiredRelativeFiles(files.keys)) {
+        _log.warning(
+          'espeak-ng-data assets missing phontab or lang voices; '
+          'keys=${files.keys.toList()..sort()}',
+        );
         return false;
       }
       if (revisionsRoot.existsSync()) {
@@ -106,10 +124,16 @@ Future<bool> ensureAndroidEspeakRuntime({
   }
 }
 
-/// A complete revision carries `phontab` plus the `.provisioned` marker, so
-/// warm launches skip asset enumeration entirely.
+/// A complete revision carries `phontab`, mapped `lang/` voices, and the
+/// `.provisioned` marker, so warm launches skip asset enumeration.
 bool _isProvisioned(Directory revisionDir) {
   final sep = Platform.pathSeparator;
-  return File('${revisionDir.path}$sep.provisioned').existsSync() &&
-      File('${revisionDir.path}${sep}espeak-ng-data${sep}phontab').existsSync();
+  final dataDir = Directory('${revisionDir.path}${sep}espeak-ng-data');
+  if (!File('${revisionDir.path}$sep.provisioned').existsSync()) return false;
+  return missingEspeakRequiredDataFiles(dataDir.path).isEmpty;
+}
+
+bool _hasRequiredRelativeFiles(Iterable<String> relativePaths) {
+  final keys = relativePaths.toSet();
+  return kEspeakRequiredDataRelativePaths.every(keys.contains);
 }

--- a/lib/features/player/application/player_interactions.g.dart
+++ b/lib/features/player/application/player_interactions.g.dart
@@ -42,7 +42,7 @@ final class PlayerInteractionsProvider
 }
 
 String _$playerInteractionsHash() =>
-    r'8ba3a0d3d614abdd2b2d4d2e0e73a5601d642af7';
+    r'4d1f012927bdf3d38c07671e4b6926ebc531fa83';
 
 abstract class _$PlayerInteractions extends $Notifier<int> {
   int build();

--- a/lib/features/transcript/application/transcript_enrichment_controller.dart
+++ b/lib/features/transcript/application/transcript_enrichment_controller.dart
@@ -14,6 +14,7 @@ import 'package:enjoy_player/data/db/media_target_resolver.dart';
 import 'package:enjoy_player/data/subtitle/alignment_language.dart';
 import 'package:enjoy_player/data/subtitle/attach_alignment_to_lines.dart';
 import 'package:enjoy_player/data/subtitle/attach_phonemes_to_lines.dart';
+import 'package:enjoy_player/data/subtitle/subtitle_markup_parser.dart';
 import 'package:enjoy_player/data/subtitle/transcript_line.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_repository_provider.dart';
@@ -139,7 +140,14 @@ final class TranscriptEnricher {
       return const TranscriptEnrichmentErr('empty');
     }
     final alignmentLanguage = alignmentLanguageForTranscript(language);
+    logNamed('transcript.enrichment').info(
+      'enrich start id=$transcriptId lang=$language '
+      'mapped=$alignmentLanguage extractable=$extractable lines=${lines.length}',
+    );
     if (alignmentLanguage == null) {
+      logNamed(
+        'transcript.enrichment',
+      ).warning('enrich failed: unsupportedLanguage lang=$language');
       return const TranscriptEnrichmentErr('unsupportedLanguage');
     }
     if (cancel?.isCancelled ?? false) {
@@ -175,7 +183,9 @@ final class TranscriptEnricher {
     late final PhonemizeOutcome outcome;
     try {
       outcome = await _phonemize(
-        texts: [for (final line in lines) line.text],
+        texts: [
+          for (final line in lines) plainTextFromSubtitleMarkup(line.text),
+        ],
         language: language,
         cancel: cancel,
       );
@@ -188,11 +198,14 @@ final class TranscriptEnricher {
     }
     switch (outcome) {
       case PhonemizeFailed(:final failure):
+        logNamed(
+          'transcript.enrichment',
+        ).warning('phonemize failed: ${failure.reason.name}');
         return TranscriptEnrichmentErr(failure.reason.name);
       case PhonemizeSuccess(lines: final phonemeLines):
         try {
           final attached = attachPhonemesToLines(lines, phonemeLines);
-          return _persistIfChanged(
+          return await _persistIfChanged(
             transcriptId: transcriptId,
             original: lines,
             attached: attached,
@@ -292,7 +305,7 @@ final class TranscriptEnricher {
       case AlignmentSuccess(:final result):
         try {
           final attached = attachAlignmentToLines(lines, result);
-          return _persistIfChanged(
+          return await _persistIfChanged(
             transcriptId: transcriptId,
             original: lines,
             attached: attached,
@@ -412,6 +425,9 @@ final class TranscriptEnricher {
       (line) => line.timeline != null && line.timeline!.isNotEmpty,
     );
     if (!anyNested) {
+      logNamed(
+        'transcript.enrichment',
+      ).warning('enrich failed: noNestedWords id=$transcriptId');
       return const TranscriptEnrichmentErr('noNestedWords');
     }
     if (cancel?.isCancelled ?? false) {
@@ -554,11 +570,13 @@ class TranscriptEnrichmentController extends _$TranscriptEnrichmentController {
         state = const TranscriptEnrichmentState.failed('cancelled');
         return;
       }
-      state = switch (outcome) {
-        TranscriptEnrichmentOk() => const TranscriptEnrichmentState.succeeded(),
-        TranscriptEnrichmentErr(:final reason) =>
-          TranscriptEnrichmentState.failed(reason),
-      };
+      switch (outcome) {
+        case TranscriptEnrichmentOk():
+          state = const TranscriptEnrichmentState.succeeded();
+        case TranscriptEnrichmentErr(:final reason):
+          logNamed('transcript.enrichment').warning('run failed: $reason');
+          state = TranscriptEnrichmentState.failed(reason);
+      }
     } on Object catch (e, st) {
       logNamed('transcript.enrichment').warning('run failed: $e', e, st);
       if (!ref.mounted || id != _runId) return;

--- a/lib/features/transcript/application/transcript_enrichment_controller.g.dart
+++ b/lib/features/transcript/application/transcript_enrichment_controller.g.dart
@@ -113,7 +113,7 @@ final class TranscriptEnrichmentControllerProvider
 }
 
 String _$transcriptEnrichmentControllerHash() =>
-    r'82926611c5dbe6e99379abb826319ade713fe6a7';
+    r'0e0f90d9904628f3dc2d148417eb6fe62f8b446b';
 
 final class TranscriptEnrichmentControllerFamily extends $Family
     with

--- a/packages/forced_alignment/lib/forced_alignment.dart
+++ b/packages/forced_alignment/lib/forced_alignment.dart
@@ -6,7 +6,11 @@ export 'src/constants.dart';
 export 'src/failures.dart';
 export 'src/flatten.dart';
 export 'src/language_map.dart'
-    show kSupportedAlignmentLanguageTags, isSupportedAlignmentLanguage;
+    show
+        kEspeakRequiredDataRelativePaths,
+        kEspeakVoiceByLanguageTag,
+        kSupportedAlignmentLanguageTags,
+        isSupportedAlignmentLanguage;
 export 'src/outcome.dart';
 export 'src/phonemize.dart';
 export 'src/request.dart';
@@ -20,8 +24,10 @@ export 'src/synth/espeak_ng_synthesizer.dart'
         productionSynthesizerIsEspeakNg;
 export 'src/synth/native_paths.dart'
     show
+        kEspeakAndroidSoname,
         resolveEspeakDataPath,
         resolveEspeakLibraryPath,
+        missingEspeakRequiredDataFiles,
         setEspeakNativePathOverrides;
 export 'src/synth/spoken_reference.dart';
 export 'src/types.dart';

--- a/packages/forced_alignment/lib/src/language_map.dart
+++ b/packages/forced_alignment/lib/src/language_map.dart
@@ -27,3 +27,11 @@ bool isSupportedAlignmentLanguage(String languageTag) =>
 
 String? espeakVoiceFor(String languageTag) =>
     kEspeakVoiceByLanguageTag[languageTag];
+
+/// Files that must exist inside a packaged `espeak-ng-data` directory.
+///
+/// Keep `.github/scripts/check_bundled_espeak_data.sh` in sync.
+List<String> get kEspeakRequiredDataRelativePaths => [
+  'phontab',
+  for (final voice in kEspeakVoiceByLanguageTag.values) 'lang/$voice',
+];

--- a/packages/forced_alignment/lib/src/phonemize.dart
+++ b/packages/forced_alignment/lib/src/phonemize.dart
@@ -2,12 +2,15 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
 
 import 'failures.dart';
 import 'language_map.dart';
 import 'request.dart';
 import 'synth/espeak_synth_host.dart';
 import 'synth/spoken_reference.dart';
+
+final _log = Logger('forced_alignment');
 
 /// One token with IPA labels and no media-timeline clocks.
 final class PhonemeWord {
@@ -67,6 +70,7 @@ Future<PhonemizeOutcome> phonemizeLines({
   }
 
   final out = <PhonemizeLineResult>[];
+  var synthFailures = 0;
   for (final text in texts) {
     if (cancel?.isCancelled ?? false) {
       return const PhonemizeFailed(
@@ -85,6 +89,7 @@ Future<PhonemizeOutcome> phonemizeLines({
               text: text,
               language: language,
               cancel: cancel,
+              phonemesOnly: true,
             );
       out.add(
         PhonemizeLineResult(
@@ -105,9 +110,22 @@ Future<PhonemizeOutcome> phonemizeLines({
       if (e.reason == AlignmentFailureReason.cancelled) {
         return PhonemizeFailed(e.toFailure());
       }
-      // Leave this cue line-only; other lines may still phonemize.
+      synthFailures++;
+      _log.warning('phonemize skipped a line: $e');
       out.add(const PhonemizeLineResult(words: []));
     }
+  }
+  final anyWords = out.any((line) => line.words.isNotEmpty);
+  if (!anyWords) {
+    _log.warning(
+      'phonemize produced no words '
+      '(synthFailures=$synthFailures lines=${texts.length})',
+    );
+    return const PhonemizeFailed(
+      AlignmentFailure(
+        reason: AlignmentFailureReason.spokenReferenceUnavailable,
+      ),
+    );
   }
   return PhonemizeSuccess(out);
 }

--- a/packages/forced_alignment/lib/src/synth/espeak_ng_synthesizer.dart
+++ b/packages/forced_alignment/lib/src/synth/espeak_ng_synthesizer.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:logging/logging.dart';
@@ -58,27 +60,51 @@ final class _WordMark {
 }
 
 final class _PhoneMark {
-  _PhoneMark({required this.phone, required this.audioMs});
+  _PhoneMark({
+    required this.phone,
+    required this.audioMs,
+    required this.textPosition,
+  });
 
   final String phone;
   final int audioMs;
+  final int textPosition;
 }
 
 /// Production spoken reference: eSpeak-NG `espeak_Synth` + WORD/PHONEME events.
 final class EspeakNgSynthesizer implements SpokenReferenceSynthesizer {
-  EspeakNgSynthesizer({this._isCancelled});
+  EspeakNgSynthesizer({this._isCancelled, this.phonemesOnly = false});
 
   final bool Function()? _isCancelled;
+
+  /// When true, discard native PCM (YouTube IPA). Still runs `espeak_Synth`
+  /// so WORD/PHONEME events arrive; does not copy samples onto the Dart heap.
+  final bool phonemesOnly;
 
   static DynamicLibrary? _lib;
   static EspeakNgBindings? _bindings;
   static bool _initialized = false;
   static int _nativeSampleRate = 22050;
   static NativeCallable<EspeakCallbackNative>? _callable;
-  static final List<int> _pcm = <int>[];
+  static Int16List _pcm = Int16List(0);
+  static int _pcmCount = 0;
+  static bool _capturePcm = true;
   static final List<_WordMark> _words = <_WordMark>[];
   static final List<_PhoneMark> _phones = <_PhoneMark>[];
   static bool Function()? _cancelHook;
+
+  static void _appendPcm(Pointer<Int16> wav, int n) {
+    if (n <= 0) return;
+    if (_pcmCount + n > _pcm.length) {
+      final next = Int16List(math.max((_pcm.length * 2), _pcmCount + n));
+      if (_pcmCount > 0) {
+        next.setRange(0, _pcmCount, _pcm);
+      }
+      _pcm = next;
+    }
+    _pcm.setRange(_pcmCount, _pcmCount + n, wav.asTypedList(n));
+    _pcmCount += n;
+  }
 
   static int _onSynth(
     Pointer<Int16> wav,
@@ -86,8 +112,8 @@ final class EspeakNgSynthesizer implements SpokenReferenceSynthesizer {
     Pointer<EspeakEvent> events,
   ) {
     if (_cancelHook?.call() ?? false) return 1;
-    if (wav != nullptr && numsamples > 0) {
-      _pcm.addAll(wav.asTypedList(numsamples));
+    if (_capturePcm && wav != nullptr && numsamples > 0) {
+      _appendPcm(wav, numsamples);
     }
     if (events != nullptr) {
       for (var i = 0; i < 64; i++) {
@@ -104,7 +130,13 @@ final class EspeakNgSynthesizer implements SpokenReferenceSynthesizer {
         } else if (event.type == espeakEventPhoneme) {
           final phone = _readPhoneme(event);
           if (phone.isNotEmpty) {
-            _phones.add(_PhoneMark(phone: phone, audioMs: event.audioPosition));
+            _phones.add(
+              _PhoneMark(
+                phone: phone,
+                audioMs: event.audioPosition,
+                textPosition: event.textPosition,
+              ),
+            );
           }
         }
       }
@@ -132,13 +164,29 @@ final class EspeakNgSynthesizer implements SpokenReferenceSynthesizer {
       );
     }
     try {
-      _lib = DynamicLibrary.open(path);
+      _lib = _openDynamicLibrary(path);
       _bindings = EspeakNgBindings(_lib!);
     } catch (e, st) {
       _log.warning('failed to open eSpeak-NG', e, st);
       throw SpokenReferenceException(message: 'failed to open $path');
     }
     return _bindings!;
+  }
+
+  static DynamicLibrary _openDynamicLibrary(String path) {
+    try {
+      return DynamicLibrary.open(path);
+    } on Object catch (e, st) {
+      if (Platform.isAndroid && path != kEspeakAndroidSoname) {
+        _log.warning(
+          'failed to open eSpeak-NG at $path; retrying Android soname',
+          e,
+          st,
+        );
+        return DynamicLibrary.open(kEspeakAndroidSoname);
+      }
+      rethrow;
+    }
   }
 
   static void _ensureInitialized(EspeakNgBindings bindings) {
@@ -199,7 +247,8 @@ final class EspeakNgSynthesizer implements SpokenReferenceSynthesizer {
     final bindings = _open();
     _ensureInitialized(bindings);
     _cancelHook = _isCancelled;
-    _pcm.clear();
+    _capturePcm = !phonemesOnly;
+    _pcmCount = 0;
     _words.clear();
     _phones.clear();
 
@@ -238,26 +287,55 @@ final class EspeakNgSynthesizer implements SpokenReferenceSynthesizer {
         message: 'spoken reference cancelled',
       );
     }
-    if (_pcm.isEmpty) {
+    if (!phonemesOnly && _pcmCount <= 0) {
       throw const SpokenReferenceException(
         message: 'eSpeak-NG produced no PCM',
       );
     }
 
-    final floatNative = int16ToFloat32(_pcm);
+    if (phonemesOnly) {
+      final duration = _eventDurationSeconds();
+      final words = _buildWords(text, duration, requireWordEvents: false);
+      return ReferenceAudio(
+        pcm: Float32List(0),
+        words: words,
+        durationSeconds: duration,
+      );
+    }
+
+    final floatNative = int16ToFloat32(_pcm.sublist(0, _pcmCount));
     final pcm = resampleToAlignmentRate(floatNative, _nativeSampleRate);
     final duration = pcm.length / kAlignmentSampleRate;
     final words = _buildWords(text, duration);
     return ReferenceAudio(pcm: pcm, words: words, durationSeconds: duration);
   }
 
-  static List<ReferenceWord> _buildWords(String text, double duration) {
+  static double _eventDurationSeconds() {
+    var maxMs = 0;
+    for (final word in _words) {
+      if (word.audioMs > maxMs) maxMs = word.audioMs;
+    }
+    for (final phone in _phones) {
+      if (phone.audioMs > maxMs) maxMs = phone.audioMs;
+    }
+    if (maxMs <= 0) return 0.05;
+    return maxMs / 1000.0;
+  }
+
+  static List<ReferenceWord> _buildWords(
+    String text,
+    double duration, {
+    bool requireWordEvents = true,
+  }) {
     if (_words.isEmpty) {
       final tokens = tokenizeWords(text);
       if (tokens.isEmpty) return const [];
-      throw const SpokenReferenceException(
-        message: 'eSpeak-NG produced PCM but no word events',
-      );
+      if (requireWordEvents) {
+        throw const SpokenReferenceException(
+          message: 'eSpeak-NG produced PCM but no word events',
+        );
+      }
+      return _wordsFromTokenSpans(text, duration);
     }
     final tokens = tokenizeWords(text);
     final built = <ReferenceWord>[];
@@ -310,6 +388,49 @@ final class EspeakNgSynthesizer implements SpokenReferenceSynthesizer {
       );
     }
     return built;
+  }
+
+  /// IPA-only fallback when eSpeak emitted phones but no WORD events.
+  static List<ReferenceWord> _wordsFromTokenSpans(
+    String text,
+    double duration,
+  ) {
+    final spans = tokenizeWordSpans(text);
+    if (spans.isEmpty) return const [];
+    final phonesByWord = List<List<String>>.generate(
+      spans.length,
+      (_) => <String>[],
+    );
+    for (final phone in _phones) {
+      var pos = phone.textPosition;
+      if (pos >= 1) pos -= 1;
+      var idx = 0;
+      for (var i = 0; i < spans.length; i++) {
+        if (pos >= spans[i].start && pos < spans[i].end) {
+          idx = i;
+          break;
+        }
+        if (pos >= spans[i].end) idx = i;
+      }
+      if (phone.phone.isNotEmpty) phonesByWord[idx].add(phone.phone);
+    }
+    return [
+      for (var i = 0; i < spans.length; i++)
+        ReferenceWord(
+          text: spans[i].text,
+          startTime: 0,
+          endTime: duration,
+          phones: [
+            for (var p = 0; p < phonesByWord[i].length; p++)
+              ReferencePhone(
+                phone: phonesByWord[i][p],
+                startTime: 0,
+                endTime: duration,
+                wordIndex: i,
+              ),
+          ],
+        ),
+    ];
   }
 
   static String _sliceText(String text, int position, int length) {

--- a/packages/forced_alignment/lib/src/synth/espeak_synth_host.dart
+++ b/packages/forced_alignment/lib/src/synth/espeak_synth_host.dart
@@ -19,6 +19,7 @@ final class _EspeakJob {
     required this.language,
     this.libraryPath,
     this.dataPath,
+    this.phonemesOnly = false,
   });
 
   final int id;
@@ -27,6 +28,7 @@ final class _EspeakJob {
   final String language;
   final String? libraryPath;
   final String? dataPath;
+  final bool phonemesOnly;
 }
 
 final class _EspeakCancel {
@@ -40,6 +42,7 @@ final class _EspeakCancel {
 /// eSpeak-NG process-global APIs are not safe across overlapping
 /// `Isolate.spawn` workers. All production synth goes through this host;
 /// DTW isolates receive a finished [ReferenceAudio] only.
+@pragma('vm:entry-point')
 void _espeakSynthIsolateMain(SendPort ready) {
   final inbox = ReceivePort();
   var cancelled = false;
@@ -59,6 +62,7 @@ void _espeakSynthIsolateMain(SendPort ready) {
     try {
       final audio = EspeakNgSynthesizer(
         isCancelled: () => cancelled,
+        phonemesOnly: message.phonemesOnly,
       ).synthesize(text: message.text, language: message.language);
       message.reply.send(audio);
     } on SpokenReferenceException catch (e) {
@@ -105,10 +109,13 @@ final class EspeakSynthHost {
   }
 
   /// Speak [text] on the dedicated eSpeak isolate (one job at a time).
+  ///
+  /// [phonemesOnly] skips copying PCM onto the Dart heap (YouTube IPA).
   static Future<ReferenceAudio> synthesize({
     required String text,
     required String language,
     AlignmentCancelToken? cancel,
+    bool phonemesOnly = false,
   }) {
     final previous = _queue;
     final released = Completer<void>();
@@ -120,6 +127,7 @@ final class EspeakSynthHost {
           text: text,
           language: language,
           cancel: cancel,
+          phonemesOnly: phonemesOnly,
         );
       } finally {
         released.complete();
@@ -131,6 +139,7 @@ final class EspeakSynthHost {
     required String text,
     required String language,
     AlignmentCancelToken? cancel,
+    bool phonemesOnly = false,
   }) async {
     await _ensureStarted();
     if (cancel?.isCancelled ?? false) {
@@ -149,6 +158,7 @@ final class EspeakSynthHost {
         language: language,
         libraryPath: resolveEspeakLibraryPath(),
         dataPath: resolveEspeakDataPath(),
+        phonemesOnly: phonemesOnly,
       ),
     );
     cancel?.onCancel(() {

--- a/packages/forced_alignment/lib/src/synth/native_paths.dart
+++ b/packages/forced_alignment/lib/src/synth/native_paths.dart
@@ -2,9 +2,15 @@ import 'dart:io';
 
 import 'package:meta/meta.dart';
 
+import '../language_map.dart';
+
 String? _libraryPathOverride;
 String? _dataPathOverride;
 String? _resolvedExecutableOverride;
+
+/// Android linker soname. `dlopen` can resolve this even when the `.so` is
+/// not a regular file under `nativeLibraryDir` (uncompressed in the APK).
+const kEspeakAndroidSoname = 'libespeak-ng.so';
 
 /// Pin resolved native paths for a worker isolate (sendable strings).
 void setEspeakNativePathOverrides({String? libraryPath, String? dataPath}) {
@@ -110,10 +116,16 @@ bool _isUsableDataDir(String path) {
   );
 }
 
+bool _libraryPathIsUsable(String path) {
+  if (File(path).existsSync()) return true;
+  // Bare soname: Android's linker namespace finds the packaged JNI lib.
+  return path == kEspeakAndroidSoname;
+}
+
 /// First existing library path, or null.
 String? resolveEspeakLibraryPath() {
   if (_libraryPathOverride != null &&
-      File(_libraryPathOverride!).existsSync()) {
+      _libraryPathIsUsable(_libraryPathOverride!)) {
     return _libraryPathOverride;
   }
   final os = espeakOsFolderName();
@@ -145,4 +157,14 @@ String? resolveEspeakDataPath() {
     if (_isUsableDataDir(candidate)) return candidate;
   }
   return null;
+}
+
+/// Relative paths from [kEspeakRequiredDataRelativePaths] that are missing
+/// under [dataDir]. Empty means focus voices can resolve via SetVoiceByName.
+List<String> missingEspeakRequiredDataFiles(String dataDir) {
+  final sep = Platform.pathSeparator;
+  return [
+    for (final rel in kEspeakRequiredDataRelativePaths)
+      if (!File('$dataDir$sep${rel.replaceAll('/', sep)}').existsSync()) rel,
+  ];
 }

--- a/packages/forced_alignment/lib/src/synth/spoken_reference.dart
+++ b/packages/forced_alignment/lib/src/synth/spoken_reference.dart
@@ -4,13 +4,28 @@ import '../failures.dart';
 
 final _wordPattern = RegExp(r"[\p{L}\p{N}']+", unicode: true);
 
-/// Words in transcript order. Punctuation-only text yields an empty list.
-List<String> tokenizeWords(String text) {
+/// One [tokenizeWords] token with Dart string indexes into the source text.
+final class WordSpan {
+  const WordSpan({required this.text, required this.start, required this.end});
+
+  final String text;
+  final int start;
+  final int end;
+}
+
+/// Word spans in transcript order. Punctuation-only text yields an empty list.
+List<WordSpan> tokenizeWordSpans(String text) {
   return [
     for (final match in _wordPattern.allMatches(text))
-      if (match.group(0)!.isNotEmpty) match.group(0)!,
+      if (match.group(0)!.isNotEmpty)
+        WordSpan(text: match.group(0)!, start: match.start, end: match.end),
   ];
 }
+
+/// Words in transcript order. Punctuation-only text yields an empty list.
+List<String> tokenizeWords(String text) => [
+  for (final span in tokenizeWordSpans(text)) span.text,
+];
 
 /// Thrown when a spoken reference cannot be produced.
 final class SpokenReferenceException implements Exception {

--- a/packages/forced_alignment/native/README.md
+++ b/packages/forced_alignment/native/README.md
@@ -45,7 +45,8 @@ data tree below in lockstep.
 Android app builds merge the per-ABI libraries via the app's jniLibs source
 (`android/app/build.gradle.kts` points at `native/android/`, whose `<abi>/`
 subfolders are exactly the jniLibs shape), and the app pubspec bundles
-`espeak-ng-data/` as Flutter assets. At startup
+`espeak-ng-data/` **and** `espeak-ng-data/lang/` as Flutter assets (Flutter
+does not recurse directory entries). At startup
 `lib/core/platform/espeak_android_provisioner.dart` reads
 `applicationInfo.nativeLibraryDir` over the `ai.enjoy.player/espeak` channel,
 extracts the data assets into app-support storage (revision-marked,
@@ -54,7 +55,9 @@ missing keeps the package fail-closed (`spokenReferenceUnavailable`).
 
 macOS and iOS app builds copy the host dylib into `Frameworks/` and the
 trimmed data tree into `Contents/Resources/espeak-ng-data` (macOS) or
-`Runner.app/espeak-ng-data` (iOS) via `bundle_into_app.sh`. Production
+`Runner.app/espeak-ng-data` (iOS) via `bundle_into_app.sh`. Package tests
+assert both layouts include `lang/en-us` (and every mapped voice) and can
+phonemize English; Apple CI greps the compiled `.app`. Production
 `align` resolves those bundle paths from `Platform.resolvedExecutable`
 when the process is not sitting in the source tree.
 

--- a/packages/forced_alignment/native/bundle_into_app.sh
+++ b/packages/forced_alignment/native/bundle_into_app.sh
@@ -62,8 +62,12 @@ fi
 
 rm -rf "${DATA_DEST}"
 mkdir -p "${DATA_DEST}"
-# -C: exclude .gitkeep so the runtime "usable data dir" check stays honest.
-rsync -a --exclude '.gitkeep' "${DATA_SRC}/" "${DATA_DEST}/"
+# Copy the trimmed voice tree (including nested lang/). Do not use a
+# Flutter asset bundle here — Xcode copies real files. Exclude .gitkeep
+# so the runtime "usable data dir" check stays honest. `cp -R` is present
+# on macOS (Xcode) and Linux (package tests); rsync is not assumed.
+cp -R "${DATA_SRC}/." "${DATA_DEST}/"
+find "${DATA_DEST}" -name '.gitkeep' -delete
 
 sign_identity="${EXPANDED_CODE_SIGN_IDENTITY:-}"
 if [ -z "${sign_identity}" ] || [ "${sign_identity}" = "-" ]; then

--- a/packages/forced_alignment/test/bundled_espeak_test.dart
+++ b/packages/forced_alignment/test/bundled_espeak_test.dart
@@ -1,11 +1,97 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:forced_alignment/forced_alignment.dart';
 import 'package:forced_alignment/src/synth/espeak_synth_host.dart';
-import 'package:forced_alignment/src/synth/native_paths.dart';
 
 void main() {
-  test('macOS app-bundle copy still synthesizes a spoken reference', () async {
+  test('source tree has every mapped voice for SetVoiceByName', () {
+    final data = resolveEspeakDataPath();
+    expect(data, isNotNull, reason: 'vendored espeak-ng-data must resolve');
+    expect(
+      missingEspeakRequiredDataFiles(data!),
+      isEmpty,
+      reason: 'source espeak-ng-data incomplete',
+    );
+  });
+
+  test(
+    'iOS and macOS bundle layouts keep lang voices for SetVoiceByName',
+    () async {
+      final src = resolveEspeakDataPath();
+      final lib = resolveEspeakLibraryPath();
+      expect(src, isNotNull);
+      expect(lib, isNotNull);
+
+      final tmp = Directory.systemTemp.createTempSync('espeak-apple-layout-');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+      final iosData =
+          '${tmp.path}${Platform.pathSeparator}Runner.app'
+          '${Platform.pathSeparator}espeak-ng-data';
+      final macData =
+          '${tmp.path}${Platform.pathSeparator}Enjoy Player.app'
+          '${Platform.pathSeparator}Contents'
+          '${Platform.pathSeparator}Resources'
+          '${Platform.pathSeparator}espeak-ng-data';
+      _copyDataTree(src!, iosData);
+      _copyDataTree(src, macData);
+
+      expect(
+        missingEspeakRequiredDataFiles(iosData),
+        isEmpty,
+        reason: 'iOS Runner.app/espeak-ng-data',
+      );
+      expect(
+        missingEspeakRequiredDataFiles(macData),
+        isEmpty,
+        reason: 'macOS Contents/Resources/espeak-ng-data',
+      );
+
+      setEspeakNativePathOverrides(libraryPath: lib, dataPath: iosData);
+      addTearDown(setEspeakNativePathOverrides);
+
+      final ref = await EspeakSynthHost.synthesize(
+        text: 'hello',
+        language: 'en-US',
+        phonemesOnly: true,
+      );
+      expect(ref.words, isNotEmpty);
+      expect(ref.words.first.phones, isNotEmpty);
+    },
+  );
+
+  test('bundle_into_app.sh copies iOS and macOS voice files', () {
+    if (Platform.isWindows) {
+      return;
+    }
+    final src = resolveEspeakDataPath();
+    expect(src, isNotNull);
+    final script = File('${Directory(src!).parent.path}/bundle_into_app.sh');
+    expect(script.existsSync(), isTrue, reason: script.path);
+
+    final tmp = Directory.systemTemp.createTempSync('espeak-bundle-script-');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+
+    final macApp = Directory('${tmp.path}/Enjoy Player.app')
+      ..createSync(recursive: true);
+    Directory('${macApp.path}/Contents/MacOS').createSync(recursive: true);
+    _runBundleScript(script.path, macApp.path, platformName: 'macosx');
+    expect(
+      missingEspeakRequiredDataFiles(
+        '${macApp.path}/Contents/Resources/espeak-ng-data',
+      ),
+      isEmpty,
+    );
+
+    final iosApp = Directory('${tmp.path}/Runner.app')..createSync();
+    _runBundleScript(script.path, iosApp.path, platformName: 'iphoneos');
+    expect(
+      missingEspeakRequiredDataFiles('${iosApp.path}/espeak-ng-data'),
+      isEmpty,
+    );
+  });
+
+  test('macOS app-bundle dylib still synthesizes a spoken reference', () async {
     if (!Platform.isMacOS) return;
     final repoNative = resolveEspeakLibraryPath();
     final repoData = resolveEspeakDataPath();
@@ -20,12 +106,7 @@ void main() {
       '${Directory(repoData!).parent.path}/bundle_into_app.sh',
     );
     expect(script.existsSync(), isTrue, reason: script.path);
-    final result = Process.runSync(
-      script.path,
-      [app.path],
-      environment: {'PLATFORM_NAME': 'macosx', 'CODE_SIGNING_ALLOWED': 'NO'},
-    );
-    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    _runBundleScript(script.path, app.path, platformName: 'macosx');
 
     final bundledLib = File(
       '${app.path}/Contents/Frameworks/libespeak-ng.dylib',
@@ -35,6 +116,7 @@ void main() {
     );
     expect(bundledLib.existsSync(), isTrue);
     expect(bundledData.existsSync(), isTrue);
+    expect(missingEspeakRequiredDataFiles(bundledData.path), isEmpty);
 
     setEspeakNativePathOverrides(
       libraryPath: bundledLib.path,
@@ -49,4 +131,29 @@ void main() {
     expect(ref.pcm, isNotEmpty);
     expect(ref.words, isNotEmpty);
   });
+}
+
+void _runBundleScript(
+  String script,
+  String appPath, {
+  required String platformName,
+}) {
+  final result = Process.runSync(
+    script,
+    [appPath],
+    environment: {'PLATFORM_NAME': platformName, 'CODE_SIGNING_ALLOWED': 'NO'},
+  );
+  expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+}
+
+void _copyDataTree(String src, String dest) {
+  final srcDir = Directory(src);
+  for (final entity in srcDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File) continue;
+    final name = entity.uri.pathSegments.last;
+    if (name == '.gitkeep') continue;
+    final destPath = dest + entity.path.substring(src.length);
+    File(destPath).parent.createSync(recursive: true);
+    entity.copySync(destPath);
+  }
 }

--- a/packages/forced_alignment/test/focus_voice_files_test.dart
+++ b/packages/forced_alignment/test/focus_voice_files_test.dart
@@ -1,22 +1,12 @@
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:forced_alignment/src/language_map.dart';
+import 'package:forced_alignment/forced_alignment.dart';
 import 'package:forced_alignment/src/synth/espeak_synth_host.dart';
-import 'package:forced_alignment/src/synth/native_paths.dart';
 
 void main() {
   test('vendored data includes a lang file for every mapped voice', () {
     final data = resolveEspeakDataPath();
-    if (data == null) {
-      return;
-    }
-    final lang = Directory('$data${Platform.pathSeparator}lang');
-    expect(lang.existsSync(), isTrue);
-    for (final voice in kEspeakVoiceByLanguageTag.values) {
-      final file = File('${lang.path}${Platform.pathSeparator}$voice');
-      expect(file.existsSync(), isTrue, reason: 'missing lang/$voice');
-    }
+    expect(data, isNotNull);
+    expect(missingEspeakRequiredDataFiles(data!), isEmpty);
   });
 
   test('fr-CA spoken reference can be built', () async {

--- a/packages/forced_alignment/test/native_paths_test.dart
+++ b/packages/forced_alignment/test/native_paths_test.dart
@@ -60,12 +60,9 @@ void main() {
     }
   });
 
-  test('resolve prefers an existing library override', () {
-    final tmp = Directory.systemTemp.createTempSync('espeak-override-');
-    addTearDown(() => tmp.deleteSync(recursive: true));
-    final fake = File('${tmp.path}/libespeak-ng.dylib')..writeAsBytesSync([]);
-    setEspeakNativePathOverrides(libraryPath: fake.path);
-    expect(resolveEspeakLibraryPath(), fake.path);
+  test('bare Android soname override resolves without a file on disk', () {
+    setEspeakNativePathOverrides(libraryPath: kEspeakAndroidSoname);
+    expect(resolveEspeakLibraryPath(), kEspeakAndroidSoname);
   });
 
   test('debug executable override finds a fake macOS app bundle', () {

--- a/packages/forced_alignment/test/phonemize_test.dart
+++ b/packages/forced_alignment/test/phonemize_test.dart
@@ -90,4 +90,19 @@ void main() {
     expect(words, isNotEmpty);
     expect(words.first.phones, isNotEmpty);
   });
+
+  test('all-line synth failure is spokenReferenceUnavailable', () async {
+    final outcome = await phonemizeLines(
+      texts: const ['Hello world'],
+      language: 'en-US',
+      synthesize: ({required text, required language, cancel}) async {
+        throw const SpokenReferenceException(message: 'forced unavailable');
+      },
+    );
+    expect(outcome, isA<PhonemizeFailed>());
+    expect(
+      (outcome as PhonemizeFailed).failure.reason,
+      AlignmentFailureReason.spokenReferenceUnavailable,
+    );
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,5 +109,8 @@ flutter:
     - assets/discover/recommended_channels.json
     # Vendored eSpeak-NG voices/dicts; extracted to disk on Android at startup
     # (espeak_android_provisioner) because eSpeak fopens real files.
+    # Flutter does not recurse: each directory needs its own entry or `lang/`
+    # is omitted and espeak_SetVoiceByName(en-us) fails on Android.
     - packages/forced_alignment/native/espeak-ng-data/
+    - packages/forced_alignment/native/espeak-ng-data/lang/
 

--- a/test/core/platform/espeak_android_assets_test.dart
+++ b/test/core/platform/espeak_android_assets_test.dart
@@ -1,0 +1,44 @@
+import 'package:enjoy_player/core/platform/espeak_android_provisioner.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forced_alignment/forced_alignment.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'Flutter asset bundle includes eSpeak lang/en-us (SetVoiceByName)',
+    () async {
+      final files = await loadEspeakDataAssets();
+      final keys = files.keys.toList()..sort();
+
+      expect(
+        files.keys.toSet().containsAll(kEspeakRequiredDataRelativePaths),
+        isTrue,
+        reason:
+            'Android IPA uses espeak_SetVoiceByName on nested lang/ files. '
+            'missing=${kEspeakRequiredDataRelativePaths.where((p) => !files.containsKey(p)).toList()} '
+            'keys=$keys',
+      );
+    },
+  );
+
+  test('AssetManifest lists nested espeak lang files', () async {
+    final manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+    final espeakKeys =
+        manifest
+            .listAssets()
+            .where(
+              (k) => k.startsWith(
+                'packages/forced_alignment/native/espeak-ng-data/',
+              ),
+            )
+            .toList()
+          ..sort();
+    expect(
+      espeakKeys.any((k) => k.endsWith('/lang/en-us')),
+      isTrue,
+      reason: 'manifest espeak keys=$espeakKeys',
+    );
+  });
+}

--- a/test/core/platform/espeak_android_provisioner_test.dart
+++ b/test/core/platform/espeak_android_provisioner_test.dart
@@ -23,6 +23,8 @@ void main() {
     'phontab': Uint8List.fromList([1, 2, 3]),
     'en_dict': Uint8List.fromList([4, 5]),
     'lang/en': Uint8List.fromList([6]),
+    for (final voice in kEspeakVoiceByLanguageTag.values)
+      'lang/$voice': Uint8List.fromList([7]),
   };
 
   Future<Map<String, Uint8List>> countingLoader() async {
@@ -75,6 +77,10 @@ void main() {
     expect(File(p.join(expectedDataPath(), 'phontab')).existsSync(), isTrue);
     expect(File(p.join(expectedDataPath(), 'lang', 'en')).existsSync(), isTrue);
     expect(
+      File(p.join(expectedDataPath(), 'lang', 'en-us')).existsSync(),
+      isTrue,
+    );
+    expect(
       File(
         p.join(supportPath, 'espeak-ng', kEspeakDataRevision, '.provisioned'),
       ).existsSync(),
@@ -106,17 +112,15 @@ void main() {
     expect(resolveEspeakDataPath(), expectedDataPath());
   });
 
-  test('missing vendored library fails closed without pinning', () async {
+  test('missing on-disk library still pins soname and extracts data', () async {
     mockNativeLibraryDir(p.join(tempRoot.path, 'no_such_dir'));
 
     final ok = await ensureAndroidEspeakRuntime(loadData: countingLoader);
 
-    expect(ok, isFalse);
-    expect(loadCalls, 0);
-    expect(
-      resolveEspeakLibraryPath(),
-      isNot(p.join(tempRoot.path, 'no_such_dir', 'libespeak-ng.so')),
-    );
+    expect(ok, isTrue);
+    expect(loadCalls, 1);
+    expect(resolveEspeakLibraryPath(), kEspeakAndroidSoname);
+    expect(resolveEspeakDataPath(), expectedDataPath());
   });
 
   test('channel failure fails closed', () async {
@@ -139,5 +143,36 @@ void main() {
 
     expect(ok, isFalse);
     expect(Directory(expectedDataPath()).existsSync(), isFalse);
+  });
+
+  test('asset bundle without lang/en-us fails closed', () async {
+    mockNativeLibraryDir(nativeLibDir.path);
+
+    final ok = await ensureAndroidEspeakRuntime(
+      loadData: () async => {
+        'phontab': Uint8List.fromList([1, 2, 3]),
+        'lang/en': Uint8List.fromList([6]),
+      },
+    );
+
+    expect(ok, isFalse);
+    expect(Directory(expectedDataPath()).existsSync(), isFalse);
+  });
+
+  test('stale extract missing lang/en-us re-extracts voices', () async {
+    mockNativeLibraryDir(nativeLibDir.path);
+    final revisionDir = Directory(
+      p.join(supportPath, 'espeak-ng', kEspeakDataRevision),
+    );
+    final dataDir = Directory(p.join(revisionDir.path, 'espeak-ng-data'));
+    dataDir.createSync(recursive: true);
+    File(p.join(revisionDir.path, '.provisioned')).writeAsStringSync('1');
+    File(p.join(dataDir.path, 'phontab')).writeAsBytesSync([1]);
+
+    final ok = await ensureAndroidEspeakRuntime(loadData: countingLoader);
+
+    expect(ok, isTrue);
+    expect(loadCalls, 1);
+    expect(File(p.join(dataDir.path, 'lang', 'en-us')).existsSync(), isTrue);
   });
 }

--- a/test/data/subtitle/alignment_language_test.dart
+++ b/test/data/subtitle/alignment_language_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:enjoy_player/data/subtitle/alignment_language.dart';
+
+void main() {
+  test('YouTube InnerTube en maps onto the alignment catalog', () {
+    expect(alignmentLanguageForTranscript('en'), 'en-US');
+    expect(alignmentLanguageForTranscript('en-US'), 'en-US');
+    expect(alignmentLanguageForTranscript('en-GB'), 'en-GB');
+  });
+
+  test('unsupported transcript languages fail closed', () {
+    expect(alignmentLanguageForTranscript('zh-CN'), isNull);
+    expect(alignmentLanguageForTranscript('zh-Hans'), isNull);
+    expect(alignmentLanguageForTranscript('und'), isNull);
+    expect(alignmentLanguageForTranscript(''), isNull);
+  });
+}

--- a/test/features/transcript/application/transcript_enrichment_youtube_test.dart
+++ b/test/features/transcript/application/transcript_enrichment_youtube_test.dart
@@ -54,7 +54,7 @@ void main() {
       final outcome = await enricher.enrich(
         transcriptId: 't1',
         lines: _lineOnly,
-        language: 'en-US',
+        language: 'en',
         extractable: false,
         localPath: 'https://youtube.example/watch',
       );
@@ -74,4 +74,52 @@ void main() {
       expect(readiness.showEnrich, isFalse);
     },
   );
+
+  test('YouTube phonemize strips subtitle markup before eSpeak', () async {
+    late List<String> seen;
+    final enricher = TranscriptEnricher(
+      replaceTimeline: ({required transcriptId, required lines}) async => true,
+      decodeFile: (path) async => fail('YouTube must not decode PCM'),
+      decodeWindow:
+          ({
+            required pathOrUri,
+            required startSeconds,
+            required durationSeconds,
+          }) async {
+            fail('YouTube must not window-extract');
+          },
+      alignSegmentsFn:
+          ({
+            required sourcePcm16k,
+            required language,
+            required segments,
+            required granularity,
+            cancel,
+          }) async {
+            fail('YouTube must not alignSegments');
+          },
+      phonemizeFn: ({required texts, required language, cancel}) async {
+        seen = texts;
+        return const PhonemizeSuccess([
+          PhonemizeLineResult(
+            words: [
+              PhonemeWord(text: 'Hello', phones: ['h']),
+            ],
+          ),
+        ]);
+      },
+    );
+
+    final outcome = await enricher.enrich(
+      transcriptId: 't1',
+      lines: const [
+        TranscriptLine(text: '<font>Hello</font>', startMs: 0, durationMs: 700),
+      ],
+      language: 'en',
+      extractable: false,
+    );
+
+    expect(outcome, isA<TranscriptEnrichmentOk>());
+    expect(seen, ['Hello']);
+  });
 }


### PR DESCRIPTION
## Summary
- Flutter does not recurse directory assets, so Android APKs shipped eSpeak `phontab` but not nested `lang/en-us`. `espeak_SetVoiceByName(en-us)` failed and YouTube IPA generation reported `spokenReferenceUnavailable`.
- Declare `espeak-ng-data/lang/` as its own Flutter asset, bump the extract revision so existing installs re-provision, and refuse to succeed without required voice files.
- Phonemize YouTube captions without copying PCM onto the Dart heap, fail closed when every line phonemizes empty, strip subtitle markup, and assert mapped `lang/` voices in Android APKs and iOS/macOS app bundles.

Windows learner-visible IPA is unchanged (it reads the source-tree files on disk). iOS/macOS already copied the full tree via Xcode; this adds tests and CI so those layouts cannot silently drop voices.

## Test plan
- [ ] `flutter test test/core/platform/espeak_android_assets_test.dart test/core/platform/espeak_android_provisioner_test.dart test/data/subtitle/alignment_language_test.dart test/features/transcript/application/transcript_enrichment_youtube_test.dart packages/forced_alignment/test/bundled_espeak_test.dart`
- [ ] Android: Generate IPA on a YouTube video (e.g. TED `6YNOQTqNfgQ`) — should succeed; logs should not include `espeak_SetVoiceByName(en-us) failed`
- [ ] Windows YouTube IPA still works
- [ ] Android APK smoke CI greps for `lang/en-us`, not only `phontab`
- [ ] Apple smoke builds contain `lang/en-us` in the `.app`
