### PR TITLE
fix(landing): show per-platform download version on each card

### DIFF
--- a/landing/i18n.js
+++ b/landing/i18n.js
@@ -25,27 +25,31 @@ const translations = {
     'download.windows.title': 'Windows',
     'download.windows.subtitle': 'Windows 10 / 11 · x64',
     'download.windows.btn': 'Download for Windows',
-    
+    'download.windows.aria': 'Download Enjoy Player installer for Windows',
+
     'download.macos.title': 'macOS',
     'download.macos.subtitle': 'macOS 10.15+ · Universal',
     'download.macos.btn': 'Download for macOS',
-    
+    'download.macos.aria': 'Download Enjoy Player for macOS',
+
     'download.android.title': 'Android',
     'download.android.subtitle': 'Android 8.0+',
     'download.android.btn.apk': 'Download APK',
     'download.android.btn.play': 'Join Play Beta',
+    'download.android.aria': 'Download Enjoy Player APK for Android',
     'download.android.note': 'Tip: installing the APK requires enabling <em>Install unknown apps</em> in your Android settings.',
-    
+
     'download.ios.title': 'iOS',
     'download.ios.subtitle': 'iOS 14.0+',
     'download.ios.btn': 'Join TestFlight',
     'download.ios.note': 'TestFlight public beta is live. App Store release coming soon.',
-    
+
     'download.comingSoon': 'Coming soon',
-    
+
     'download.linux.title': 'Linux',
     'download.linux.subtitle': 'Ubuntu 22.04 LTS · x86_64',
     'download.linux.btn': 'Download for Linux',
+    'download.linux.aria': 'Download Enjoy Player AppImage for Linux',
     'download.linux.note': 'AppImage: <code>chmod +x enjoy-player-*.AppImage && ./enjoy-player-*.AppImage</code>',
     
     'recommended': 'Recommended',
@@ -77,27 +81,31 @@ const translations = {
     'download.windows.title': 'Windows',
     'download.windows.subtitle': 'Windows 10 / 11 · x64',
     'download.windows.btn': '下载 Windows 版',
-    
+    'download.windows.aria': '下载 Enjoy Player Windows 安装包',
+
     'download.macos.title': 'macOS',
     'download.macos.subtitle': 'macOS 10.15+ · Universal',
     'download.macos.btn': '下载 macOS 版',
-    
+    'download.macos.aria': '下载 Enjoy Player macOS 版',
+
     'download.android.title': 'Android',
     'download.android.subtitle': 'Android 8.0+',
     'download.android.btn.apk': '下载 APK',
     'download.android.btn.play': '加入 Play Beta',
+    'download.android.aria': '下载 Enjoy Player Android APK',
     'download.android.note': '提示：安装 APK 需要在 Android 设置中开启<em>允许安装未知应用</em>。',
-    
+
     'download.ios.title': 'iOS',
     'download.ios.subtitle': 'iOS 14.0+',
     'download.ios.btn': '加入 TestFlight',
     'download.ios.note': 'TestFlight 公开测试已上线，App Store 版本即将推出。',
-    
+
     'download.comingSoon': '即将推出',
-    
+
     'download.linux.title': 'Linux',
     'download.linux.subtitle': 'Ubuntu 22.04 LTS · x86_64',
     'download.linux.btn': '下载 Linux 版',
+    'download.linux.aria': '下载 Enjoy Player Linux AppImage',
     'download.linux.note': 'AppImage: <code>chmod +x enjoy-player-*.AppImage && ./enjoy-player-*.AppImage</code>',
     
     'recommended': '推荐',
@@ -109,7 +117,7 @@ function setLanguage(lang) {
   if (!translations[lang]) lang = 'en';
   document.documentElement.lang = lang;
   localStorage.setItem('enjoy_lang', lang);
-  
+
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');
     if (translations[lang][key]) {
@@ -120,6 +128,18 @@ function setLanguage(lang) {
         el.textContent = translations[lang][key];
       }
     }
+  });
+
+  // Re-compose aria-labels for elements that opted into data-aria-i18n.
+  // If the element also carries a data-version stamp (set by main.js after
+  // the manifest loads), append a "(vX.Y.Z)" suffix so the screen-reader
+  // text reflects the version this button actually downloads.
+  document.querySelectorAll('[data-aria-i18n]').forEach(el => {
+    const key = el.getAttribute('data-aria-i18n');
+    const base = translations[lang][key];
+    if (!base) return;
+    const version = el.dataset.version;
+    el.setAttribute('aria-label', version ? `${base} (v${version})` : base);
   });
 
   // Update meta tags

--- a/landing/index.html
+++ b/landing/index.html
@@ -143,7 +143,10 @@
                 <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24L10.949 22.051"/>
               </svg>
               <div>
-                <div class="card-title" data-i18n="download.windows.title">Windows</div>
+                <div class="card-title-row">
+                  <span class="card-title" data-i18n="download.windows.title">Windows</span>
+                  <span class="card-version hidden" id="version-windows"></span>
+                </div>
                 <div class="card-subtitle" data-i18n="download.windows.subtitle">Windows 10 / 11 · x64</div>
               </div>
             </div>
@@ -153,6 +156,7 @@
                 class="btn btn--primary"
                 href="https://dl.enjoy.bot/player/"
                 aria-label="Download Enjoy Player installer for Windows"
+                data-aria-i18n="download.windows.aria"
               >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 12l-4.5-4.5 1.06-1.06L7 8.88V2h2v6.88l2.44-2.44L12.5 7.5 8 12zM2 14v-2h12v2H2z"/></svg>
                 <span data-i18n="download.windows.btn">Download for Windows</span>
@@ -167,7 +171,10 @@
                 <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.54 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/>
               </svg>
               <div>
-                <div class="card-title" data-i18n="download.macos.title">macOS</div>
+                <div class="card-title-row">
+                  <span class="card-title" data-i18n="download.macos.title">macOS</span>
+                  <span class="card-version hidden" id="version-macos"></span>
+                </div>
                 <div class="card-subtitle" data-i18n="download.macos.subtitle">macOS 10.15+ · Universal</div>
               </div>
             </div>
@@ -177,6 +184,7 @@
                 class="btn btn--primary"
                 href="https://dl.enjoy.bot/player/"
                 aria-label="Download Enjoy Player for macOS"
+                data-aria-i18n="download.macos.aria"
               >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 12l-4.5-4.5 1.06-1.06L7 8.88V2h2v6.88l2.44-2.44L12.5 7.5 8 12zM2 14v-2h12v2H2z"/></svg>
                 <span data-i18n="download.macos.btn">Download for macOS</span>
@@ -191,7 +199,10 @@
                 <path d="M17.523 15.341c-.551 0-.999-.449-.999-1s.448-.999.999-.999c.551 0 .999.448.999.999 0 .551-.448 1-.999 1m-11.046 0c-.551 0-.999-.449-.999-1s.448-.999.999-.999c.551 0 .999.448.999.999 0 .551-.448 1-.999 1m11.405-6.02l1.997-3.459a.416.416 0 00-.71-.419L17.172 8.9C15.59 8.244 13.853 7.851 12 7.851s-3.59.393-5.172 1.049L4.831 5.443a.416.416 0 00-.71.419l1.997 3.459C2.689 11.187.343 14.659 0 18.761h24c-.344-4.102-2.689-7.574-6.118-9.44"/>
               </svg>
               <div>
-                <div class="card-title" data-i18n="download.android.title">Android</div>
+                <div class="card-title-row">
+                  <span class="card-title" data-i18n="download.android.title">Android</span>
+                  <span class="card-version hidden" id="version-android"></span>
+                </div>
                 <div class="card-subtitle" data-i18n="download.android.subtitle">Android 8.0+</div>
               </div>
             </div>
@@ -201,6 +212,7 @@
                 class="btn btn--primary"
                 href="https://dl.enjoy.bot/player/"
                 aria-label="Download Enjoy Player APK for Android"
+                data-aria-i18n="download.android.aria"
               >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 12l-4.5-4.5 1.06-1.06L7 8.88V2h2v6.88l2.44-2.44L12.5 7.5 8 12zM2 14v-2h12v2H2z"/></svg>
                 <span data-i18n="download.android.btn.apk">Download APK</span>
@@ -256,7 +268,10 @@
                 <path d="M19.5 11.5c0 4.14-3.36 7.5-7.5 7.5s-7.5-3.36-7.5-7.5 3.36-7.5 7.5-7.5 7.5 3.36 7.5 7.5zm-7.5-5.5c-1.3 0-2.5.42-3.5 1.16-.22.24-.5.4-.83.4-.41 0-.77-.26-.89-.66l-.19-.63c-.06-.2-.24-.34-.44-.34-.27 0-.48.22-.48.49 0 .05.01.09.02.14-.02 0-.06.01-.1.01-.4 0-.73-.33-.73-.73 0-.13.03-.25.09-.35.1-.53.15-1.08.15-1.65 0-3.31 2.69-6 6-6s6 2.69 6 6c0 .57-.05 1.12-.15 1.65.06.1.09.22.09.35 0 .4-.33.73-.73.73-.04 0-.08 0-.1-.01.01-.05.02-.09.02-.14 0-.27-.22-.49-.48-.49-.2 0-.38.14-.44.34l-.19.63c-.12.4-.48.66-.89.66-.33 0-.61-.16-.83-.4-1-.74-2.2-1.16-3.5-1.16zm-.9 5.6c-.54.28-1.17.44-1.84.44-.68 0-1.31-.16-1.86-.44-.14.07-.28.14-.42.22-.92.55-1.48 1.49-1.63 2.53.85.67 1.88 1.15 3.02 1.34.34.06.66.15.96.28.12-.1.27-.17.42-.17h.02c.15 0 .3.07.42.17.3-.13.62-.22.96-.28 1.14-.19 2.17-.67 3.02-1.34-.15-1.04-.71-1.98-1.63-2.53-.14-.08-.28-.15-.44-.22zm4.07-.38c-.28-.16-.59-.28-.92-.34-.33.32-.75.58-1.23.76-.52.2-1.1.32-1.69.32-.59 0-1.17-.12-1.69-.32-.48-.18-.9-.44-1.23-.76-.34.06-.65.18-.94.34-1.04.6-1.67 1.63-1.83 2.77.88.75 1.97 1.3 3.16 1.55.44.09.85.22 1.21.41.28-.18.63-.29 1-.29h.54c.37 0 .72.11 1 .29.36-.19.77-.32 1.21-.41 1.19-.25 2.28-.8 3.16-1.55-.16-1.14-.79-2.17-1.85-2.77z"/>
               </svg>
               <div>
-                <div class="card-title" data-i18n="download.linux.title">Linux</div>
+                <div class="card-title-row">
+                  <span class="card-title" data-i18n="download.linux.title">Linux</span>
+                  <span class="card-version hidden" id="version-linux"></span>
+                </div>
                 <div class="card-subtitle" data-i18n="download.linux.subtitle">Ubuntu 22.04 LTS · x86_64</div>
               </div>
             </div>
@@ -266,6 +281,7 @@
                 class="btn btn--primary"
                 href="https://dl.enjoy.bot/player/"
                 aria-label="Download Enjoy Player AppImage for Linux"
+                data-aria-i18n="download.linux.aria"
               >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 12l-4.5-4.5 1.06-1.06L7 8.88V2h2v6.88l2.44-2.44L12.5 7.5 8 12zM2 14v-2h12v2H2z"/></svg>
                 <span data-i18n="download.linux.btn">Download for Linux</span>

--- a/landing/main.js
+++ b/landing/main.js
@@ -34,34 +34,77 @@ async function fetchManifest(url, timeoutMs = 5000) {
 }
 
 // ── Apply manifest data to the page ────────────────────────────
+// Each asset URL embeds the version in its path (…/player/<version>/…),
+// so we treat that as the source of truth for which version a platform
+// actually downloads. This keeps each platform button pointing to the
+// latest version uploaded for THAT platform, even when other platforms
+// are still on an earlier release.
 function applyManifest(manifest) {
   if (!manifest) return;
 
-  const { version, assets = {} } = manifest;
+  const { assets = {} } = manifest;
 
-  // Version badge
-  if (version) {
-    const badge = document.getElementById('version-badge');
-    if (badge) {
-      badge.textContent = `v${version}`;
-      badge.classList.remove('hidden');
+  // Map button id → (asset key, card-version element id).
+  // The card-version element renders the per-platform version chip.
+  const platformMap = {
+    'btn-windows': { asset: 'windows',            chipId: 'version-windows' },
+    'btn-macos':   { asset: 'macos',              chipId: 'version-macos' },
+    'btn-android': { asset: 'android_arm64_v8a',  chipId: 'version-android' },
+    'btn-linux':   { asset: 'linux',              chipId: 'version-linux' },
+  };
+
+  const parsedVersions = [];
+
+  for (const [btnId, { asset: assetKey, chipId }] of Object.entries(platformMap)) {
+    const asset = assets[assetKey];
+    const btn = document.getElementById(btnId);
+    if (!asset || !asset.url || !btn) continue;
+
+    btn.href = asset.url;
+    btn.setAttribute('download', '');
+
+    // Extract version from the URL path: …/player/<version>/<file>.
+    const versionMatch = asset.url.match(/\/player\/([^/]+)\//);
+    const platformVersion = versionMatch ? versionMatch[1] : null;
+    if (!platformVersion) continue;
+
+    parsedVersions.push(platformVersion);
+
+    // Stamp the version on the element so the i18n handler can re-compose
+    // the aria-label when the language changes.
+    btn.dataset.version = platformVersion;
+
+    // Reveal the per-card version chip.
+    const chip = document.getElementById(chipId);
+    if (chip) {
+      chip.textContent = `v${platformVersion}`;
+      chip.classList.remove('hidden');
+    }
+
+    // Compose a localized aria-label that includes the version.
+    const ariaKey = btn.getAttribute('data-aria-i18n');
+    if (ariaKey && window.translations) {
+      const lang = document.documentElement.lang || 'en';
+      const base = window.translations[lang]?.[ariaKey];
+      if (base) {
+        btn.setAttribute('aria-label', `${base} (v${platformVersion})`);
+      }
     }
   }
 
-  // Update download hrefs for direct-download platforms
-  const urlMap = {
-    'btn-windows':  assets.windows?.url,
-    'btn-macos':    assets.macos?.url,
-    'btn-android':  assets.android_arm64_v8a?.url,
-    'btn-linux':    assets.linux?.url,
-  };
-
-  for (const [id, url] of Object.entries(urlMap)) {
-    if (!url) continue;
-    const el = document.getElementById(id);
-    if (el) {
-      el.href = url;
-      el.setAttribute('download', '');
+  // Hero version badge: only show when every direct-download platform is
+  // at the same version. Otherwise the per-card chips are authoritative
+  // and the badge would be misleading.
+  const badge = document.getElementById('version-badge');
+  if (badge) {
+    const allAligned =
+      parsedVersions.length === Object.keys(platformMap).length &&
+      parsedVersions.every((v) => v === parsedVersions[0]);
+    if (allAligned) {
+      badge.textContent = `v${parsedVersions[0]}`;
+      badge.classList.remove('hidden');
+    } else {
+      badge.classList.add('hidden');
     }
   }
 }

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -470,12 +470,35 @@ a:hover { text-decoration: underline; }
 
 .card--recommended .platform-icon { color: var(--brand-from); }
 
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .card-title {
   font-size: 1rem;
   font-weight: 600;
   color: var(--text);
   line-height: 1.2;
 }
+
+.card-version {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(71, 151, 245, 0.1);
+  border: 1px solid rgba(71, 151, 245, 0.25);
+  color: var(--brand-from);
+  line-height: 1.2;
+}
+
+.card-version.hidden { display: none; }
 
 .card-subtitle {
   font-size: 0.75rem;


### PR DESCRIPTION
## Problem

The hero version badge always reflected the overall `version` field of `latest.json`. When only one platform was uploaded for a new release (e.g. macOS on v0.8.3 while Windows/Android/Linux were still on v0.8.2), the page advertised `v0.8.3` but the Windows/Android/Linux buttons installed `v0.8.2`. The links were valid; the headline was misleading.

The release pipeline was already correct — `.github/scripts/merge_latest_json.sh` keeps each platform's latest URL. The bug was purely cosmetic on the landing page.

## Fix

- Each download card now shows a small `vX.Y.Z` chip next to the platform title, parsed from the asset URL path (no manifest schema change needed).
- The hero `#version-badge` only shows when every direct-download platform is at the same version. Otherwise it hides, and the per-card chips carry the truth.
- `aria-label` is re-composed on language change so screen readers announce the actual version each button downloads.

## Files

- `landing/index.html` — wrap each card title in `.card-title-row`, add `<span class="card-version hidden" id="version-{platform}">`, add `data-aria-i18n` to the four direct-download buttons.
- `landing/main.js` — rework `applyManifest` to extract per-platform version, update chips + aria-labels, conditionally show/hide the hero badge.
- `landing/styles.css` — add `.card-title-row` and `.card-version` styles (matching the existing `.version-badge` visual language).
- `landing/i18n.js` — add `download.{platform}.aria` keys (en + zh) and a `data-aria-i18n` handler in `setLanguage`.

## Verification

Tested against three representative manifests via a Node fixture:

- **Aligned** (all on 0.8.3): all chips show `v0.8.3`, hero badge shows `v0.8.3`.
- **Mixed** (macOS 0.8.3, others 0.8.2): macOS chip shows `v0.8.3`, others show `v0.8.2`, hero badge hides.
- **Partial** (only macOS uploaded): only macOS chip shows, hero badge hides.

All 9 assertions pass.

## Out of scope

- The `latest.json` schema — the URL already encodes the version, so no per-asset `version` field is needed.
- The backend merge logic — already verified correct (jq `*` makes the right operand win).