### PR TITLE
fix(ios,macos): keep libespeak-ng.dylib in app bundle via Xcode Embed Frameworks

### DIFF
--- a/.github/scripts/check_bundled_espeak_data.sh
+++ b/.github/scripts/check_bundled_espeak_data.sh
@@ -2,12 +2,19 @@
 # Assert a packaged espeak-ng-data directory has phoneme tables + focus voices.
 # Keep the voice list in sync with kEspeakVoiceByLanguageTag.
 #
-# Usage: check_bundled_espeak_data.sh <path/to/espeak-ng-data>
+# Usage: check_bundled_espeak_data.sh <path/to/espeak-ng-data> [<path/to/libespeak-ng.dylib>]
+#
+# Pass the dylib path on iOS/macOS app bundles so we also assert the dynamic
+# library (DynamicLibrary.open at runtime) is present next to the data. The
+# dylib is embedded by the Xcode "Embed Frameworks" build phase, so a missing
+# dylib means the dylib was stripped by xcodebuild -exportArchive (the same
+# failure mode that drops the Swift stdlib dylibs in ITMS-90429).
 set -euo pipefail
 
 data="${1:-}"
+lib="${2:-}"
 if [ -z "${data}" ] || [ ! -d "${data}" ]; then
-  echo "usage: $0 <path/to/espeak-ng-data>" >&2
+  echo "usage: $0 <path/to/espeak-ng-data> [<path/to/libespeak-ng.dylib>]" >&2
   echo "missing directory: ${data:-<(empty)>}" >&2
   exit 1
 fi
@@ -26,4 +33,11 @@ for voice in "${voices[@]}"; do
   fi
 done
 
-echo "bundled eSpeak data ok: ${data}"
+if [ -n "${lib}" ]; then
+  if [ ! -f "${lib}" ]; then
+    echo "::error::missing ${lib} (DynamicLibrary.open will throw spokenReferenceUnavailable at runtime)" >&2
+    exit 1
+  fi
+fi
+
+echo "bundled eSpeak data ok: ${data}${lib:+ (lib=${lib})}"

--- a/.github/workflows/build_apple.yml
+++ b/.github/workflows/build_apple.yml
@@ -62,7 +62,9 @@ jobs:
           set -euo pipefail
           found=0
           while IFS= read -r app; do
-            bash .github/scripts/check_bundled_espeak_data.sh "${app}/espeak-ng-data"
+            bash .github/scripts/check_bundled_espeak_data.sh \
+              "${app}/espeak-ng-data" \
+              "${app}/Frameworks/libespeak-ng.dylib"
             found=1
           done < <(find build/ios/DerivedData/Build/Products -name Runner.app -type d)
           test "$found" -eq 1
@@ -98,7 +100,8 @@ jobs:
           found=0
           while IFS= read -r app; do
             bash .github/scripts/check_bundled_espeak_data.sh \
-              "${app}/Contents/Resources/espeak-ng-data"
+              "${app}/Contents/Resources/espeak-ng-data" \
+              "${app}/Contents/Frameworks/libespeak-ng.dylib"
             found=1
           done < <(find build/macos/Build/Products -name 'Enjoy Player.app' -type d)
           test "$found" -eq 1

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -596,11 +596,20 @@ played to the learner and does not replace Craft/library audio.
   `ios/` (iphoneos arm64 + iphonesimulator universal). Provenance and
   rebuild notes live in `packages/forced_alignment/native/README.md`.
   iOS rebuilds run `native/build_ios.sh` on a macOS host with Xcode.
-- macOS and iOS app targets copy the dylib + `espeak-ng-data` into the
-  `.app` via `native/bundle_into_app.sh` (Xcode "Bundle eSpeak-NG" phase)
-  so packaged `align` / `alignSegments` can `DynamicLibrary.open` without
-  the source tree. Android ships the per-ABI `.so` through jniLibs and
-  `espeak-ng-data` as Flutter assets extracted at startup
+- macOS and iOS app targets copy `espeak-ng-data` into the `.app` via
+  `native/bundle_into_app.sh` (Xcode "Bundle eSpeak-NG" phase) so packaged
+  `align` / `alignSegments` can `DynamicLibrary.open` without the source
+  tree. **`libespeak-ng.dylib` itself is embedded by the Xcode "Embed
+  Frameworks" `CopyFiles` build phase** (`dstSubfolderSpec = 10`,
+  `Frameworks/`) — the script verifies the dylib is present (Xcode owns
+  the copy, with `CodeSignOnCopy` / `RemoveHeadersOnCopy`) so a missing
+  dylib fails the build with a clear error instead of silently dropping
+  the spoken-reference at runtime (`spokenReferenceUnavailable` →
+  "failed to generate, tap to retry"). The script also re-signs the
+  whole bundle (iOS only) to keep the Swift stdlib dylibs in the
+  TestFlight IPA (same root cause as the ITMS-90429 fix in `bf820c03`).
+  Android ships the per-ABI `.so` through jniLibs and `espeak-ng-data`
+  as Flutter assets extracted at startup
   (`lib/core/platform/espeak_android_provisioner.dart`). Flutter does **not**
   recurse directory assets — `pubspec.yaml` must list `espeak-ng-data/` **and**
   `espeak-ng-data/lang/` or `espeak_SetVoiceByName(en-us)` fails on device
@@ -609,7 +618,10 @@ played to the learner and does not replace Craft/library audio.
 - **CI gates**: unit tests assert iOS (`Runner.app/espeak-ng-data`) and macOS
   (`Contents/Resources/espeak-ng-data`) layouts include every mapped `lang/`
   voice and can phonemize `en-US`. [Build Apple](../.github/workflows/build_apple.yml)
-  runs `.github/scripts/check_bundled_espeak_data.sh` on the compiled `.app`.
+  runs `.github/scripts/check_bundled_espeak_data.sh` on the compiled `.app`,
+  passing both the data directory and the `libespeak-ng.dylib` path so
+  archive-stripped dylibs (the same failure mode as the Swift stdlib
+  ITMS-90429) also fail the gate.
   [Android APK smoke](../.github/workflows/android_apk_smoke.yml) greps the
   APK for `lang/en-us`, not only `phontab`.
 - `packages/forced_alignment`'s eSpeak FFI tests run unconditionally on

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		E8F2A1C12D4C5E6F7A8B9C20 /* libespeak-ng.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E8F2A1C02D4C5E6F7A8B9C1F /* libespeak-ng.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EF23D88E35DA0DE9BA66C977 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C182831482E12604FA8D0E5 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
@@ -36,6 +37,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				E8F2A1C12D4C5E6F7A8B9C20 /* libespeak-ng.dylib in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -64,6 +66,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A1B2C3D42EC3AA0100C636F1 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
+		E8F2A1C02D4C5E6F7A8B9C1F /* libespeak-ng.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libespeak-ng.dylib"; path = "../packages/forced_alignment/native/ios/libespeak-ng.dylib"; sourceTree = SOURCE_ROOT; };
 		F3D3B5EBA1FF8CB830D86C98 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -84,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				7C182831482E12604FA8D0E5 /* Pods_Runner.framework */,
+				E8F2A1C02D4C5E6F7A8B9C1F /* libespeak-ng.dylib */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -343,18 +347,20 @@
 		};
 		E8F2A1B52D4C5E6F7A8B9C0F /* Bundle eSpeak-NG */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/../packages/forced_alignment/native/espeak-ng-data",
 			);
 			name = "Bundle eSpeak-NG";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/espeak-ng-data",
+				"$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Contents/Resources/espeak-ng-data",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		5B5C9F1026E3A5D9007B0001 /* SecurityScopedBookmarkChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5C9F1026E3A5D9007B0002 /* SecurityScopedBookmarkChannel.swift */; };
 		DFF45C875C0FEABD840BA019 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FA82744BC17A0C5098C537C /* Pods_Runner.framework */; };
+		E8F2A1C12D4C5E6F7A8B9C30 /* libespeak-ng.dylib in Bundle Framework */ = {isa = PBXBuildFile; fileRef = E8F2A1C02D4C5E6F7A8B9C2F /* libespeak-ng.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy); }; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
@@ -56,6 +57,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				E8F2A1C12D4C5E6F7A8B9C30 /* libespeak-ng.dylib in Bundle Framework */,
 			);
 			name = "Bundle Framework";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -83,6 +85,7 @@
 		79C4D5C3E1CB9B6FD25B6FFF /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		7FA82744BC17A0C5098C537C /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E8F2A1C02D4C5E6F7A8B9C2F /* libespeak-ng.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libespeak-ng.dylib; path = "../packages/forced_alignment/native/macos/libespeak-ng.dylib"; sourceTree = SOURCE_ROOT; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		CE9425446C74203A7863608B /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		DB600046C585E82334273B5E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -201,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				7FA82744BC17A0C5098C537C /* Pods_Runner.framework */,
+				E8F2A1C02D4C5E6F7A8B9C2F /* libespeak-ng.dylib */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -384,18 +388,20 @@
 		};
 		E8F2A1B42D4C5E6F7A8B9C0E /* Bundle eSpeak-NG */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/../packages/forced_alignment/native/espeak-ng-data",
 			);
 			name = "Bundle eSpeak-NG";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Contents/Resources/espeak-ng-data",
+				"$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/espeak-ng-data",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/forced_alignment/native/bundle_into_app.sh
+++ b/packages/forced_alignment/native/bundle_into_app.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
-# Copy vendored libespeak-ng + espeak-ng-data into a built macOS/iOS app.
+# Copy vendored espeak-ng-data into a built macOS/iOS app.
 #
 # Usage: bundle_into_app.sh <path/to/App.app>
 # Xcode env: PLATFORM_NAME, EXPANDED_CODE_SIGN_IDENTITY, CODE_SIGN_IDENTITY,
 #            CODE_SIGNING_ALLOWED, ENABLE_HARDENED_RUNTIME, CONFIGURATION
+#
+# The libespeak-ng.dylib itself is embedded by the Xcode "Embed Frameworks"
+# phase (PBXCopyFilesBuildPhase with dstSubfolderSpec=10), so this script
+# only handles the data tree copy and the bundle re-sign that keeps the
+# Swift stdlib dylibs in the TestFlight IPA (see commit bf820c03).
 set -eu
 
 APP_BUNDLE="${1:-}"
@@ -25,26 +30,14 @@ fi
 
 case "${PLATFORM_NAME}" in
   macosx)
-    LIB_SRC="${NATIVE_DIR}/macos/libespeak-ng.dylib"
-    FRAMEWORKS_DIR="${APP_BUNDLE}/Contents/Frameworks"
+    LIB_DEST="${APP_BUNDLE}/Contents/Frameworks/libespeak-ng.dylib"
     DATA_DEST="${APP_BUNDLE}/Contents/Resources/espeak-ng-data"
     ;;
-  iphonesimulator)
-    LIB_SRC="${NATIVE_DIR}/ios/libespeak-ng.simulator.dylib"
-    FRAMEWORKS_DIR="${APP_BUNDLE}/Frameworks"
-    DATA_DEST="${APP_BUNDLE}/espeak-ng-data"
-    ;;
-  iphoneos|*)
-    LIB_SRC="${NATIVE_DIR}/ios/libespeak-ng.dylib"
-    FRAMEWORKS_DIR="${APP_BUNDLE}/Frameworks"
+  iphonesimulator | iphoneos | *)
+    LIB_DEST="${APP_BUNDLE}/Frameworks/libespeak-ng.dylib"
     DATA_DEST="${APP_BUNDLE}/espeak-ng-data"
     ;;
 esac
-
-if [ ! -f "${LIB_SRC}" ]; then
-  echo "bundle_espeak_ng: missing ${LIB_SRC}" >&2
-  exit 1
-fi
 
 DATA_SRC="${NATIVE_DIR}/espeak-ng-data"
 if [ ! -d "${DATA_SRC}" ]; then
@@ -52,10 +45,14 @@ if [ ! -d "${DATA_SRC}" ]; then
   exit 1
 fi
 
-mkdir -p "${FRAMEWORKS_DIR}"
-LIB_DEST="${FRAMEWORKS_DIR}/libespeak-ng.dylib"
-cp -f "${LIB_SRC}" "${LIB_DEST}"
-chmod +x "${LIB_DEST}"
+# Xcode's "Embed Frameworks" phase (dstSubfolderSpec=10) is the source of
+# truth for libespeak-ng.dylib. Fail closed if it didn't land — without the
+# dylib the production align path returns spokenReferenceUnavailable at
+# runtime, which the user sees as "failed to generate, tap to retry".
+if [ ! -f "${LIB_DEST}" ]; then
+  echo "bundle_espeak_ng: missing ${LIB_DEST} (Xcode Embed Frameworks did not copy libespeak-ng.dylib)" >&2
+  exit 1
+fi
 if command -v install_name_tool >/dev/null 2>&1; then
   install_name_tool -id "@rpath/libespeak-ng.dylib" "${LIB_DEST}" 2>/dev/null || true
 fi
@@ -74,22 +71,43 @@ if [ -z "${sign_identity}" ] || [ "${sign_identity}" = "-" ]; then
   sign_identity="${CODE_SIGN_IDENTITY:-}"
 fi
 
-# For iOS, do NOT hand-sign the dylib here. The runner target's
-# "Embed Frameworks" phase is empty and the Swift stdlib dylibs
-# (libswift_Concurrency.dylib, etc.) are only embedded by Xcode's
-# automatic Swift stdlib copy. A manual `codesign --force --sign`
-# rewrites libespeak-ng.dylib after Xcode's outer CodeResources
-# seal has been computed, which causes xcodebuild -exportArchive
-# to drop the unmatched Swift stdlib dylibs from the IPA and
-# App Store Connect rejects the upload with ITMS-90429
-# ("Invalid Swift Support — libswift_Concurrency.dylib isn't at
-# the expected location /Payload/Runner.app/Frameworks"). Let
-# Xcode's implicit outer sign handle libespeak-ng.dylib via the
-# bundle-level re-sign below so the dylib hash and the outer
-# seal stay consistent.
+# For iOS, do NOT hand-sign the dylib here. The Runner target's
+# "Embed Frameworks" phase carries libespeak-ng.dylib and the Swift
+# stdlib dylibs (libswift_Concurrency.dylib, etc.) are only embedded
+# by Xcode's automatic Swift stdlib copy — files that are not
+# declared in the Embed Frameworks phase. A manual `codesign --force
+# --sign "$LIB_DEST"` rewrites the dylib hash after Xcode's outer
+# CodeResources seal has been computed, which causes
+# xcodebuild -exportArchive to drop the unmatched Swift stdlib dylibs
+# from the IPA and App Store Connect rejects the upload with
+# ITMS-90429 ("Invalid Swift Support — libswift_Concurrency.dylib
+# isn't at the expected location /Payload/Runner.app/Frameworks").
+# Let Xcode's implicit outer sign handle libespeak-ng.dylib via the
+# bundle-level re-sign below so the dylib hash and the outer seal
+# stay consistent.
+#
+# Skip the whole-bundle re-sign on Debug iOS builds: Flutter's
+# ENABLE_DEBUG_DYLIB=YES drops an unsigned __preview.dylib at the
+# bundle root, which fails `codesign --force --sign "$APP_BUNDLE"`
+# with "unsealed contents present in the bundle root". The Debug
+# build never hits xcodebuild -exportArchive so the ITMS-90429 fix
+# is unnecessary there.
+#
+# Likewise, prune the empty `Contents/Resources/` (a stray macOS-style
+# Resources folder that Xcode's asset/strip pipeline leaves behind in
+# iOS bundles and codesign refuses to seal) before signing.
+if [ "${PLATFORM_NAME}" = "iphoneos" ] || [ "${PLATFORM_NAME}" = "iphonesimulator" ]; then
+  for d in "${APP_BUNDLE}/Contents/Resources" "${APP_BUNDLE}/Contents"; do
+    if [ -d "$d" ] && [ -z "$(ls -A "$d" 2>/dev/null)" ]; then
+      rmdir "$d" 2>/dev/null || true
+    fi
+  done
+fi
+
 case "${PLATFORM_NAME}" in
   iphoneos | iphonesimulator)
-    if [ "${CODE_SIGNING_ALLOWED:-YES}" != "NO" ] &&
+    if [ "${CONFIGURATION:-Debug}" != "Debug" ] &&
+       [ "${CODE_SIGNING_ALLOWED:-YES}" != "NO" ] &&
        [ -n "${sign_identity}" ] && [ "${sign_identity}" != "-" ]; then
       # shellcheck disable=SC2086
       codesign --force --sign "${sign_identity}" "${APP_BUNDLE}"
@@ -110,4 +128,4 @@ case "${PLATFORM_NAME}" in
     ;;
 esac
 
-echo "bundle_espeak_ng: ${LIB_DEST} + ${DATA_DEST} (${PLATFORM_NAME})"
+echo "bundle_espeak_ng: data=${DATA_DEST} (${PLATFORM_NAME})"

--- a/packages/forced_alignment/test/bundled_espeak_test.dart
+++ b/packages/forced_alignment/test/bundled_espeak_test.dart
@@ -65,16 +65,24 @@ void main() {
       return;
     }
     final src = resolveEspeakDataPath();
+    final lib = resolveEspeakLibraryPath();
     expect(src, isNotNull);
+    expect(lib, isNotNull);
     final script = File('${Directory(src!).parent.path}/bundle_into_app.sh');
     expect(script.existsSync(), isTrue, reason: script.path);
 
     final tmp = Directory.systemTemp.createTempSync('espeak-bundle-script-');
     addTearDown(() => tmp.deleteSync(recursive: true));
 
+    // Xcode's "Embed Frameworks" phase owns libespeak-ng.dylib; the script
+    // only handles the data tree copy and the bundle re-sign. Pre-stage the
+    // dylib the way Xcode would.
     final macApp = Directory('${tmp.path}/Enjoy Player.app')
       ..createSync(recursive: true);
     Directory('${macApp.path}/Contents/MacOS').createSync(recursive: true);
+    final macFrameworks = Directory('${macApp.path}/Contents/Frameworks')
+      ..createSync();
+    File(lib!).copySync('${macFrameworks.path}/libespeak-ng.dylib');
     _runBundleScript(script.path, macApp.path, platformName: 'macosx');
     expect(
       missingEspeakRequiredDataFiles(
@@ -84,6 +92,8 @@ void main() {
     );
 
     final iosApp = Directory('${tmp.path}/Runner.app')..createSync();
+    final iosFrameworks = Directory('${iosApp.path}/Frameworks')..createSync();
+    File(lib).copySync('${iosFrameworks.path}/libespeak-ng.dylib');
     _runBundleScript(script.path, iosApp.path, platformName: 'iphoneos');
     expect(
       missingEspeakRequiredDataFiles('${iosApp.path}/espeak-ng-data'),
@@ -102,6 +112,10 @@ void main() {
     addTearDown(() => tmp.deleteSync(recursive: true));
     final app = Directory('${tmp.path}/Enjoy Player.app');
     Directory('${app.path}/Contents/MacOS').createSync(recursive: true);
+    // Xcode's "Embed Frameworks" phase copies the dylib; pre-stage it.
+    final macFrameworks = Directory('${app.path}/Contents/Frameworks')
+      ..createSync();
+    File(repoNative!).copySync('${macFrameworks.path}/libespeak-ng.dylib');
     final script = File(
       '${Directory(repoData!).parent.path}/bundle_into_app.sh',
     );


### PR DESCRIPTION
## Summary

- `libespeak-ng.dylib` was only ever copied into `Runner.app/Frameworks/` by the `Bundle eSpeak-NG` script, with empty `inputPaths` and `alwaysOutOfDate = 1`. `xcodebuild -exportArchive` re-validated `CodeResources` and stripped any `Frameworks/` file that wasn't declared in the Xcode project's Embed Frameworks phase, so production align silently fell back to `spokenReferenceUnavailable` ("failed to generate, tap to retry") at runtime.
- Register the dylib as a real Xcode file reference on both Runner targets (iOS and macOS) and add it to the existing `CopyFiles` phase (`dstSubfolderSpec = 10`) with `CodeSignOnCopy` / `RemoveHeadersOnCopy`, so the dylib is tracked by the project and survives `exportArchive`. Apply the same wiring to `macos/Runner.xcodeproj/project.pbxproj` so `flutter run -d macos` also lands the dylib in `Contents/Frameworks/`.
- The script now only handles the data tree copy and (for iOS) the whole-bundle re-sign that keeps the Swift stdlib dylibs in the TestFlight IPA (`bf820c03`). It also uses proper `inputPaths`/`outputPaths` so Xcode re-runs it on data changes; skips the re-sign on Debug iOS builds (Flutter's `ENABLE_DEBUG_DYLIB=YES` drops an unsigned `__preview.dylib` at the bundle root and breaks `codesign`); and prunes an empty `Runner.app/Contents/Resources/` Xcode's pipeline leaves behind on iOS before codesign, so the seal succeeds.
- CI: `check_bundled_espeak_data.sh` now accepts an optional lib path and the `Build Apple` workflow asserts it for both iOS (`Frameworks/`) and macOS (`Contents/Frameworks/`) on every build, so a stripped dylib fails the gate before it ships (same failure mode as the Swift stdlib ITMS-90429).

## Why the previous bundle script wasn't enough

`xcodebuild -exportArchive` re-validates `CodeResources` against the Xcode project. Any `Frameworks/` file that wasn't declared in a `CopyFiles` build phase is dropped from the IPA, even if a script placed it on disk earlier. The `Bundle eSpeak-NG` build phase could write the dylib into `Frameworks/`, but the project never owned it, so `exportArchive` cleaned it up. `flutter run` builds succeeded (the script ran and dropped the dylib), but every TestFlight upload lost it.

## Verification

- `xcodebuild ... -configuration Debug -sdk iphoneos ... -CODE_SIGN_STYLE=Automatic build` → `BUILD SUCCEEDED`, `Runner.app/Frameworks/libespeak-ng.dylib` present, bundle signed.
- `xcodebuild ... -configuration Release -sdk iphoneos ... -CODE_SIGN_STYLE=Automatic build` → `BUILD SUCCEEDED`, same.
- `flutter run -d macos` → `BUILD SUCCEEDED`, `Contents/Frameworks/libespeak-ng.dylib` present, bundle signed.
- `flutter analyze` clean, `check_dart_format` clean, `flutter test packages/forced_alignment/test/bundled_espeak_test.dart` passes.

## Test plan

- [x] `bash .github/scripts/check_dart_format.sh`
- [x] `flutter analyze --no-fatal-infos`
- [x] `flutter test packages/forced_alignment/test/bundled_espeak_test.dart`
- [ ] CI `.github/workflows/build_apple.yml` (macOS + iOS Runner.app dylib + data layout assertions)

Fixes the original report:

> ```
> flutter: [WARNING] forced_alignment: phonemize skipped a line: SpokenReferenceException(AlignmentFailureReason.spokenReferenceUnavailable: failed to open /private/var/containers/Bundle/Application/.../Runner.app/Frameworks/libespeak-ng.dylib)
> flutter: [WARNING] forced_alignment: phonemize produced no words (synthFailures=76 lines=76)
> flutter: [WARNING] transcript.enrichment: run failed: spokenReferenceUnavailable
> ```