### PR TITLE
refactor(shadow-reading): extract take capture and persistence into ShadowTakeStore

### DIFF
--- a/docs/features/shadow-reading.md
+++ b/docs/features/shadow-reading.md
@@ -13,6 +13,17 @@ The recording bus is the single source of truth for "is the user recording right
 - `ShadowReadingHotkeyBus` (a singleton bus, generated from `shadow_reading_hotkey_bus.dart`) emits typed events (`ShadowRecordingHotkeyEvent`) when the user presses the global shortcut, toggling the panel's idle toolbar state. The bus decouples the hotkey layer (which knows nothing about the panel) from the UI.
 - Mic selection is persisted in `SettingsKeys.prefsRecordingInputDeviceId` and re-read on every take via `recordingInputDeviceCtrlProvider`. Unknown / virtual devices are skipped by `pickPreferredInputDeviceId` (GlideX Shared Audio, VoiceMeeter, VB-Audio CABLE, NVIDIA Broadcast, etc.) so Windows defaults don't silently capture only zeros.
 
+## Take capture & persistence (ShadowTakeStore)
+
+Mic capture and take persistence live in [`ShadowTakeStore`](../../lib/features/shadow_reading/application/shadow_take_store.dart) (issue #597) — the panel is view + callbacks only. Interface: `start(device:)` / `cancel()` / `stopAndPersist(region:)` / `deleteTake(row)` / `dispose()`.
+
+- **Capture**: mic permission gate, `{appSupport}/recordings/{uuid}.wav` paths, and the 16 kHz mono PCM16 WAV config (`buildShadowRecordConfig`, aligned with web + Azure Speech).
+- **Recorder lifecycle**: the `MicRecorder` port wraps `package:record`'s `AudioRecorder`; the recorder is **recreated after every `stop()`** — `record` on Windows keeps stale Media Foundation state on the same instance, so reusing it silently produces a zero-sample WAV ("second take won't record").
+- **Persistence**: `stopAndPersist` reads the WAV, computes sha256 + duration, applies the **silence heuristic** (RMS < 0.001 or non-zero ratio < 1% → `looksSilent` verdict surfaced by the panel as a warning; the row is persisted regardless), builds the `RecordingRow`, inserts via `recordingDao` (ADR-0002), then enqueues sync create through the injected `SyncEnqueueFn` (ADR-0013).
+- **Deletion**: `deleteTake` enqueues sync delete, removes the WAV file, then deletes the DAO row. Stopping preview playback of the take first is the panel's job (a presentation concern).
+
+Craft's `CaptureStage` still owns its own capture loop (it needs the amplitude stream and does not persist takes); migrating it onto the shared `MicRecorder` port is a follow-up.
+
 ## Idle toolbar (centered FAB)
 
 - The panel shows an **idle toolbar** with the **pitch icon**, a centered **FAB** (start recording), **play**, and **pronunciation assess**. Delete moves into a **more** menu gated by a confirmation dialog.

--- a/lib/features/shadow_reading/application/shadow_take_store.dart
+++ b/lib/features/shadow_reading/application/shadow_take_store.dart
@@ -1,0 +1,339 @@
+/// Shadow-reading take capture + persistence (issue #597).
+///
+/// A deep module behind a small interface: `start` / `cancel` /
+/// `stopAndPersist` / `deleteTake`. It hides microphone permission handling,
+/// take-path construction, the "recreate the recorder after every stop"
+/// Windows workaround, WAV hashing / duration parsing, the silence heuristic,
+/// 18-field [RecordingRow] construction, Drift insert, and sync enqueue.
+/// The panel shrinks to view + callbacks; tests exercise the seam directly.
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:record/record.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:enjoy_player/core/audio/wav_duration_ms.dart';
+import 'package:enjoy_player/core/audio/wav_signal_peak.dart';
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/features/sync/domain/sync_types.dart';
+
+final _log = logNamed('ShadowTakeStore');
+
+/// Minimal seam over `package:record`'s [AudioRecorder] so the store can be
+/// tested with a fake (production adapter: [PackageRecordMicRecorder]).
+abstract class MicRecorder {
+  Future<bool> hasPermission();
+
+  Future<void> start(RecordConfig config, {required String path});
+
+  /// Returns the path of the written WAV, or `null`/empty when nothing was
+  /// captured.
+  Future<String?> stop();
+
+  Future<void> dispose();
+}
+
+/// Production adapter delegating to a real [AudioRecorder].
+class PackageRecordMicRecorder implements MicRecorder {
+  PackageRecordMicRecorder() : _impl = AudioRecorder();
+
+  final AudioRecorder _impl;
+
+  @override
+  Future<bool> hasPermission() => _impl.hasPermission();
+
+  @override
+  Future<void> start(RecordConfig config, {required String path}) =>
+      _impl.start(config, path: path);
+
+  @override
+  Future<String?> stop() => _impl.stop();
+
+  @override
+  Future<void> dispose() => _impl.dispose();
+}
+
+/// The echo region a take is recorded against — everything the persisted
+/// [RecordingRow] needs beyond the WAV itself.
+class TakeRegion {
+  const TakeRegion({
+    required this.targetType,
+    required this.targetId,
+    required this.language,
+    required this.referenceText,
+    required this.startSec,
+    required this.endSec,
+  });
+
+  final String targetType;
+  final String targetId;
+  final String language;
+  final String referenceText;
+  final double startSec;
+  final double endSec;
+}
+
+/// Outcome of a successful [ShadowTakeStore.stopAndPersist].
+class TakePersistResult {
+  const TakePersistResult({required this.row, required this.looksSilent});
+
+  final RecordingRow row;
+
+  /// True when the captured WAV looks silent (low RMS / non-zero ratio). The
+  /// caller surfaces a warning; the row is persisted regardless.
+  final bool looksSilent;
+}
+
+/// Microphone permission was denied by the OS.
+final class MicPermissionDeniedException implements Exception {
+  const MicPermissionDeniedException();
+
+  @override
+  String toString() => 'microphone permission denied';
+}
+
+/// The captured WAV is missing or unreadable at persist time.
+final class TakeFileMissingException implements Exception {
+  const TakeFileMissingException(this.path);
+
+  final String path;
+
+  @override
+  String toString() => 'recording wav missing at path: $path';
+}
+
+/// Capture config aligned with the web client and Azure Speech expectations.
+///
+/// 16 kHz mono PCM16 WAV avoids stereo downmix loss (one mic channel + one
+/// silent / out-of-phase channel cancelling each other to zero) and matches
+/// what the Azure Speech SDK accepts directly without downstream re-encoding.
+///
+/// `device` is the user's chosen (or auto-picked, non-virtual) microphone —
+/// this is what stops Windows from silently picking GlideX / VoiceMeeter /
+/// Stereo-Mix loopback devices.
+RecordConfig buildShadowRecordConfig(InputDevice? device) => RecordConfig(
+  encoder: AudioEncoder.wav,
+  sampleRate: 16000,
+  numChannels: 1,
+  device: device,
+);
+
+class ShadowTakeStore {
+  ShadowTakeStore({
+    required AppDatabase db,
+    required SyncEnqueueFn enqueueSync,
+    MicRecorder Function()? recorderFactory,
+    Directory? takeDirectory,
+  }) {
+    _db = db;
+    _enqueueSync = enqueueSync;
+    _recorderFactory = recorderFactory ?? PackageRecordMicRecorder.new;
+    _takeDirectoryOverride = takeDirectory;
+    _recorder = _recorderFactory();
+  }
+
+  late final AppDatabase _db;
+  late final SyncEnqueueFn _enqueueSync;
+  late final MicRecorder Function() _recorderFactory;
+  late final Directory? _takeDirectoryOverride;
+
+  late MicRecorder _recorder;
+  bool _active = false;
+
+  /// Whether a take capture is currently in flight on the microphone.
+  bool get isActive => _active;
+
+  Future<Directory> _takeDirectory() async {
+    final override = _takeDirectoryOverride;
+    if (override != null) return override;
+    final support = await getApplicationSupportDirectory();
+    return Directory(p.join(support.path, 'recordings'));
+  }
+
+  /// Begins capturing a take. Throws [MicPermissionDeniedException] when the
+  /// OS denies the microphone, or propagates recorder errors.
+  Future<void> start({required InputDevice? device}) async {
+    final dir = await _takeDirectory();
+    await dir.create(recursive: true);
+    final id = const Uuid().v4();
+    final outPath = p.join(dir.path, '$id.wav');
+
+    final granted = await _recorder.hasPermission();
+    if (!granted) {
+      throw const MicPermissionDeniedException();
+    }
+
+    await _recorder.start(buildShadowRecordConfig(device), path: outPath);
+    _active = true;
+  }
+
+  /// Discards an in-progress take without persisting it.
+  Future<void> cancel() async {
+    if (!_active) return;
+    _active = false;
+    String? path;
+    try {
+      path = await _recorder.stop();
+    } catch (e, st) {
+      _log.warning('microphone stop (cancel recording) failed', e, st);
+    }
+    await _resetRecorder();
+    await _deleteFileIfExists(path);
+  }
+
+  /// Stops the capture and persists it as a [RecordingRow]. Returns the row
+  /// plus a silence verdict; throws [TakeFileMissingException] when nothing
+  /// was captured, or propagates DB / sync errors for the caller to surface.
+  Future<TakePersistResult> stopAndPersist({required TakeRegion region}) async {
+    if (!_active) {
+      throw const TakeFileMissingException('');
+    }
+    _active = false;
+
+    final path = await _recorder.stop();
+    await _resetRecorder();
+
+    if (path == null || path.isEmpty) {
+      _log.warning('recorder.stop returned no path');
+      throw const TakeFileMissingException('');
+    }
+    _log.fine('recorder.stop wrote $path');
+    return _persistRecording(path, region);
+  }
+
+  /// Removes a persisted take: sync-enqueue delete, file GC, then DAO delete.
+  /// Callers stop any preview playback of [row] first (a presentation concern).
+  Future<void> deleteTake(RecordingRow row) async {
+    await _enqueueSync(SyncEntityType.recording, row.id, SyncAction.delete);
+    final lp = row.localPath;
+    if (lp != null && lp.isNotEmpty) {
+      await _deleteFileIfExists(lp);
+    }
+    await _db.recordingDao.deleteId(row.id);
+  }
+
+  /// Stops any in-flight capture (discarding the WAV) and releases the
+  /// recorder. Safe to call from a widget `dispose`.
+  Future<void> dispose() async {
+    if (_active) {
+      _active = false;
+      try {
+        final path = await _recorder.stop();
+        await _deleteFileIfExists(path);
+      } catch (e, st) {
+        _log.fine('recorder stop on dispose', e, st);
+      }
+    }
+    try {
+      await _recorder.dispose();
+    } catch (_) {}
+  }
+
+  /// Recreated after every `stop()` — `record` on Windows can keep stale
+  /// Media Foundation state on the same instance, so a second `start()`
+  /// quietly produces a zero-sample WAV ("second take won't record").
+  Future<void> _resetRecorder() async {
+    final old = _recorder;
+    _recorder = _recorderFactory();
+    try {
+      await old.dispose();
+    } catch (e, st) {
+      _log.fine('audio recorder dispose after stop failed', e, st);
+    }
+  }
+
+  Future<void> _deleteFileIfExists(String? path) async {
+    if (path == null || path.isEmpty) return;
+    try {
+      final f = File(path);
+      if (await f.exists()) await f.delete();
+    } catch (e, st) {
+      _log.fine('delete recording wav failed', e, st);
+    }
+  }
+
+  Future<TakePersistResult> _persistRecording(
+    String wavPath,
+    TakeRegion region,
+  ) async {
+    final file = File(wavPath);
+    if (!await file.exists()) {
+      _log.warning('recording wav missing at path: $wavPath');
+      throw TakeFileMissingException(wavPath);
+    }
+    final bytes = await file.readAsBytes();
+    final hash = sha256.convert(bytes).toString();
+
+    final parsedMs = wavDurationMsFromBytes(bytes);
+    final durationMs = parsedMs ?? 0;
+    if (parsedMs == null && bytes.isNotEmpty) {
+      _log.warning(
+        'could not parse WAV duration ($wavPath, ${bytes.length} bytes)',
+      );
+    }
+
+    var looksSilent = false;
+    final peak = scanWavDataPeakFromBytes(bytes);
+    if (peak != null) {
+      _log.fine(
+        'recording wav fmt=${peak.fmt.audioFormat} '
+        'ch=${peak.fmt.numChannels} ${peak.fmt.sampleRate}Hz '
+        '${peak.fmt.bitsPerSample}bit '
+        'peak≈${peak.peakNormalized.toStringAsFixed(5)} '
+        'rms≈${peak.rmsNormalized.toStringAsFixed(6)} '
+        'nonZero=${(peak.nonZeroRatio * 100).toStringAsFixed(2)}% '
+        'samples=${peak.totalSamples} '
+        'bytes=${bytes.length} durMs=$durationMs',
+      );
+      // Real speech captured at moderate volume gives RMS in the rough
+      // 0.02-0.3 range. RMS below ~0.001 with non-zero ratio under ~1% means
+      // the WAV is essentially silent even when peak looks healthy.
+      const minRms = 0.001;
+      const minNonZeroRatio = 0.01;
+      looksSilent =
+          peak.rmsNormalized < minRms || peak.nonZeroRatio < minNonZeroRatio;
+      if (looksSilent) {
+        _log.warning(
+          'recording wav appears silent '
+          '(peak≈${peak.peakNormalized.toStringAsFixed(6)} '
+          'rms≈${peak.rmsNormalized.toStringAsFixed(6)} '
+          'nonZero=${(peak.nonZeroRatio * 100).toStringAsFixed(2)}%). '
+          'Check Windows microphone privacy / default input device.',
+        );
+      }
+    }
+
+    final id = p.basenameWithoutExtension(wavPath);
+    final now = DateTime.now();
+    final startMs = (region.startSec * 1000).round();
+    final durMs = ((region.endSec - region.startSec) * 1000).round();
+    final row = RecordingRow(
+      id: id,
+      targetType: region.targetType,
+      targetId: region.targetId,
+      referenceStart: startMs,
+      referenceDuration: durMs,
+      referenceText: region.referenceText,
+      language: region.language,
+      duration: durationMs,
+      md5: hash,
+      audioUrl: null,
+      pronunciationScore: null,
+      assessmentJson: null,
+      localPath: wavPath,
+      syncStatus: 'local',
+      serverUpdatedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    );
+    await _db.recordingDao.insertRow(row);
+    await _enqueueSync(SyncEntityType.recording, id, SyncAction.create);
+    return TakePersistResult(row: row, looksSilent: looksSilent);
+  }
+}

--- a/lib/features/shadow_reading/presentation/shadow_reading_panel.dart
+++ b/lib/features/shadow_reading/presentation/shadow_reading_panel.dart
@@ -4,18 +4,11 @@ library;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show Ticker;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
-import 'package:record/record.dart';
-import 'package:uuid/uuid.dart';
 
 import 'package:enjoy_player/core/audio/recording_preview_player_provider.dart';
-import 'package:enjoy_player/core/audio/wav_duration_ms.dart';
-import 'package:enjoy_player/core/audio/wav_signal_peak.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
@@ -27,10 +20,10 @@ import 'package:enjoy_player/data/db/media_registry.dart';
 import 'package:enjoy_player/features/hotkeys/presentation/hotkey_tooltip_label.dart';
 import 'package:enjoy_player/features/shadow_reading/application/recording_input_device_controller.dart';
 import 'package:enjoy_player/features/shadow_reading/application/shadow_reading_hotkey_bus.dart';
+import 'package:enjoy_player/features/shadow_reading/application/shadow_take_store.dart';
 import 'package:enjoy_player/features/shadow_reading/presentation/recording_assessment_flow.dart';
 import 'package:enjoy_player/features/share_poster/presentation/share_practice_poster_button.dart';
 import 'package:enjoy_player/features/sync/application/sync_providers.dart';
-import 'package:enjoy_player/features/sync/domain/sync_types.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 import 'pitch_contour_section.dart';
@@ -100,29 +93,18 @@ class ShadowReadingPanel extends ConsumerStatefulWidget {
   ConsumerState<ShadowReadingPanel> createState() => _ShadowReadingPanelState();
 }
 
-/// Capture config aligned with the web client and Azure Speech expectations.
-///
-/// 16 kHz mono PCM16 WAV avoids stereo downmix loss (one mic channel + one
-/// silent / out-of-phase channel cancelling each other to zero) and matches
-/// what the Azure Speech SDK accepts directly without downstream re-encoding.
-///
-/// `device` is filled in at call site from
-/// [recordingInputDeviceCtrlProvider] so we capture from the user's chosen
-/// (or auto-picked, non-virtual) microphone — this is what stops Windows from
-/// silently picking GlideX / VoiceMeeter / Stereo-Mix loopback devices.
-RecordConfig _buildShadowRecordConfig(InputDevice? device) => RecordConfig(
-  encoder: AudioEncoder.wav,
-  sampleRate: 16000,
-  numChannels: 1,
-  device: device,
-);
+/// Capture config aligned with the web client and Azure Speech expectations
+/// lives in [buildShadowRecordConfig] (shadow_take_store.dart).
 
 class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
     with TickerProviderStateMixin {
-  /// Recreated after every `stop()` — `record` on Windows can keep stale Media
-  /// Foundation state on the same instance, so a second `start()` quietly
-  /// produces a zero-sample WAV ("second take won't record").
-  AudioRecorder _recorder = AudioRecorder();
+  ShadowTakeStore? _takeStoreInstance;
+
+  ShadowTakeStore get _takeStore => _takeStoreInstance ??= ShadowTakeStore(
+    db: ref.read(appDatabaseProvider),
+    enqueueSync: ref.read(syncEnqueueProvider),
+  );
+
   bool _recording = false;
   bool _recordingPending = false;
   String? _selectedRecordingId;
@@ -219,25 +201,11 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
       if (mounted) setState(() {});
       return;
     }
-    String? path;
-    try {
-      path = await _recorder.stop();
-    } catch (e, st) {
-      _log.warning('microphone stop (cancel recording) failed', e, st);
-    }
+    await _takeStore.cancel();
     _recording = false;
     _recordingPending = false;
     _clearRecordingTiming();
     _setRecordingActiveOnBus(false);
-    await _resetRecorderInstance();
-    if (path != null && path.isNotEmpty) {
-      try {
-        final f = File(path);
-        if (await f.exists()) await f.delete();
-      } catch (e, st) {
-        _log.fine('delete cancelled recording wav failed', e, st);
-      }
-    }
     if (mounted) setState(() {});
   }
 
@@ -251,23 +219,10 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
       _recordingPending = false;
       _setRecordingActiveOnBus(false);
     }
-    unawaited(() async {
-      if (wasRecording) {
-        try {
-          final path = await _recorder.stop();
-          if (path != null && path.isNotEmpty) {
-            try {
-              await File(path).delete();
-            } catch (_) {}
-          }
-        } catch (e, st) {
-          _log.fine('recorder stop on dispose', e, st);
-        }
-      }
-      try {
-        await _recorder.dispose();
-      } catch (_) {}
-    }());
+    final store = _takeStoreInstance;
+    if (store != null) {
+      unawaited(store.dispose());
+    }
     super.dispose();
   }
 
@@ -288,50 +243,31 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
     return (t - widget.startSec).clamp(0.0, widget.endSec - widget.startSec);
   }
 
-  Future<void> _resetRecorderInstance() async {
-    final old = _recorder;
-    _recorder = AudioRecorder();
-    try {
-      await old.dispose();
-    } catch (e, st) {
-      _log.fine('audio recorder dispose after stop failed', e, st);
-    }
-  }
-
   Future<void> _toggleRecord(AppLocalizations l10n) async {
     if (!widget.echoActive) return;
     if (_recording) {
-      String? path;
-      try {
-        path = await _recorder.stop();
-      } catch (e, st) {
-        _log.warning('microphone stop failed', e, st);
-        _recording = false;
-        _recordingPending = false;
-        _setRecordingActiveOnBus(false);
-        _clearRecordingTiming();
-        await _resetRecorderInstance();
-        if (mounted) setState(() {});
-        if (mounted) {
-          AppNotice.error(
-            context,
-            l10n.shadowRecordingSaveFailed(_shortSaveError(e)),
-          );
-        }
-        return;
-      }
       _recording = false;
       _recordingPending = false;
       _setRecordingActiveOnBus(false);
       _clearRecordingTiming();
-      await _resetRecorderInstance();
       setState(() {});
-      if (path == null || path.isEmpty) {
-        _log.warning('recorder.stop returned no path');
+      TakePersistResult outcome;
+      try {
+        outcome = await _takeStore.stopAndPersist(region: _takeRegion);
+      } catch (e) {
+        if (mounted) {
+          final message = e is TakeFileMissingException
+              ? l10n.shadowRecordingFileNotFound
+              : l10n.shadowRecordingSaveFailed(_shortSaveError(e));
+          AppNotice.error(context, message);
+        }
         return;
       }
-      _log.fine('recorder.stop wrote $path');
-      await _persistRecording(path, l10n);
+      if (!mounted) return;
+      if (outcome.looksSilent) {
+        AppNotice.warning(context, l10n.shadowRecordingSilentWarning);
+      }
+      setState(() => _selectedRecordingId = outcome.row.id);
       return;
     }
 
@@ -340,51 +276,26 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
     _setRecordingActiveOnBus(true);
     _recordingPending = true;
 
-    final support = await getApplicationSupportDirectory();
-    final dir = Directory(p.join(support.path, 'recordings'));
-    await dir.create(recursive: true);
-    final id = const Uuid().v4();
-    final outPath = p.join(dir.path, '$id.wav');
+    // Refresh so a USB mic plugged in since app start is considered by the
+    // auto-pick heuristic (selection is then read from the provider state).
+    await ref.read(recordingInputDeviceCtrlProvider.notifier).refresh();
+    final deviceState = ref.read(recordingInputDeviceCtrlProvider).valueOrNull;
+    final selectedDevice = deviceState?.selectedDevice;
 
-    bool granted;
     try {
-      granted = await _recorder.hasPermission();
-    } catch (e, st) {
-      _log.warning('recorder.hasPermission failed', e, st);
-      _recordingPending = false;
-      _setRecordingActiveOnBus(false);
-      if (mounted) {
-        AppNotice.error(
-          context,
-          l10n.shadowRecordingSaveFailed(_shortSaveError(e)),
-        );
-      }
-      return;
-    }
-    if (!granted) {
+      await _takeStore.start(device: selectedDevice);
+    } on MicPermissionDeniedException {
       _recordingPending = false;
       _setRecordingActiveOnBus(false);
       if (mounted) {
         AppNotice.warning(context, l10n.shadowRecordingMicDenied);
       }
       return;
-    }
-
-    // Refresh so a USB mic plugged in since app start is considered by the
-    // auto-pick heuristic (selection is then read from the provider state).
-    await ref.read(recordingInputDeviceCtrlProvider.notifier).refresh();
-    final deviceState = ref.read(recordingInputDeviceCtrlProvider).valueOrNull;
-    final selectedDevice = deviceState?.selectedDevice;
-    final config = _buildShadowRecordConfig(selectedDevice);
-
-    try {
-      await _recorder.start(config, path: outPath);
     } catch (e, st) {
-      _log.warning('recorder.start failed at $outPath', e, st);
+      _log.warning('take start failed', e, st);
       _recordingPending = false;
       _setRecordingActiveOnBus(false);
       _clearRecordingTiming();
-      await _resetRecorderInstance();
       if (mounted) setState(() {});
       if (mounted) {
         AppNotice.error(
@@ -395,9 +306,7 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
       return;
     }
     _log.fine(
-      'recorder.start ok path=$outPath '
-      'sampleRate=${config.sampleRate} numChannels=${config.numChannels} '
-      'device="${selectedDevice?.label ?? "<os-default>"}"'
+      'take start device="${selectedDevice?.label ?? "<os-default>"}"'
       '${deviceState?.autoPicked == false ? " (user)" : " (auto)"}',
     );
     _recording = true;
@@ -409,106 +318,14 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
     setState(() {});
   }
 
-  Future<void> _persistRecording(String wavPath, AppLocalizations l10n) async {
-    try {
-      final file = File(wavPath);
-      if (!await file.exists()) {
-        _log.warning('recording wav missing at path: $wavPath');
-        if (mounted) {
-          AppNotice.error(
-            context,
-            l10n.shadowRecordingSaveFailed(l10n.shadowRecordingFileNotFound),
-          );
-        }
-        return;
-      }
-      final bytes = await file.readAsBytes();
-      final hash = sha256.convert(bytes).toString();
-
-      final parsedMs = wavDurationMsFromBytes(bytes);
-      final durationMs = parsedMs ?? 0;
-      if (parsedMs == null && bytes.isNotEmpty) {
-        _log.warning(
-          'could not parse WAV duration ($wavPath, ${bytes.length} bytes)',
-        );
-      }
-
-      final peak = scanWavDataPeakFromBytes(bytes);
-      if (peak != null) {
-        _log.fine(
-          'recording wav fmt=${peak.fmt.audioFormat} '
-          'ch=${peak.fmt.numChannels} ${peak.fmt.sampleRate}Hz '
-          '${peak.fmt.bitsPerSample}bit '
-          'peak≈${peak.peakNormalized.toStringAsFixed(5)} '
-          'rms≈${peak.rmsNormalized.toStringAsFixed(6)} '
-          'nonZero=${(peak.nonZeroRatio * 100).toStringAsFixed(2)}% '
-          'samples=${peak.totalSamples} '
-          'bytes=${bytes.length} durMs=$durationMs',
-        );
-        // Real speech captured at moderate volume gives RMS in the rough
-        // 0.02-0.3 range. RMS below ~0.001 with non-zero ratio under ~1% means
-        // the WAV is essentially silent even when peak looks healthy.
-        const minRms = 0.001;
-        const minNonZeroRatio = 0.01;
-        final looksSilent =
-            peak.rmsNormalized < minRms || peak.nonZeroRatio < minNonZeroRatio;
-        if (looksSilent) {
-          _log.warning(
-            'recording wav appears silent '
-            '(peak≈${peak.peakNormalized.toStringAsFixed(6)} '
-            'rms≈${peak.rmsNormalized.toStringAsFixed(6)} '
-            'nonZero=${(peak.nonZeroRatio * 100).toStringAsFixed(2)}%). '
-            'Check Windows microphone privacy / default input device.',
-          );
-          if (mounted) {
-            AppNotice.warning(context, l10n.shadowRecordingSilentWarning);
-          }
-        }
-      }
-
-      final db = ref.read(appDatabaseProvider);
-      final id = p.basenameWithoutExtension(wavPath);
-      final now = DateTime.now();
-      final startMs = (widget.startSec * 1000).round();
-      final durMs = ((widget.endSec - widget.startSec) * 1000).round();
-      final row = RecordingRow(
-        id: id,
-        targetType: widget.targetType,
-        targetId: widget.mediaId,
-        referenceStart: startMs,
-        referenceDuration: durMs,
-        referenceText: widget.referenceText,
-        language: widget.language,
-        duration: durationMs,
-        md5: hash,
-        audioUrl: null,
-        pronunciationScore: null,
-        assessmentJson: null,
-        localPath: wavPath,
-        syncStatus: 'local',
-        serverUpdatedAt: null,
-        createdAt: now,
-        updatedAt: now,
-      );
-      await db.recordingDao.insertRow(row);
-      await ref.read(syncEnqueueProvider)(
-        SyncEntityType.recording,
-        id,
-        SyncAction.create,
-      );
-      if (mounted) {
-        setState(() => _selectedRecordingId = id);
-      }
-    } catch (e, st) {
-      _log.warning('save recording failed', e, st);
-      if (mounted) {
-        AppNotice.error(
-          context,
-          l10n.shadowRecordingSaveFailed(_shortSaveError(e)),
-        );
-      }
-    }
-  }
+  TakeRegion get _takeRegion => TakeRegion(
+    targetType: widget.targetType,
+    targetId: widget.mediaId,
+    language: widget.language,
+    referenceText: widget.referenceText,
+    startSec: widget.startSec,
+    endSec: widget.endSec,
+  );
 
   Future<void> _playOrPauseTake(String path) async {
     try {
@@ -522,11 +339,7 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
   }
 
   Future<void> _deleteRecording(RecordingRow r) async {
-    await ref.read(syncEnqueueProvider)(
-      SyncEntityType.recording,
-      r.id,
-      SyncAction.delete,
-    );
+    // Stop preview playback of this take before its file is removed.
     final preview = ref.read(recordingPreviewPlayerProvider);
     final lp = r.localPath;
     if (lp != null && lp.isNotEmpty) {
@@ -534,10 +347,9 @@ class _ShadowReadingPanelState extends ConsumerState<ShadowReadingPanel>
         if (preview.loadedPath == File(lp).absolute.path) {
           await preview.stop();
         }
-        await File(lp).delete();
       } catch (_) {}
     }
-    await ref.read(appDatabaseProvider).recordingDao.deleteId(r.id);
+    await _takeStore.deleteTake(r);
     if (mounted) {
       setState(() => _selectedRecordingId = null);
     }

--- a/test/features/shadow_reading/application/shadow_take_store_test.dart
+++ b/test/features/shadow_reading/application/shadow_take_store_test.dart
@@ -1,0 +1,349 @@
+// Tests for ShadowTakeStore (issue #597) through its seam: in-memory Drift,
+// a fake MicRecorder, a temp take directory, and a recording SyncEnqueueFn.
+// The interface is the test surface — no widget tree, no platform channels.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:record/record.dart';
+
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/features/shadow_reading/application/shadow_take_store.dart';
+import 'package:enjoy_player/features/sync/domain/sync_types.dart';
+
+/// Minimal RIFF PCM16 mono WAV (44-byte header + samples).
+Uint8List buildPcm16Wav(List<int> samples, {int sampleRate = 16000}) {
+  const bitsPerSample = 16;
+  const numChannels = 1;
+  final blockAlign = numChannels * bitsPerSample ~/ 8;
+  final byteRate = sampleRate * blockAlign;
+  final dataSize = samples.length * blockAlign;
+  final data = ByteData(44 + dataSize);
+  void ascii(int offset, String s) {
+    for (var i = 0; i < s.length; i++) {
+      data.setUint8(offset + i, s.codeUnitAt(i));
+    }
+  }
+
+  ascii(0, 'RIFF');
+  data.setUint32(4, 36 + dataSize, Endian.little);
+  ascii(8, 'WAVE');
+  ascii(12, 'fmt ');
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little); // PCM
+  data.setUint16(22, numChannels, Endian.little);
+  data.setUint32(24, sampleRate, Endian.little);
+  data.setUint32(28, byteRate, Endian.little);
+  data.setUint16(32, blockAlign, Endian.little);
+  data.setUint16(34, bitsPerSample, Endian.little);
+  ascii(36, 'data');
+  data.setUint32(40, dataSize, Endian.little);
+  for (var i = 0; i < samples.length; i++) {
+    data.setInt16(44 + i * 2, samples[i], Endian.little);
+  }
+  return data.buffer.asUint8List();
+}
+
+class FakeMicRecorder implements MicRecorder {
+  bool permissionGranted = true;
+  Object? permissionError;
+  Object? startError;
+  Object? stopError;
+  String? Function()? stopResult;
+
+  final startedPaths = <String>[];
+  RecordConfig? lastConfig;
+  int stopCalls = 0;
+  int disposeCalls = 0;
+
+  @override
+  Future<bool> hasPermission() async {
+    final e = permissionError;
+    if (e != null) throw e;
+    return permissionGranted;
+  }
+
+  @override
+  Future<void> start(RecordConfig config, {required String path}) async {
+    final e = startError;
+    if (e != null) throw e;
+    lastConfig = config;
+    startedPaths.add(path);
+  }
+
+  @override
+  Future<String?> stop() async {
+    stopCalls++;
+    final e = stopError;
+    if (e != null) throw e;
+    final r = stopResult;
+    return r == null ? null : r();
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+  }
+}
+
+const _region = TakeRegion(
+  targetType: 'video',
+  targetId: 'media-1',
+  language: 'en',
+  referenceText: 'hello world',
+  startSec: 10.0,
+  endSec: 12.5,
+);
+
+void main() {
+  late AppDatabase db;
+  late Directory tempDir;
+  late FakeMicRecorder recorder;
+  late List<(SyncEntityType, String, SyncAction)> syncCalls;
+  late ShadowTakeStore store;
+
+  setUp(() async {
+    db = AppDatabase(executor: NativeDatabase.memory());
+    tempDir = await Directory.systemTemp.createTemp('take_store_test');
+    recorder = FakeMicRecorder();
+    syncCalls = [];
+    store = ShadowTakeStore(
+      db: db,
+      enqueueSync: (type, id, action) async {
+        syncCalls.add((type, id, action));
+      },
+      recorderFactory: () => recorder,
+      takeDirectory: tempDir,
+    );
+  });
+
+  tearDown(() async {
+    await store.dispose();
+    await db.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  /// Starts a take and arms the fake so `stop` returns the started path.
+  Future<String> startTake() async {
+    await store.start(device: null);
+    final path = recorder.startedPaths.last;
+    recorder.stopResult = () => path;
+    return path;
+  }
+
+  group('start', () {
+    test(
+      'captures into the take directory with 16 kHz mono WAV config',
+      () async {
+        await store.start(device: null);
+        expect(recorder.startedPaths, hasLength(1));
+        final path = recorder.startedPaths.single;
+        expect(path, startsWith(tempDir.path));
+        expect(path, endsWith('.wav'));
+        expect(store.isActive, isTrue);
+        final config = recorder.lastConfig!;
+        expect(config.encoder, AudioEncoder.wav);
+        expect(config.sampleRate, 16000);
+        expect(config.numChannels, 1);
+      },
+    );
+
+    test(
+      'throws MicPermissionDeniedException when the OS denies the mic',
+      () async {
+        recorder.permissionGranted = false;
+        await expectLater(
+          store.start(device: null),
+          throwsA(isA<MicPermissionDeniedException>()),
+        );
+        expect(recorder.startedPaths, isEmpty);
+        expect(store.isActive, isFalse);
+      },
+    );
+
+    test('propagates recorder start errors without going active', () async {
+      recorder.startError = StateError('device busy');
+      await expectLater(store.start(device: null), throwsA(isA<StateError>()));
+      expect(store.isActive, isFalse);
+    });
+  });
+
+  group('stopAndPersist', () {
+    test(
+      'persists hash, duration, reference fields and enqueues sync create',
+      () async {
+        final path = await startTake();
+        final samples = List<int>.generate(
+          1600,
+          (i) => i.isEven ? 16000 : -16000,
+        );
+        final bytes = buildPcm16Wav(samples);
+        await File(path).writeAsBytes(bytes);
+
+        final outcome = await store.stopAndPersist(region: _region);
+        final row = outcome.row;
+
+        expect(outcome.looksSilent, isFalse);
+        expect(
+          row.id,
+          path.split(Platform.pathSeparator).last.replaceAll('.wav', ''),
+        );
+        expect(row.targetType, 'video');
+        expect(row.targetId, 'media-1');
+        expect(row.language, 'en');
+        expect(row.referenceText, 'hello world');
+        expect(row.referenceStart, 10000);
+        expect(row.referenceDuration, 2500);
+        expect(row.duration, 100); // 1600 samples @ 16 kHz
+        expect(row.md5, sha256.convert(bytes).toString());
+        expect(row.localPath, path);
+        expect(row.syncStatus, 'local');
+
+        final stored = await db.recordingDao.getById(row.id);
+        expect(stored, isNotNull);
+        expect(stored!.id, row.id);
+        expect(syncCalls, [
+          (SyncEntityType.recording, row.id, SyncAction.create),
+        ]);
+        expect(store.isActive, isFalse);
+      },
+    );
+
+    test('flags a silent WAV but still persists it', () async {
+      final path = await startTake();
+      await File(path).writeAsBytes(buildPcm16Wav(List.filled(1600, 0)));
+
+      final outcome = await store.stopAndPersist(region: _region);
+      expect(outcome.looksSilent, isTrue);
+      expect(await db.recordingDao.getById(outcome.row.id), isNotNull);
+      expect(syncCalls, hasLength(1));
+    });
+
+    test('throws TakeFileMissingException when the WAV is gone', () async {
+      final path = await startTake();
+      // No file written — simulates the recorder yielding nothing on disk.
+      await expectLater(
+        store.stopAndPersist(region: _region),
+        throwsA(isA<TakeFileMissingException>()),
+      );
+      expect(path, isNotEmpty);
+      expect(syncCalls, isEmpty);
+    });
+
+    test('throws TakeFileMissingException when stop yields no path', () async {
+      await store.start(device: null);
+      recorder.stopResult = null;
+      await expectLater(
+        store.stopAndPersist(region: _region),
+        throwsA(isA<TakeFileMissingException>()),
+      );
+      expect(syncCalls, isEmpty);
+    });
+
+    test(
+      'recreates the recorder after a persist (Windows stale-state fix)',
+      () async {
+        var created = 0;
+        final countingStore = ShadowTakeStore(
+          db: db,
+          enqueueSync: (type, id, action) async {},
+          recorderFactory: () {
+            created++;
+            return recorder;
+          },
+          takeDirectory: tempDir,
+        );
+        await countingStore.start(device: null);
+        final path = recorder.startedPaths.last;
+        recorder.stopResult = () => path;
+        await File(path).writeAsBytes(buildPcm16Wav(List.filled(160, 8000)));
+        expect(created, 1);
+        await countingStore.stopAndPersist(region: _region);
+        expect(created, 2);
+        await countingStore.dispose();
+      },
+    );
+  });
+
+  group('cancel', () {
+    test('deletes the captured WAV and leaves the store inactive', () async {
+      final path = await startTake();
+      await File(path).writeAsBytes(buildPcm16Wav(List.filled(160, 8000)));
+
+      await store.cancel();
+
+      expect(await File(path).exists(), isFalse);
+      expect(store.isActive, isFalse);
+      expect(syncCalls, isEmpty);
+      await expectLater(
+        store.stopAndPersist(region: _region),
+        throwsA(isA<TakeFileMissingException>()),
+      );
+    });
+
+    test('is a no-op when nothing is being captured', () async {
+      await store.cancel();
+      expect(recorder.stopCalls, 0);
+      expect(store.isActive, isFalse);
+    });
+  });
+
+  group('deleteTake', () {
+    test('removes the file and row and enqueues sync delete', () async {
+      final path = await startTake();
+      final bytes = buildPcm16Wav(List.filled(160, 8000));
+      await File(path).writeAsBytes(bytes);
+      final outcome = await store.stopAndPersist(region: _region);
+      final row = outcome.row;
+      syncCalls.clear();
+
+      await store.deleteTake(row);
+
+      expect(await File(path).exists(), isFalse);
+      expect(await db.recordingDao.getById(row.id), isNull);
+      expect(syncCalls, [
+        (SyncEntityType.recording, row.id, SyncAction.delete),
+      ]);
+    });
+
+    test('tolerates a row whose file is already gone', () async {
+      final inserted = RecordingRow(
+        id: 'orphan',
+        targetType: 'video',
+        targetId: 'media-1',
+        referenceStart: 0,
+        referenceDuration: 1000,
+        referenceText: '',
+        language: 'en',
+        duration: 100,
+        localPath: '${tempDir.path}/never-there.wav',
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      );
+      await db.recordingDao.insertRow(inserted);
+
+      await store.deleteTake(inserted);
+
+      expect(await db.recordingDao.getById('orphan'), isNull);
+      expect(syncCalls, [
+        (SyncEntityType.recording, 'orphan', SyncAction.delete),
+      ]);
+    });
+  });
+
+  group('dispose', () {
+    test('discards an in-flight capture', () async {
+      final path = await startTake();
+      await File(path).writeAsBytes(buildPcm16Wav(List.filled(160, 8000)));
+
+      await store.dispose();
+
+      expect(await File(path).exists(), isFalse);
+      expect(store.isActive, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Resolves #597 (part of #592)

## Summary

- Introduces `ShadowTakeStore`, a deep module that owns the full take lifecycle — mic capture, WAV persistence, silence heuristics, Drift insert, and sync enqueue — behind a four-method interface (`start`, `stopAndPersist`, `cancel`, `deleteTake`).
- `ShadowReadingPanel` shrinks by ~230 lines to a pure view + callbacks: it maps sealed outcomes (`MicPermissionDeniedException`, `TakeFileMissingException`, `TakePersistResult.looksSilent`) to localized notices and nothing else.
- Adds a `MicRecorder` port with `PackageRecordMicRecorder` as the production adapter — a real seam justified by Craft's `CaptureStage` duplicating the same recorder lifecycle (migration of that second call site is a follow-up).

## Changes

- `lib/features/shadow_reading/application/shadow_take_store.dart` (new): capture config (`buildShadowRecordConfig`), `TakeRegion`, `TakePersistResult`, typed exceptions; recreate-after-stop invariant for Windows Media Foundation preserved inside `_resetRecorder`; persistence pipeline = file-exists check → sha256 → WAV duration → peak/RMS silence scan → `RecordingRow` insert (ADR-0002) → sync enqueue (ADR-0013).
- `lib/features/shadow_reading/presentation/shadow_reading_panel.dart`: delegates record / stop / cancel / delete to the store; keeps preview-player stop-on-delete, device selection via Riverpod, hotkey bus, and tickers.
- `test/features/shadow_reading/application/shadow_take_store_test.dart` (new): 13 seam tests through the store interface with a fake `MicRecorder` and in-memory Drift DB.
- `docs/features/shadow-reading.md`: new "Take capture & persistence (ShadowTakeStore)" section.

## Verification

- `flutter test test/features/shadow_reading/` — 228 tests, all passing
- `flutter analyze` — no issues
- `bash .github/scripts/validate_ci_gates.sh --fix` — all gates passed

## Test plan

- [ ] Record a take and stop — take appears selected, row + sync create enqueued
- [ ] Record a silent take — warning notice shown, take still persisted
- [ ] Deny mic permission — denied notice, no stuck recording state
- [ ] Cancel mid-record (button + Escape) — temp WAV deleted, no row
- [ ] Delete a take — file removed, row gone, sync delete enqueued
- [ ] Close panel mid-record — recorder disposed, no leaked mic session