### PR TITLE
fix(release): merge latest.json assets across version bumps

### DIFF
--- a/.github/scripts/merge_latest_json.sh
+++ b/.github/scripts/merge_latest_json.sh
@@ -23,7 +23,7 @@ fi
 
 jq -s '
   .[0] as $new | .[1] as $remote |
-  if ($remote | type) != "object" or ($remote.version != $new.version) then
+  if ($remote | type) != "object" then
     $new
   else
     $new


### PR DESCRIPTION
## Problem

`merge_latest_json.sh` returned `$new` as-is whenever its `version` field differed from the remote. With per-platform rolling releases (macOS often ships before Windows/Android/Linux), that meant the moment a new release was published for one platform first, the merged manifest kept only that platform's URL and dropped every other platform's asset.

Concrete case: the user reported `/latest` returning only `macos` for v0.8.3 after the macOS publish, while the other platforms' URLs in the manifest were gone — leaving the landing page's Windows/Android/Linux cards pointing at the no-JS fallback URL.

## Fix

Drop the version-mismatch branch in the merge jq so assets are always merged. The just-uploaded platform's URL still wins for its own key (the right operand wins in jq `*`), but older platforms stay in the manifest at their previous version until they're re-uploaded.

Behavior preserved for all other cases:
- Same-version re-upload: identical (already went through the merge branch).
- First publish, no remote: identical (handled by the `cp -f` guard before the jq).
- Full release where every platform is uploaded at once: identical (each new key wins for itself).

## Verified

Run against four scenarios (`bash test-merge.sh`):

| Scenario | Remote `assets` | New `assets` | Merged result |
|---|---|---|---|
| User's case: v0.8.3 macos first | windows/android/linux at v0.8.2 | macos at v0.8.3 | all four; macos v0.8.3, others v0.8.2 |
| v0.8.2 macos re-uploaded | all four at v0.8.2 | macos at v0.8.2 | all four at v0.8.2 |
| First publish, no remote | — | macos at v0.8.3 | macos at v0.8.3 only |
| v1.0.0 all four, remote v0.9.0 | all four at v0.9.0 | all four at v1.0.0 | all four at v1.0.0 |

## Pairs with

The per-platform version chips from #582 now light up correctly: macOS card shows `v0.8.3`, the others show `v0.8.2`, and the hero badge stays hidden because not all platforms are at the same version.

## Out of scope

- The `latest.json` schema — no per-asset `version` field needed; the URL already encodes the version.
- The landing page itself — already updated in #582.