### PR TITLE
fix(transcript): FFmpegKit alignment on mobile + cue progress

### DIFF
--- a/docs/features/transcript.md
+++ b/docs/features/transcript.md
@@ -234,9 +234,14 @@ duration-model tone stand-in. Missing voice → `spokenReferenceUnavailable`.
 [ADR-0076](../decisions/0076-stacked-ipa-player-controls.md)):
 every real (non-dedupe) Craft write attempts `alignSegments` and may attach
 nested spans onto spec 030 lines. **On-demand enrich** ([ADR-0078](../decisions/0078-on-demand-transcript-enrichment.md))
-is the CC-sheet button: owned local files run `alignSegments` / per-cue
-`align()`; YouTube phonemizes caption text (untimed words + IPA labels, no
-demux). Karaoke highlight ([ADR-0074](../decisions/0074-karaoke-word-highlight.md))
+is the CC-sheet button: owned local files extract 16 kHz mono PCM via
+[`pcm16k_mono.dart`](../../lib/data/audio/pcm16k_mono.dart) (**FFmpegKit** on
+Android/iOS/macOS; CLI `ffmpeg` on Windows and Linux, including a binary next
+to the Linux app/AppImage). While a long file runs per-cue extract + `align()`,
+the enrich tile shows **cue N of M** plus a determinate bar and stays tappable
+to cancel. YouTube phonemizes
+caption text (untimed words + IPA labels, no demux). Karaoke highlight
+([ADR-0074](../decisions/0074-karaoke-word-highlight.md))
 and IPA display ([ADR-0076](../decisions/0076-stacked-ipa-player-controls.md))
 only **read** stored spans when their player transcript toggles are on **and**
 capability gating allows it; they do not run alignment on open/play/seek.

--- a/lib/core/presentation/loading_icon.dart
+++ b/lib/core/presentation/loading_icon.dart
@@ -8,18 +8,26 @@ class LoadingIcon extends StatelessWidget {
     this.size = 18,
     this.strokeWidth = 2,
     this.color,
+    this.value,
   });
 
   final double size;
   final double strokeWidth;
   final Color? color;
 
+  /// When non-null, draws a determinate spinner (`0…1`).
+  final double? value;
+
   @override
   Widget build(BuildContext context) {
     return SizedBox(
       width: size,
       height: size,
-      child: CircularProgressIndicator(strokeWidth: strokeWidth, color: color),
+      child: CircularProgressIndicator(
+        strokeWidth: strokeWidth,
+        color: color,
+        value: value,
+      ),
     );
   }
 }

--- a/lib/data/audio/pcm16k_mono.dart
+++ b/lib/data/audio/pcm16k_mono.dart
@@ -3,11 +3,17 @@ library;
 
 import 'dart:io';
 import 'dart:math' as math;
-import 'dart:typed_data';
 
+import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_new/return_code.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:forced_alignment/forced_alignment.dart';
 
+import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/data/files/ffmpeg_media_probe.dart';
+
+final _log = logNamed('audio.pcm16k');
 
 /// Thrown when Craft bytes cannot be decoded to 16 kHz mono PCM.
 final class Pcm16kDecodeException implements Exception {
@@ -21,7 +27,9 @@ final class Pcm16kDecodeException implements Exception {
 /// Turns WAV (or other FFmpeg-decodable) bytes into 16 kHz mono [Float32List].
 ///
 /// PCM WAV is decoded in-process. Other encodings fall back to a temp-file
-/// FFmpeg convert (`pcm_s16le -ar 16000 -ac 1`). Does not import ASR.
+/// FFmpeg convert (`pcm_s16le -ar 16000 -ac 1`): CLI when a binary is on PATH
+/// (Windows bundled / Linux), otherwise FFmpegKit (Android / iOS / macOS).
+/// Does not import ASR.
 Future<Float32List> decodeToPcm16kMono(Uint8List bytes) async {
   final inProcess = decodePcmWavTo16kMono(bytes);
   if (inProcess != null && inProcess.isNotEmpty) {
@@ -41,6 +49,9 @@ Future<Float32List> decodeFileToPcm16kMono(String pathOrUri) async {
 }
 
 /// Decode a time window of a local media file to 16 kHz mono Float32.
+///
+/// Uses **FFmpegKit** on Android / iOS / macOS. Windows and Linux run a CLI
+/// `ffmpeg` (bundled next to the app, or on PATH).
 Future<Float32List> decodeFileWindowToPcm16kMono({
   required String pathOrUri,
   required double startSeconds,
@@ -50,38 +61,18 @@ Future<Float32List> decodeFileWindowToPcm16kMono({
   if (!File(input).existsSync()) {
     throw Pcm16kDecodeException('file does not exist: $input');
   }
-  final ffmpeg = await FfmpegMediaProbe.resolveFfmpegExecutable();
-  if (ffmpeg == null) {
-    throw const Pcm16kDecodeException('ffmpeg unavailable');
-  }
   final start = startSeconds < 0 ? 0.0 : startSeconds;
   final duration = durationSeconds <= 0 ? 0.05 : durationSeconds;
   final dir = await Directory.systemTemp.createTemp('enjoy_pcm16k_win_');
   try {
     final output = File('${dir.path}${Platform.pathSeparator}out.wav');
-    final result = await Process.run(ffmpeg, [
-      '-hide_banner',
-      '-nostdin',
-      '-y',
-      '-ss',
-      start.toStringAsFixed(3),
-      '-t',
-      duration.toStringAsFixed(3),
-      '-i',
-      input,
-      '-ar',
-      '$kAlignmentSampleRate',
-      '-ac',
-      '1',
-      '-c:a',
-      'pcm_s16le',
-      output.path,
-    ]);
-    if (result.exitCode != 0 || !output.existsSync()) {
-      throw Pcm16kDecodeException(
-        'ffmpeg window extract failed (exit ${result.exitCode})',
-      );
-    }
+    await _runFfmpegToWav(
+      input: input,
+      outputPath: output.path,
+      startSeconds: start,
+      durationSeconds: duration,
+      failLabel: 'window extract',
+    );
     final decoded = decodePcmWavTo16kMono(
       Uint8List.fromList(await output.readAsBytes()),
     );
@@ -105,32 +96,16 @@ Float32List? decodePcmWavTo16kMono(Uint8List bytes) {
 }
 
 Future<Float32List> _ffmpegFallback(Uint8List bytes) async {
-  final ffmpeg = await FfmpegMediaProbe.resolveFfmpegExecutable();
-  if (ffmpeg == null) {
-    throw const Pcm16kDecodeException('ffmpeg unavailable');
-  }
   final dir = await Directory.systemTemp.createTemp('enjoy_pcm16k_');
   try {
     final input = File('${dir.path}${Platform.pathSeparator}in.bin');
     final output = File('${dir.path}${Platform.pathSeparator}out.wav');
     await input.writeAsBytes(bytes, flush: true);
-    final result = await Process.run(ffmpeg, [
-      '-hide_banner',
-      '-nostdin',
-      '-y',
-      '-i',
-      input.path,
-      '-ar',
-      '$kAlignmentSampleRate',
-      '-ac',
-      '1',
-      '-c:a',
-      'pcm_s16le',
-      output.path,
-    ]);
-    if (result.exitCode != 0 || !output.existsSync()) {
-      throw Pcm16kDecodeException('ffmpeg failed (exit ${result.exitCode})');
-    }
+    await _runFfmpegToWav(
+      input: input.path,
+      outputPath: output.path,
+      failLabel: 'convert',
+    );
     final outBytes = await output.readAsBytes();
     final decoded = decodePcmWavTo16kMono(Uint8List.fromList(outBytes));
     if (decoded == null || decoded.isEmpty) {
@@ -141,6 +116,77 @@ Future<Float32List> _ffmpegFallback(Uint8List bytes) async {
     try {
       await dir.delete(recursive: true);
     } on Object catch (_) {}
+  }
+}
+
+/// Android / iOS / macOS ship FFmpegKit. Windows / Linux use a CLI binary.
+@visibleForTesting
+bool pcm16kUsesFfmpegKit({
+  required bool isAndroid,
+  required bool isIOS,
+  required bool isMacOS,
+}) => isAndroid || isIOS || isMacOS;
+
+/// Windows/Linux: bundled or PATH `ffmpeg`. Android/iOS/macOS: FFmpegKit
+/// (there is no CLI binary in those app packages).
+Future<void> _runFfmpegToWav({
+  required String input,
+  required String outputPath,
+  required String failLabel,
+  double? startSeconds,
+  double? durationSeconds,
+}) async {
+  final args = <String>[
+    '-hide_banner',
+    '-nostdin',
+    '-y',
+    if (startSeconds != null) ...['-ss', startSeconds.toStringAsFixed(3)],
+    if (durationSeconds != null) ...['-t', durationSeconds.toStringAsFixed(3)],
+    '-i',
+    input,
+    '-vn',
+    '-ar',
+    '$kAlignmentSampleRate',
+    '-ac',
+    '1',
+    '-c:a',
+    'pcm_s16le',
+    outputPath,
+  ];
+
+  if (!pcm16kUsesFfmpegKit(
+    isAndroid: Platform.isAndroid,
+    isIOS: Platform.isIOS,
+    isMacOS: Platform.isMacOS,
+  )) {
+    final ffmpeg = await FfmpegMediaProbe.resolveFfmpegExecutable();
+    if (ffmpeg == null) {
+      throw const Pcm16kDecodeException('ffmpeg unavailable');
+    }
+    final result = await Process.run(ffmpeg, args);
+    if (result.exitCode != 0 || !File(outputPath).existsSync()) {
+      _log.fine('ffmpeg $failLabel failed (exit ${result.exitCode})');
+      throw Pcm16kDecodeException(
+        'ffmpeg $failLabel failed (exit ${result.exitCode})',
+      );
+    }
+    return;
+  }
+
+  try {
+    final session = await FFmpegKit.executeWithArguments(args);
+    final code = await session.getReturnCode();
+    if (!ReturnCode.isSuccess(code) || !File(outputPath).existsSync()) {
+      _log.fine('FFmpegKit $failLabel failed: ${await session.getOutput()}');
+      throw Pcm16kDecodeException(
+        'ffmpeg $failLabel failed (exit ${code?.getValue() ?? -1})',
+      );
+    }
+  } on Pcm16kDecodeException {
+    rethrow;
+  } on MissingPluginException catch (e, st) {
+    _log.fine('FFmpegKit not registered', e, st);
+    throw const Pcm16kDecodeException('ffmpeg unavailable');
   }
 }
 

--- a/lib/data/files/ffmpeg_media_probe.dart
+++ b/lib/data/files/ffmpeg_media_probe.dart
@@ -18,31 +18,51 @@ class FfmpegMediaProbe {
   /// same in-flight [Future].
   static Future<String?>? _resolvedFuture;
 
-  /// Bundled `ffmpeg.exe` next to the app, or `ffmpeg` on PATH (Windows),
-  /// or `ffmpeg` on PATH elsewhere. The result is memoized for the process
-  /// lifetime (see [_resolvedFuture]).
+  /// Bundled CLI next to the app (Windows `ffmpeg.exe`, Linux `ffmpeg`), or
+  /// `ffmpeg` on PATH. Android / iOS / macOS do not use this — they run
+  /// FFmpegKit. The result is memoized for the process lifetime
+  /// (see [_resolvedFuture]).
   static Future<String?> resolveFfmpegExecutable() {
     return _resolvedFuture ??= _resolveFfmpegExecutableUncached();
   }
 
   static Future<String?> _resolveFfmpegExecutableUncached() async {
-    if (Platform.isWindows) {
-      final bundled = p.join(
-        p.dirname(Platform.resolvedExecutable),
-        'ffmpeg.exe',
-      );
-      if (File(bundled).existsSync()) return bundled;
-      try {
-        final r = await Process.run('ffmpeg', ['-version']);
-        if (r.exitCode == 0) return 'ffmpeg';
-      } on Object catch (_) {}
-      return null;
+    final dir = p.dirname(Platform.resolvedExecutable);
+    for (final candidate in bundledFfmpegCandidatePaths(
+      executableDir: dir,
+      isWindows: Platform.isWindows,
+      isLinux: Platform.isLinux,
+    )) {
+      if (File(candidate).existsSync()) return candidate;
     }
     try {
       final r = await Process.run('ffmpeg', ['-version']);
       if (r.exitCode == 0) return 'ffmpeg';
     } on Object catch (_) {}
     return null;
+  }
+
+  /// Windows: `ffmpeg.exe` next to the app. Linux: `ffmpeg` next to the app
+  /// or under `lib/` (AppImage / desktop bundle). Empty on Apple/Android.
+  @visibleForTesting
+  static List<String> bundledFfmpegCandidatePaths({
+    required String executableDir,
+    required bool isWindows,
+    required bool isLinux,
+  }) {
+    if (isWindows) {
+      return [
+        p.Context(style: p.Style.windows).join(executableDir, 'ffmpeg.exe'),
+      ];
+    }
+    if (isLinux) {
+      final join = p.Context(style: p.Style.posix).join;
+      return [
+        join(executableDir, 'ffmpeg'),
+        join(executableDir, 'lib', 'ffmpeg'),
+      ];
+    }
+    return const [];
   }
 
   /// Test seam: clears the memoized resolution so the next call re-probes.

--- a/lib/features/transcript/application/transcript_enrichment_controller.dart
+++ b/lib/features/transcript/application/transcript_enrichment_controller.dart
@@ -25,29 +25,56 @@ enum TranscriptEnrichmentPhase { idle, running, failed, succeeded }
 
 @immutable
 class TranscriptEnrichmentState {
-  const TranscriptEnrichmentState({required this.phase, this.failureReason});
+  const TranscriptEnrichmentState({
+    required this.phase,
+    this.failureReason,
+    this.completed = 0,
+    this.total = 0,
+  });
 
   const TranscriptEnrichmentState.idle()
     : phase = TranscriptEnrichmentPhase.idle,
-      failureReason = null;
+      failureReason = null,
+      completed = 0,
+      total = 0;
 
-  const TranscriptEnrichmentState.running()
+  const TranscriptEnrichmentState.running({this.completed = 0, this.total = 0})
     : phase = TranscriptEnrichmentPhase.running,
       failureReason = null;
 
   const TranscriptEnrichmentState.succeeded()
     : phase = TranscriptEnrichmentPhase.succeeded,
-      failureReason = null;
+      failureReason = null,
+      completed = 0,
+      total = 0;
 
   const TranscriptEnrichmentState.failed(this.failureReason)
-    : phase = TranscriptEnrichmentPhase.failed;
+    : phase = TranscriptEnrichmentPhase.failed,
+      completed = 0,
+      total = 0;
 
   final TranscriptEnrichmentPhase phase;
   final String? failureReason;
 
+  /// Cues finished in the current run. Meaningful while [isRunning].
+  final int completed;
+
+  /// Cue count for the current run. `0` means progress is still unknown.
+  final int total;
+
   bool get isRunning => phase == TranscriptEnrichmentPhase.running;
   bool get isFailed => phase == TranscriptEnrichmentPhase.failed;
+
+  /// `0…1` while running with a known total; otherwise null (indeterminate).
+  double? get fraction {
+    if (!isRunning || total <= 0) return null;
+    return (completed / total).clamp(0.0, 1.0);
+  }
 }
+
+/// Cue-level progress for a long owned-media align (hundreds of windows).
+typedef EnrichProgressFn =
+    void Function({required int completed, required int total});
 
 typedef DecodeFilePcm16k = Future<Float32List> Function(String pathOrUri);
 
@@ -135,6 +162,7 @@ final class TranscriptEnricher {
     required bool extractable,
     String? localPath,
     AlignmentCancelToken? cancel,
+    EnrichProgressFn? onProgress,
   }) async {
     if (lines.isEmpty) {
       return const TranscriptEnrichmentErr('empty');
@@ -160,6 +188,7 @@ final class TranscriptEnricher {
         lines: lines,
         language: alignmentLanguage,
         cancel: cancel,
+        onProgress: onProgress,
       );
     }
     if (localPath == null || localPath.isEmpty || _looksRemote(localPath)) {
@@ -171,6 +200,7 @@ final class TranscriptEnricher {
       language: alignmentLanguage,
       localPath: localPath,
       cancel: cancel,
+      onProgress: onProgress,
     );
   }
 
@@ -179,7 +209,9 @@ final class TranscriptEnricher {
     required List<TranscriptLine> lines,
     required String language,
     AlignmentCancelToken? cancel,
+    EnrichProgressFn? onProgress,
   }) async {
+    onProgress?.call(completed: 0, total: lines.length);
     late final PhonemizeOutcome outcome;
     try {
       outcome = await _phonemize(
@@ -205,6 +237,7 @@ final class TranscriptEnricher {
       case PhonemizeSuccess(lines: final phonemeLines):
         try {
           final attached = attachPhonemesToLines(lines, phonemeLines);
+          onProgress?.call(completed: lines.length, total: lines.length);
           return await _persistIfChanged(
             transcriptId: transcriptId,
             original: lines,
@@ -226,6 +259,7 @@ final class TranscriptEnricher {
     required String language,
     required String localPath,
     AlignmentCancelToken? cancel,
+    EnrichProgressFn? onProgress,
   }) async {
     final lastEnd = lines
         .map((l) => l.endSeconds)
@@ -237,6 +271,7 @@ final class TranscriptEnricher {
         language: language,
         localPath: localPath,
         cancel: cancel,
+        onProgress: onProgress,
       );
     }
     return _enrichWindows(
@@ -245,6 +280,7 @@ final class TranscriptEnricher {
       language: language,
       localPath: localPath,
       cancel: cancel,
+      onProgress: onProgress,
     );
   }
 
@@ -254,7 +290,9 @@ final class TranscriptEnricher {
     required String language,
     required String localPath,
     AlignmentCancelToken? cancel,
+    EnrichProgressFn? onProgress,
   }) async {
+    onProgress?.call(completed: 0, total: lines.length);
     late final Float32List pcm;
     try {
       pcm = await _decodeFile(localPath);
@@ -305,6 +343,7 @@ final class TranscriptEnricher {
       case AlignmentSuccess(:final result):
         try {
           final attached = attachAlignmentToLines(lines, result);
+          onProgress?.call(completed: lines.length, total: lines.length);
           return await _persistIfChanged(
             transcriptId: transcriptId,
             original: lines,
@@ -326,68 +365,74 @@ final class TranscriptEnricher {
     required String language,
     required String localPath,
     AlignmentCancelToken? cancel,
+    EnrichProgressFn? onProgress,
   }) async {
+    onProgress?.call(completed: 0, total: lines.length);
     final segments = <TimelineEntry>[];
     for (var i = 0; i < lines.length; i++) {
       if (cancel?.isCancelled ?? false) {
         return const TranscriptEnrichmentErr('cancelled');
       }
-      final line = lines[i];
-      if (line.text.trim().isEmpty) continue;
-      final start = math.max(0.0, line.startSeconds - kCuePadSeconds);
-      final duration =
-          (line.endSeconds - line.startSeconds) + (2 * kCuePadSeconds);
-      late final Float32List pcm;
       try {
-        pcm = await _decodeWindow(
-          pathOrUri: localPath,
-          startSeconds: start,
-          durationSeconds: duration <= 0 ? kMinAudioSeconds : duration,
-        );
-      } on Object catch (e, st) {
-        logNamed(
-          'transcript.enrichment',
-        ).warning('window extract failed for cue $i: $e', e, st);
-        continue;
-      }
-      if (pcm.isEmpty) continue;
-
-      late final AlignmentOutcome outcome;
-      try {
-        outcome = await _align(
-          sourcePcm16k: pcm,
-          transcript: line.text,
-          language: language,
-          cancel: cancel,
-          timeOffset: start,
-        );
-      } on Object catch (e, st) {
-        logNamed(
-          'transcript.enrichment',
-        ).warning('align threw for cue $i: $e', e, st);
-        continue;
-      }
-      switch (outcome) {
-        case AlignmentFailed():
-          continue;
-        case AlignmentSuccess(:final result):
-          final tagged = result.timeline.where(
-            (e) => e.type == TimelineEntryType.segment,
+        final line = lines[i];
+        if (line.text.trim().isEmpty) continue;
+        final start = math.max(0.0, line.startSeconds - kCuePadSeconds);
+        final duration =
+            (line.endSeconds - line.startSeconds) + (2 * kCuePadSeconds);
+        late final Float32List pcm;
+        try {
+          pcm = await _decodeWindow(
+            pathOrUri: localPath,
+            startSeconds: start,
+            durationSeconds: duration <= 0 ? kMinAudioSeconds : duration,
           );
-          if (tagged.isEmpty) {
-            segments.add(
-              TimelineEntry(
-                type: TimelineEntryType.segment,
-                text: line.text,
-                startTime: line.startSeconds,
-                endTime: line.endSeconds,
-                id: i,
-                timeline: result.wordTimeline,
-              ),
+        } on Object catch (e, st) {
+          logNamed(
+            'transcript.enrichment',
+          ).warning('window extract failed for cue $i: $e', e, st);
+          continue;
+        }
+        if (pcm.isEmpty) continue;
+
+        late final AlignmentOutcome outcome;
+        try {
+          outcome = await _align(
+            sourcePcm16k: pcm,
+            transcript: line.text,
+            language: language,
+            cancel: cancel,
+            timeOffset: start,
+          );
+        } on Object catch (e, st) {
+          logNamed(
+            'transcript.enrichment',
+          ).warning('align threw for cue $i: $e', e, st);
+          continue;
+        }
+        switch (outcome) {
+          case AlignmentFailed():
+            continue;
+          case AlignmentSuccess(:final result):
+            final tagged = result.timeline.where(
+              (e) => e.type == TimelineEntryType.segment,
             );
-          } else {
-            segments.add(tagged.first.copyWithId(i));
-          }
+            if (tagged.isEmpty) {
+              segments.add(
+                TimelineEntry(
+                  type: TimelineEntryType.segment,
+                  text: line.text,
+                  startTime: line.startSeconds,
+                  endTime: line.endSeconds,
+                  id: i,
+                  timeline: result.wordTimeline,
+                ),
+              );
+            } else {
+              segments.add(tagged.first.copyWithId(i));
+            }
+        }
+      } finally {
+        onProgress?.call(completed: i + 1, total: lines.length);
       }
     }
 
@@ -555,6 +600,7 @@ class TranscriptEnrichmentController extends _$TranscriptEnrichmentController {
         _ => null,
       };
 
+      state = TranscriptEnrichmentState.running(total: lines.length);
       final outcome = await ref
           .read(transcriptEnricherProvider)
           .enrich(
@@ -564,6 +610,13 @@ class TranscriptEnrichmentController extends _$TranscriptEnrichmentController {
             extractable: extractable,
             localPath: localPath,
             cancel: token,
+            onProgress: ({required completed, required total}) {
+              if (!ref.mounted || id != _runId) return;
+              state = TranscriptEnrichmentState.running(
+                completed: completed,
+                total: total,
+              );
+            },
           );
       if (!ref.mounted || id != _runId) return;
       if (token.isCancelled) {

--- a/lib/features/transcript/presentation/transcript_busy_action.dart
+++ b/lib/features/transcript/presentation/transcript_busy_action.dart
@@ -73,6 +73,7 @@ class TranscriptBusyListTile extends StatefulWidget {
     this.busy,
     this.tapWhenBusy = false,
     this.contentPadding,
+    this.progress,
     super.key,
   });
 
@@ -87,6 +88,9 @@ class TranscriptBusyListTile extends StatefulWidget {
   /// When true, [onTap] stays enabled while busy (cancel / retry).
   final bool tapWhenBusy;
   final EdgeInsetsGeometry? contentPadding;
+
+  /// Determinate `0…1` while [busy]. Null keeps an indeterminate spinner.
+  final double? progress;
 
   @override
   State<TranscriptBusyListTile> createState() => _TranscriptBusyListTileState();
@@ -111,10 +115,11 @@ class _TranscriptBusyListTileState extends State<TranscriptBusyListTile> {
     final showBusy = widget.busy ?? _busy;
     final usesExternalBusy = widget.busy != null;
     final tapEnabled = widget.tapWhenBusy || !showBusy;
-    return ListTile(
+    final progress = showBusy ? widget.progress : null;
+    final tile = ListTile(
       contentPadding: widget.contentPadding,
       leading: showBusy
-          ? LoadingIcon(size: 24, color: cs.primary)
+          ? LoadingIcon(size: 24, color: cs.primary, value: progress)
           : Icon(widget.icon, size: 24, color: cs.onSurfaceVariant),
       title: Text(widget.title),
       subtitle: widget.subtitle == null ? null : Text(widget.subtitle!),
@@ -124,6 +129,14 @@ class _TranscriptBusyListTileState extends State<TranscriptBusyListTile> {
           : usesExternalBusy
           ? widget.onTap
           : _run,
+    );
+    if (progress == null) return tile;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        tile,
+        LinearProgressIndicator(minHeight: 2, value: progress.clamp(0.0, 1.0)),
+      ],
     );
   }
 }

--- a/lib/features/transcript/presentation/transcript_display_settings_sheet.dart
+++ b/lib/features/transcript/presentation/transcript_display_settings_sheet.dart
@@ -92,6 +92,9 @@ class TranscriptDisplaySettingsSection extends ConsumerWidget {
       final running = enrich.isRunning;
       final failed = enrich.isFailed;
       final owned = readiness.canTrustWordTimes;
+      final progressLabel = running && enrich.total > 0
+          ? l10n.transcriptEnrichProgress(enrich.completed, enrich.total)
+          : null;
       tiles.add(
         TranscriptBusyListTile(
           icon: Icons.auto_fix_high_outlined,
@@ -102,12 +105,15 @@ class TranscriptDisplaySettingsSection extends ConsumerWidget {
               : owned
               ? l10n.transcriptEnrichOwnedTitle
               : l10n.transcriptEnrichYoutubeTitle,
-          subtitle: failed
+          subtitle: running
+              ? (progressLabel ?? l10n.transcriptEnrichWorking)
+              : failed
               ? l10n.transcriptEnrichFailed
               : owned
               ? l10n.transcriptEnrichOwnedSubtitle
               : l10n.transcriptEnrichYoutubeSubtitle,
           busy: running,
+          progress: enrich.fraction,
           tapWhenBusy: true,
           onTap: () async {
             final ctrl = ref.read(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -637,6 +637,18 @@
   "@transcriptEnrichFailed": {
     "description": "Inline error on the enrich tile after failure or cancel."
   },
+  "transcriptEnrichWorking": "Generating…",
+  "@transcriptEnrichWorking": {
+    "description": "Busy enrich tile subtitle before the first cue reports progress."
+  },
+  "transcriptEnrichProgress": "{completed} of {total}",
+  "@transcriptEnrichProgress": {
+    "description": "Busy enrich tile subtitle while aligning cues on a long transcript.",
+    "placeholders": {
+      "completed": { "type": "int", "example": "12" },
+      "total": { "type": "int", "example": "240" }
+    }
+  },
   "settingsRecordingMicTitle": "Microphone",
   "@settingsRecordingMicTitle": {
     "description": "Title of the microphone picker tile in settings."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2007,6 +2007,18 @@ abstract class AppLocalizations {
   /// **'Couldn\'t generate. Tap to try again.'**
   String get transcriptEnrichFailed;
 
+  /// Busy enrich tile subtitle before the first cue reports progress.
+  ///
+  /// In en, this message translates to:
+  /// **'Generating…'**
+  String get transcriptEnrichWorking;
+
+  /// Busy enrich tile subtitle while aligning cues on a long transcript.
+  ///
+  /// In en, this message translates to:
+  /// **'{completed} of {total}'**
+  String transcriptEnrichProgress(int completed, int total);
+
   /// Title of the microphone picker tile in settings.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1065,6 +1065,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get transcriptEnrichFailed => 'Couldn\'t generate. Tap to try again.';
 
   @override
+  String get transcriptEnrichWorking => 'Generating…';
+
+  @override
+  String transcriptEnrichProgress(int completed, int total) {
+    return '$completed of $total';
+  }
+
+  @override
   String get settingsRecordingMicTitle => 'Microphone';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1013,6 +1013,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get transcriptEnrichFailed => '无法生成。点按重试。';
 
   @override
+  String get transcriptEnrichWorking => '正在生成…';
+
+  @override
+  String transcriptEnrichProgress(int completed, int total) {
+    return '$completed / $total';
+  }
+
+  @override
   String get settingsRecordingMicTitle => '麦克风';
 
   @override
@@ -4525,6 +4533,14 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get transcriptEnrichFailed => '无法生成。点按重试。';
+
+  @override
+  String get transcriptEnrichWorking => '正在生成…';
+
+  @override
+  String transcriptEnrichProgress(int completed, int total) {
+    return '$completed / $total';
+  }
 
   @override
   String get settingsRecordingMicTitle => '麦克风';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -457,6 +457,18 @@
   "@transcriptEnrichFailed": {
     "description": "Inline error on the enrich tile after failure or cancel."
   },
+  "transcriptEnrichWorking": "正在生成…",
+  "@transcriptEnrichWorking": {
+    "description": "Busy enrich tile subtitle before the first cue reports progress."
+  },
+  "transcriptEnrichProgress": "{completed} / {total}",
+  "@transcriptEnrichProgress": {
+    "description": "Busy enrich tile subtitle while aligning cues on a long transcript.",
+    "placeholders": {
+      "completed": { "type": "int", "example": "12" },
+      "total": { "type": "int", "example": "240" }
+    }
+  },
   "settingsRecordingMicTitle": "麦克风",
   "@settingsRecordingMicTitle": {
     "description": "Title of the microphone picker tile in settings."

--- a/lib/l10n/app_zh_CN.arb
+++ b/lib/l10n/app_zh_CN.arb
@@ -378,6 +378,18 @@
   "@transcriptEnrichFailed": {
     "description": "Inline error on the enrich tile after failure or cancel."
   },
+  "transcriptEnrichWorking": "正在生成…",
+  "@transcriptEnrichWorking": {
+    "description": "Busy enrich tile subtitle before the first cue reports progress."
+  },
+  "transcriptEnrichProgress": "{completed} / {total}",
+  "@transcriptEnrichProgress": {
+    "description": "Busy enrich tile subtitle while aligning cues on a long transcript.",
+    "placeholders": {
+      "completed": { "type": "int", "example": "12" },
+      "total": { "type": "int", "example": "240" }
+    }
+  },
   "settingsRecordingMicTitle": "麦克风",
   "@settingsRecordingMicTitle": {
     "description": "Title of the microphone picker tile in settings."

--- a/test/data/audio/pcm16k_file_decode_test.dart
+++ b/test/data/audio/pcm16k_file_decode_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:enjoy_player/data/audio/pcm16k_mono.dart';
@@ -20,4 +22,26 @@ void main() {
       throwsA(isA<Pcm16kDecodeException>()),
     );
   });
+
+  test(
+    'decodeFileWindowToPcm16kMono fails closed when FFmpeg cannot decode',
+    () async {
+      final junk = File(
+        '${Directory.systemTemp.path}${Platform.pathSeparator}'
+        'enjoy_pcm16k_not_media_${DateTime.now().microsecondsSinceEpoch}.bin',
+      );
+      await junk.writeAsBytes(const [0, 1, 2, 3, 4, 5, 6, 7], flush: true);
+      addTearDown(() {
+        if (junk.existsSync()) junk.deleteSync();
+      });
+      await expectLater(
+        decodeFileWindowToPcm16kMono(
+          pathOrUri: junk.path,
+          startSeconds: 0,
+          durationSeconds: 0.2,
+        ),
+        throwsA(isA<Pcm16kDecodeException>()),
+      );
+    },
+  );
 }

--- a/test/data/audio/pcm16k_mono_test.dart
+++ b/test/data/audio/pcm16k_mono_test.dart
@@ -78,4 +78,23 @@ void main() {
     expect(pcm, isNotEmpty);
     expect(pcm.length, closeTo(1600, 2));
   });
+
+  test('FFmpegKit is used on Android, iOS, and macOS only', () {
+    expect(
+      pcm16kUsesFfmpegKit(isAndroid: true, isIOS: false, isMacOS: false),
+      isTrue,
+    );
+    expect(
+      pcm16kUsesFfmpegKit(isAndroid: false, isIOS: true, isMacOS: false),
+      isTrue,
+    );
+    expect(
+      pcm16kUsesFfmpegKit(isAndroid: false, isIOS: false, isMacOS: true),
+      isTrue,
+    );
+    expect(
+      pcm16kUsesFfmpegKit(isAndroid: false, isIOS: false, isMacOS: false),
+      isFalse,
+    );
+  });
 }

--- a/test/data/files/ffmpeg_media_probe_test.dart
+++ b/test/data/files/ffmpeg_media_probe_test.dart
@@ -174,4 +174,39 @@ Stream #0:5(en): Subtitle: subrip
       // We don't assert on internal state; just that the seam is callable.
     });
   });
+
+  group('FfmpegMediaProbe.bundledFfmpegCandidatePaths', () {
+    test('Windows looks next to the exe', () {
+      expect(
+        FfmpegMediaProbe.bundledFfmpegCandidatePaths(
+          executableDir: r'C:\Program Files\Enjoy',
+          isWindows: true,
+          isLinux: false,
+        ),
+        [r'C:\Program Files\Enjoy\ffmpeg.exe'],
+      );
+    });
+
+    test('Linux looks next to the exe and under lib/', () {
+      expect(
+        FfmpegMediaProbe.bundledFfmpegCandidatePaths(
+          executableDir: '/opt/enjoy/bin',
+          isWindows: false,
+          isLinux: true,
+        ),
+        ['/opt/enjoy/bin/ffmpeg', '/opt/enjoy/bin/lib/ffmpeg'],
+      );
+    });
+
+    test('Apple and Android have no CLI bundle', () {
+      expect(
+        FfmpegMediaProbe.bundledFfmpegCandidatePaths(
+          executableDir: '/Applications/Enjoy.app',
+          isWindows: false,
+          isLinux: false,
+        ),
+        isEmpty,
+      );
+    });
+  });
 }

--- a/test/features/transcript/application/transcript_enrichment_owned_test.dart
+++ b/test/features/transcript/application/transcript_enrichment_owned_test.dart
@@ -287,4 +287,76 @@ void main() {
     expect(readiness.hasNestedWords, isTrue);
     expect(readiness.showEnrich, isFalse);
   });
+
+  test('window path reports cue progress including failed cues', () async {
+    final progress = <(int, int)>[];
+    final lines = [
+      const TranscriptLine(text: 'Hello', startMs: 0, durationMs: 1000),
+      const TranscriptLine(text: 'Later', startMs: 91000, durationMs: 1000),
+    ];
+    final enricher = TranscriptEnricher(
+      replaceTimeline: ({required transcriptId, required lines}) async => true,
+      decodeFile: (path) async => fail('long files must not decode whole clip'),
+      decodeWindow:
+          ({
+            required pathOrUri,
+            required startSeconds,
+            required durationSeconds,
+          }) async {
+            if (startSeconds > 10) throw StateError('window missing');
+            return Float32List(kAlignmentSampleRate);
+          },
+      alignFn:
+          ({
+            required sourcePcm16k,
+            required transcript,
+            required language,
+            cancel,
+            required timeOffset,
+          }) async {
+            return AlignmentSuccess(
+              AlignmentResult(
+                timeline: [
+                  TimelineEntry(
+                    type: TimelineEntryType.segment,
+                    text: transcript,
+                    startTime: timeOffset,
+                    endTime: timeOffset + 0.7,
+                    timeline: [
+                      TimelineEntry(
+                        type: TimelineEntryType.word,
+                        text: 'Hello',
+                        startTime: timeOffset,
+                        endTime: timeOffset + 0.7,
+                      ),
+                    ],
+                  ),
+                ],
+                wordTimeline: const [],
+                transcript: transcript,
+                language: language,
+                durationSeconds: 1,
+              ),
+            );
+          },
+      phonemizeFn: ({required texts, required language, cancel}) async {
+        fail('owned path must not phonemize');
+      },
+    );
+
+    await enricher.enrich(
+      transcriptId: 't1',
+      lines: lines,
+      language: 'en-US',
+      extractable: true,
+      localPath: '/tmp/long.wav',
+      onProgress: ({required completed, required total}) {
+        progress.add((completed, total));
+      },
+    );
+
+    expect(progress.first, (0, 2));
+    expect(progress, contains((1, 2)));
+    expect(progress.last, (2, 2));
+  });
 }

--- a/test/features/transcript/transcript_display_gating_test.dart
+++ b/test/features/transcript/transcript_display_gating_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/data/subtitle/transcript_display_readiness.dart';
 import 'package:enjoy_player/features/settings/application/karaoke_highlight_settings.dart';
+import 'package:enjoy_player/features/transcript/application/transcript_enrichment_controller.dart';
 import 'package:enjoy_player/features/transcript/presentation/subtitle_track_picker_primitives.dart';
 import 'package:enjoy_player/features/transcript/presentation/transcript_busy_action.dart';
 import 'package:enjoy_player/features/transcript/presentation/transcript_display_settings_sheet.dart';
@@ -27,12 +29,14 @@ class _SpyKaraoke extends KaraokeHighlightSettingsOverride {
 Widget _harness({
   required TranscriptDisplayReadiness readiness,
   required KaraokeHighlightSettings karaoke,
+  List<Override> extraOverrides = const [],
 }) {
   final scheme = ColorScheme.fromSeed(seedColor: const Color(0xFF003366));
   return ProviderScope(
     overrides: [
       karaokeHighlightSettingsProvider.overrideWith(() => karaoke),
       ...transcriptIpaOverlayOffOverrides(),
+      ...extraOverrides,
     ],
     child: MaterialApp(
       theme: ThemeData(
@@ -139,5 +143,34 @@ void main() {
       find.text(l10n.transcriptKaraokeUnavailableRemoteHint),
       findsOneWidget,
     );
+  });
+
+  testWidgets('running enrich tile shows cue progress', (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        karaoke: KaraokeHighlightSettingsOverride(false),
+        extraOverrides: [
+          transcriptEnrichmentControllerProvider(
+            'media-gating',
+          ).overrideWithValue(
+            const TranscriptEnrichmentState.running(completed: 12, total: 240),
+          ),
+        ],
+        readiness: const TranscriptDisplayReadiness(
+          hasNestedWords: false,
+          hasTimedWords: false,
+          hasPhones: false,
+          canTrustWordTimes: true,
+          karaokeSwitchEnabled: false,
+          ipaSwitchEnabled: false,
+          showEnrich: true,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text(l10n.transcriptEnrichCancel), findsOneWidget);
+    expect(find.text(l10n.transcriptEnrichProgress(12, 240)), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Owned-media transcript enrich failed on Android with `Pcm16kDecodeException(ffmpeg unavailable)` because PCM window extract only probed a CLI `ffmpeg` binary. Android/iOS/macOS now use FFmpegKit; Windows/Linux use bundled or PATH CLI (`ffmpeg` next to the Linux binary as well as PATH).
- Long transcripts report per-cue progress on the CC-sheet Generate tile (determinate spinner, bar, `N of M`) and stay tappable to cancel.
- Generated l10n for the new progress strings (`en` / `zh` / `zh_CN`).

## Test plan
- [ ] Android: open a local video, generate word timings — no `ffmpeg unavailable`; tile shows cue progress and cancel still works
- [ ] iOS / macOS: same generate path (FFmpegKit)
- [ ] Linux: CLI `ffmpeg` on PATH or next to the app; fail closed if missing
- [ ] Windows: unchanged bundled `ffmpeg.exe` path
- [ ] Short clip (<90s) still uses whole-file align; YouTube still IPA-only with no PCM extract
