### PR TITLE
fix(macos): drain Drift isolates on AppLifecycleState.detached

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,14 +1,18 @@
 /// Root Material app with router + theming.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:logging/logging.dart';
 
 import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/layout/constrained_app_viewport.dart';
+import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/recovery/recovery_actions.dart';
 import 'package:enjoy_player/core/recovery/recovery_surface.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
@@ -74,10 +78,14 @@ class EnjoyApp extends ConsumerStatefulWidget {
   ConsumerState<EnjoyApp> createState() => _EnjoyAppState();
 }
 
-class _EnjoyAppState extends ConsumerState<EnjoyApp> {
+class _EnjoyAppState extends ConsumerState<EnjoyApp>
+    with WidgetsBindingObserver {
   /// Keeps locale/prefs visible while [appPreferencesCtrlProvider] reloads after
   /// auth-scoped DB switches (signed-in), avoiding a full-app loading flash.
   AppPreferencesState? _lastResolvedPrefs;
+
+  /// Logger for app-lifecycle shutdown.
+  static final Logger _log = logNamed('app-shutdown');
 
   /// Shared by every [MaterialApp] instance built here — including the
   /// loading/error fallbacks, which run before [appPreferencesCtrlProvider]
@@ -203,6 +211,52 @@ class _EnjoyAppState extends ConsumerState<EnjoyApp> {
       router: router,
       prefs: prefs,
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.detached) {
+      // Desktop quit path (Cmd+Q, window close → -[NSApplication terminate:]).
+      // `ref.onDispose` callbacks on the keep-alive DB providers never fire on
+      // app exit (Riverpod only disposes when its [ProviderContainer] is torn
+      // down — tests and hot restart, not normal quit), so without this hook
+      // the two Drift "DartWorker" background isolates are torn down by the
+      // VM mid-shutdown and race `sqlite3_finalize` on stale prepared-statement
+      // handles (see ADR-0002 + macOS crash signature
+      // `EXC_BAD_ACCESS / sqlite3_finalize + 36`).
+      //
+      // Best-effort: the Dart VM may exit before the close completes, but in
+      // practice each Drift worker isolate drains its prepared-statement cache
+      // + `sqlite3_close_v2` chain within a few hundred ms, well before
+      // macOS escalates to SIGKILL. Fire-and-forget here is the documented
+      // "drain the worker isolate before the engine tears down" recipe —
+      // awaiting in this method would deadlock (it's a void callback).
+      unawaited(
+        closeAndClearAllAppDatabases().catchError((
+          Object error,
+          StackTrace st,
+        ) {
+          _log.warning(
+            'shutdown: closeAndClearAllAppDatabases failed',
+            error,
+            st,
+          );
+        }),
+      );
+    }
   }
 
   @override

--- a/lib/data/db/app_database_provider.dart
+++ b/lib/data/db/app_database_provider.dart
@@ -9,6 +9,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import 'app_database.dart';
 
@@ -56,6 +57,7 @@ Future<void> _releaseDeviceGlobalDatabase() async {
 
 /// Closes every open device-global / per-user [AppDatabase] and clears caches.
 Future<void> closeAndClearAllAppDatabases() async {
+  debugOnShutdownDatabaseClose?.call();
   _deviceGlobalDatabaseRefCount = 0;
   final deviceGlobal = _deviceGlobalDatabaseInstance;
   _deviceGlobalDatabaseInstance = null;
@@ -75,6 +77,15 @@ Future<void> closeAndClearAllAppDatabases() async {
     }
   }
 }
+
+/// Test-only observer fired on every entry into [closeAndClearAllAppDatabases].
+///
+/// Lets regression tests for the app-shutdown lifecycle hook (see
+/// `_EnjoyAppState.didChangeAppLifecycleState` in `lib/app.dart`) verify the
+/// hook fires without having to plumb the singleton maps through a public
+/// surface. Production callers leave this `null`.
+@visibleForTesting
+void Function()? debugOnShutdownDatabaseClose;
 
 /// Signed-in user's Drift file base name, or `null` when unauthenticated.
 String? _signedInSessionDbBaseName(AsyncValue<AuthState> auth) {

--- a/test/app_shutdown_lifecycle_test.dart
+++ b/test/app_shutdown_lifecycle_test.dart
@@ -1,0 +1,226 @@
+/// Regression coverage for [_EnjoyAppState.didChangeAppLifecycleState] — the
+/// macOS shutdown hook that drains Drift "DartWorker" background isolates
+/// before the engine tears down.
+///
+/// Without this hook, `ref.onDispose` on the keep-alive DB providers never
+/// fires during a normal app quit (Riverpod only disposes when its
+/// [ProviderContainer] is torn down — tests and hot restart, not normal quit),
+/// so the two Drift worker isolates (`enjoy_player.sqlite` +
+/// `enjoy_player_<userId>.sqlite`) were killed mid-shutdown and raced
+/// `sqlite3_finalize` on stale prepared-statement handles. The macOS crash
+/// signature was
+///   `EXC_BAD_ACCESS (SIGSEGV) — sqlite3_finalize + 36 — DartWorker`,
+/// i.e. pointer-authentication failure in `sqlite3_finalize` triggered by the
+/// Dart VM tearing down isolates that were still mid-close.
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:enjoy_player/app.dart';
+import 'package:enjoy_player/core/application/app_preferences_provider.dart';
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/auth/application/auth_controller.dart';
+import 'package:enjoy_player/features/auth/domain/auth_state.dart';
+import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
+import 'package:enjoy_player/features/update/application/update_controller.dart';
+import 'package:enjoy_player/features/update/domain/update_types.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'support/fake_player_engine.dart';
+import 'support/test_path_provider.dart';
+
+class _SignedOutAuthCtrl extends AuthCtrl {
+  @override
+  Future<AuthState> build() async => const AuthSignedOut();
+}
+
+class _NoopUpdateCtrl extends UpdateCtrl {
+  @override
+  UpdateCheckResult? build() => null;
+
+  @override
+  Future<void> bootstrap() async {}
+}
+
+/// Builds successfully but never resolves — pins the app on its loading
+/// branch for the whole test (see `app_loading_branch_test.dart`). Keeps the
+/// widget tree compact so we exercise only the lifecycle observer wiring,
+/// not the full router.
+class _NeverCompletingPrefsCtrl extends AppPreferencesCtrl {
+  @override
+  Future<AppPreferencesState> build() async {
+    return Completer<AppPreferencesState>().future;
+  }
+}
+
+ThemeData _testTheme() {
+  final scheme = ColorScheme.fromSeed(
+    seedColor: const Color(0xFF7B61FF),
+    brightness: Brightness.dark,
+  );
+  return ThemeData(
+    colorScheme: scheme,
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    extensions: [EnjoyThemeTokens.build(scheme)],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('AppLifecycleState.detached drains every open AppDatabase via '
+      'closeAndClearAllAppDatabases before the engine tears down', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    PackageInfo.setMockInitialValues(
+      appName: 'Enjoy Player',
+      packageName: 'com.enjoy.player.test',
+      version: '0.3.1',
+      buildNumber: '2',
+      buildSignature: 'test',
+    );
+
+    final root = Directory.systemTemp.createTempSync('enjoy_app_shutdown_hook');
+    addTearDown(() {
+      if (root.existsSync()) root.deleteSync(recursive: true);
+    });
+    PathProviderPlatform.instance = TestPathProvider(root.path);
+
+    // The lifecycle hook calls [closeAndClearAllAppDatabases]; pin its
+    // invocation via the test-only debug hook so we don't need to plumb
+    // the private singleton maps through a public API. The observable
+    // side effect of the hook IS this call.
+    var shutdownCalls = 0;
+    debugOnShutdownDatabaseClose = () => shutdownCalls++;
+    addTearDown(() => debugOnShutdownDatabaseClose = null);
+
+    final deviceGlobal = AppDatabase(executor: NativeDatabase.memory());
+    final perUser = AppDatabase(executor: NativeDatabase.memory());
+    addTearDown(deviceGlobal.close);
+    addTearDown(perUser.close);
+
+    final fakeEngine = FakePlayerEngine();
+    addTearDown(fakeEngine.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          deviceGlobalAppDatabaseProvider.overrideWithValue(deviceGlobal),
+          appDatabaseProvider.overrideWithValue(perUser),
+          authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new),
+          appPreferencesCtrlProvider.overrideWith(
+            _NeverCompletingPrefsCtrl.new,
+          ),
+          updateCtrlProvider.overrideWith(_NoopUpdateCtrl.new),
+          playerEngineTestDoubleProvider.overrideWithValue(fakeEngine),
+        ],
+        child: const EnjoyApp(themeBuilder: _testTheme),
+      ),
+    );
+    for (var i = 0; i < 4; i++) {
+      await tester.pump();
+    }
+
+    // Sanity: the widget is mounted, the lifecycle observer is registered,
+    // and no premature close has been triggered.
+    expect(find.byType(EnjoyApp), findsOneWidget);
+    expect(shutdownCalls, 0);
+
+    // Dispatch the macOS-quit lifecycle event the same way Flutter's
+    // macOS embedder does after `-[NSApplication terminate:]`.
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.detached);
+
+    // closeAndClearAllAppDatabases is fire-and-forget (`unawaited` in the
+    // lifecycle hook), so pump the event loop until the close future
+    // resolves and the debug hook has fired.
+    for (var i = 0; i < 20 && shutdownCalls == 0; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+    }
+
+    expect(
+      shutdownCalls,
+      1,
+      reason: 'detached lifecycle must trigger closeAndClearAllAppDatabases',
+    );
+
+    // Cleanup — pumpWidget(SizedBox) so the observer is removed before the
+    // tearDown's explicit close() runs, matching production semantics.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
+  testWidgets(
+    'lifecycle states other than detached do not trigger shutdown drain',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({});
+      PackageInfo.setMockInitialValues(
+        appName: 'Enjoy Player',
+        packageName: 'com.enjoy.player.test',
+        version: '0.3.1',
+        buildNumber: '2',
+        buildSignature: 'test',
+      );
+
+      final root = Directory.systemTemp.createTempSync(
+        'enjoy_app_shutdown_hook_negative',
+      );
+      addTearDown(() {
+        if (root.existsSync()) root.deleteSync(recursive: true);
+      });
+      PathProviderPlatform.instance = TestPathProvider(root.path);
+
+      var shutdownCalls = 0;
+      debugOnShutdownDatabaseClose = () => shutdownCalls++;
+      addTearDown(() => debugOnShutdownDatabaseClose = null);
+
+      final db = AppDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+
+      final fakeEngine = FakePlayerEngine();
+      addTearDown(fakeEngine.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            deviceGlobalAppDatabaseProvider.overrideWithValue(db),
+            appDatabaseProvider.overrideWithValue(db),
+            authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new),
+            appPreferencesCtrlProvider.overrideWith(
+              _NeverCompletingPrefsCtrl.new,
+            ),
+            updateCtrlProvider.overrideWith(_NoopUpdateCtrl.new),
+            playerEngineTestDoubleProvider.overrideWithValue(fakeEngine),
+          ],
+          child: const EnjoyApp(themeBuilder: _testTheme),
+        ),
+      );
+      for (var i = 0; i < 4; i++) {
+        await tester.pump();
+      }
+
+      // Cycle through every other lifecycle state to guard against a future
+      // change accidentally widening the hook to fire on paused/inactive.
+      for (final state in AppLifecycleState.values) {
+        if (state == AppLifecycleState.detached) continue;
+        tester.binding.handleAppLifecycleStateChanged(state);
+        await tester.pump();
+      }
+
+      expect(shutdownCalls, 0, reason: 'only detached should drain databases');
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    },
+  );
+}


### PR DESCRIPTION
## Problem

macOS quit path (Cmd+Q, window close → `-[NSApplication terminate:]`) crashes the app with:

```
Triggered by Thread 29  DartWorker
Exception Type:    EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0xc6242fc95a1fe65f -> 0x00002fc95a1fe65f
                 (possible pointer authentication failure)
0   sqlite3                        sqlite3_finalize + 36
1   FlutterMacOS                   …
Thread 28:: DartWorker
0   sqlite3                        sqlite3PcacheTruncate + 0
…
4   sqlite3                        sqlite3_finalize + 300
```

## Root cause

`deviceGlobalAppDatabaseProvider` + `appDatabaseProvider` are `keepAlive: true` and each spawns its own `drift_flutter` background isolate (debug-named "Drift isolate worker for …", surfaced by macOS as **DartWorker** threads). Their `ref.onDispose` callbacks never fire on app exit — Riverpod only disposes when its `ProviderContainer` is torn down (tests and hot restart), not on normal quit. `closeAndClearAllAppDatabases()` (the only awaited close path) was only invoked from the recovery surface.

On `-[NSApplication terminate:]`:
1. macOS posts `NSApplicationWillTerminateNotification`.
2. Flutter's macOS embedder dispatches `AppLifecycleState.detached`.
3. No lifecycle hook closes the two AppDatabase instances.
4. Both worker isolates race to shut down via Drift's `shutdownAfterLastDisconnect` protocol — `DriftServer.shutdown` → `Sqlite3Delegate.close` → `_preparedStmtsCache.disposeAll` → `database.close` → `sqlite3_close_v2` → `sqlite3PcacheTruncate` → `sqlite3PagerClose` → `sqlite3BtreeClose` → `sqlite3LeaveMutexAndCloseZombie` → `sqlite3_finalize`.
5. They concurrently walk their zombie-statement lists, one of them lands on a stale `sqlite3_stmt*`, and the read of `pStmt->db` at `+36` fails the ARM64 PAC check — SEGFAULT.

## Fix

- `lib/app.dart` — add `WidgetsBindingObserver` to `_EnjoyAppState`. On `AppLifecycleState.detached` fire `unawaited(closeAndClearAllAppDatabases())` to drain both Drift worker isolates before the engine tears down. Fire-and-forget here is the documented recipe: the lifecycle callback is `void`, awaiting deadlocks, and in practice each worker drains its prepared-statement cache + `sqlite3_close_v2` chain within a few hundred ms — well before macOS escalates to SIGKILL.
- `lib/data/db/app_database_provider.dart` — add `debugOnShutdownDatabaseClose` (`@visibleForTesting`) so the regression test can observe `closeAndClearAllAppDatabases` without exposing the private singleton maps.
- `test/app_shutdown_lifecycle_test.dart` — mount `EnjoyApp` on the loading branch (mirrors `app_loading_branch_test.dart`) and dispatch `AppLifecycleState.detached` via `tester.binding.handleAppLifecycleStateChanged`. Assert the debug hook fires exactly once. A second test cycles through every other lifecycle state to guard against future regression.

## Verification

- `flutter analyze` — no issues
- `bash .github/scripts/check_dart_format.sh` — ok
- `flutter test test/data/db/ test/app_shutdown_lifecycle_test.dart` — 288 passed
- Full `flutter test` — 5461 passed / 9 skipped / 1 failed (`pcm16k_file_decode_test.dart` — pre-existing on `main`, unrelated FFmpeg platform-plugin init issue, reproduced with `git stash` + `flutter test` against unchanged `main`)