### PR TITLE
refactor(transcript): collapse TranscriptEnricher seams into one EnrichmentBackend port

### DIFF
--- a/lib/features/transcript/application/transcript_enrichment_controller.dart
+++ b/lib/features/transcript/application/transcript_enrichment_controller.dart
@@ -19,6 +19,8 @@ import 'package:enjoy_player/data/subtitle/subtitle_markup_parser.dart';
 import 'package:enjoy_player/data/subtitle/transcript_line.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_repository_provider.dart';
+import 'package:enjoy_player/features/transcript/data/forced_alignment_enrichment_backend.dart';
+import 'package:enjoy_player/features/transcript/domain/enrichment_backend.dart';
 
 part 'transcript_enrichment_controller.g.dart';
 
@@ -77,40 +79,6 @@ class TranscriptEnrichmentState {
 typedef EnrichProgressFn =
     void Function({required int completed, required int total});
 
-typedef DecodeFilePcm16k = Future<Float32List> Function(String pathOrUri);
-
-typedef DecodeFileWindowPcm16k =
-    Future<Float32List> Function({
-      required String pathOrUri,
-      required double startSeconds,
-      required double durationSeconds,
-    });
-
-typedef AlignSegmentsFn =
-    Future<AlignmentOutcome> Function({
-      required Float32List sourcePcm16k,
-      required String language,
-      required List<AlignmentSegment> segments,
-      required AlignmentGranularity granularity,
-      AlignmentCancelToken? cancel,
-    });
-
-typedef AlignFn =
-    Future<AlignmentOutcome> Function({
-      required Float32List sourcePcm16k,
-      required String transcript,
-      required String language,
-      AlignmentCancelToken? cancel,
-      required double timeOffset,
-    });
-
-typedef PhonemizeLinesFn =
-    Future<PhonemizeOutcome> Function({
-      required List<String> texts,
-      required String language,
-      AlignmentCancelToken? cancel,
-    });
-
 typedef ReplaceTimelineFn =
     Future<bool> Function({
       required String transcriptId,
@@ -133,33 +101,14 @@ final class TranscriptEnrichmentErr extends TranscriptEnrichmentOutcome {
   final String reason;
 }
 
-typedef DownloadHttpMedia =
-    Future<String> Function(String url, {AlignmentCancelToken? cancel});
-
 /// Injectable owned-align / YouTube-phonemize worker. No work until [enrich].
 final class TranscriptEnricher {
-  TranscriptEnricher({
-    required this.replaceTimeline,
-    DecodeFilePcm16k? decodeFile,
-    DecodeFileWindowPcm16k? decodeWindow,
-    AlignSegmentsFn? alignSegmentsFn,
-    AlignFn? alignFn,
-    PhonemizeLinesFn? phonemizeFn,
-    DownloadHttpMedia? downloadHttp,
-  }) : _decodeFile = decodeFile ?? decodeFileToPcm16kMono,
-       _decodeWindow = decodeWindow ?? decodeFileWindowToPcm16kMono,
-       _alignSegments = alignSegmentsFn ?? _productionAlignSegments,
-       _align = alignFn ?? _productionAlign,
-       _phonemize = phonemizeFn ?? _productionPhonemize,
-       _downloadHttp = downloadHttp ?? downloadHttpMediaToTemp;
+  TranscriptEnricher({required this.replaceTimeline, required this.backend});
 
   final ReplaceTimelineFn replaceTimeline;
-  final DecodeFilePcm16k _decodeFile;
-  final DecodeFileWindowPcm16k _decodeWindow;
-  final AlignSegmentsFn _alignSegments;
-  final AlignFn _align;
-  final PhonemizeLinesFn _phonemize;
-  final DownloadHttpMedia _downloadHttp;
+
+  /// Decode / align / phonemize / download machinery for this run.
+  final EnrichmentBackend backend;
 
   /// Owned media: timed words + phones. YouTube: untimed IPA labels.
   Future<TranscriptEnrichmentOutcome> enrich({
@@ -205,7 +154,7 @@ final class TranscriptEnricher {
     String? downloaded;
     if (pcm16kInputIsRemoteHttp(ownedPath)) {
       try {
-        downloaded = await _downloadHttp(ownedPath, cancel: cancel);
+        downloaded = await backend.downloadHttp(ownedPath, cancel: cancel);
         ownedPath = downloaded;
       } on Object catch (e, st) {
         if (cancel?.isCancelled ?? false) {
@@ -243,7 +192,7 @@ final class TranscriptEnricher {
     onProgress?.call(completed: 0, total: lines.length);
     late final PhonemizeOutcome outcome;
     try {
-      outcome = await _phonemize(
+      outcome = await backend.phonemize(
         texts: [
           for (final line in lines) plainTextFromSubtitleMarkup(line.text),
         ],
@@ -324,7 +273,7 @@ final class TranscriptEnricher {
     onProgress?.call(completed: 0, total: lines.length);
     late final Float32List pcm;
     try {
-      pcm = await _decodeFile(localPath);
+      pcm = await backend.decodeFile(localPath);
     } on Object catch (e, st) {
       logNamed(
         'transcript.enrichment',
@@ -350,7 +299,7 @@ final class TranscriptEnricher {
 
     late final AlignmentOutcome outcome;
     try {
-      outcome = await _alignSegments(
+      outcome = await backend.alignSegments(
         sourcePcm16k: pcm,
         language: language,
         segments: segments,
@@ -410,7 +359,7 @@ final class TranscriptEnricher {
             (line.endSeconds - line.startSeconds) + (2 * kCuePadSeconds);
         late final Float32List pcm;
         try {
-          pcm = await _decodeWindow(
+          pcm = await backend.decodeWindow(
             pathOrUri: localPath,
             startSeconds: start,
             durationSeconds: duration <= 0 ? kMinAudioSeconds : duration,
@@ -425,7 +374,7 @@ final class TranscriptEnricher {
 
         late final AlignmentOutcome outcome;
         try {
-          outcome = await _align(
+          outcome = await backend.align(
             sourcePcm16k: pcm,
             transcript: line.text,
             language: language,
@@ -530,46 +479,6 @@ extension on TimelineEntry {
   }
 }
 
-Future<AlignmentOutcome> _productionAlignSegments({
-  required Float32List sourcePcm16k,
-  required String language,
-  required List<AlignmentSegment> segments,
-  required AlignmentGranularity granularity,
-  AlignmentCancelToken? cancel,
-}) {
-  return alignSegments(
-    sourcePcm16k: sourcePcm16k,
-    language: language,
-    segments: segments,
-    granularity: granularity,
-    cancel: cancel,
-  );
-}
-
-Future<AlignmentOutcome> _productionAlign({
-  required Float32List sourcePcm16k,
-  required String transcript,
-  required String language,
-  AlignmentCancelToken? cancel,
-  required double timeOffset,
-}) {
-  return align(
-    sourcePcm16k: sourcePcm16k,
-    transcript: transcript,
-    language: language,
-    cancel: cancel,
-    timeOffset: timeOffset,
-  );
-}
-
-Future<PhonemizeOutcome> _productionPhonemize({
-  required List<String> texts,
-  required String language,
-  AlignmentCancelToken? cancel,
-}) {
-  return phonemizeLines(texts: texts, language: language, cancel: cancel);
-}
-
 @Riverpod(keepAlive: true)
 TranscriptEnricher transcriptEnricher(Ref ref) {
   final repo = ref.watch(transcriptRepositoryProvider);
@@ -577,6 +486,7 @@ TranscriptEnricher transcriptEnricher(Ref ref) {
     replaceTimeline: ({required transcriptId, required lines}) {
       return repo.replaceTimeline(transcriptId: transcriptId, lines: lines);
     },
+    backend: const ForcedAlignmentEnrichmentBackend(),
   );
 }
 

--- a/lib/features/transcript/application/transcript_enrichment_controller.g.dart
+++ b/lib/features/transcript/application/transcript_enrichment_controller.g.dart
@@ -55,7 +55,7 @@ final class TranscriptEnricherProvider
 }
 
 String _$transcriptEnricherHash() =>
-    r'842cc15d5b7d044d1095f8d45b94cdb6c4f276c2';
+    r'2de1e4884094f26def55abd9b9a0143a5af86aef';
 
 @ProviderFor(TranscriptEnrichmentController)
 final transcriptEnrichmentControllerProvider =

--- a/lib/features/transcript/data/forced_alignment_enrichment_backend.dart
+++ b/lib/features/transcript/data/forced_alignment_enrichment_backend.dart
@@ -1,0 +1,88 @@
+/// Production `EnrichmentBackend`: ffmpeg PCM decode + the forced_alignment
+/// engine + Dart HTTP download.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:forced_alignment/forced_alignment.dart'
+    hide align, alignSegments;
+import 'package:forced_alignment/forced_alignment.dart'
+    as fa
+    show align, alignSegments;
+
+import 'package:enjoy_player/data/audio/http_media_download.dart';
+import 'package:enjoy_player/data/audio/pcm16k_mono.dart';
+import 'package:enjoy_player/features/transcript/domain/enrichment_backend.dart';
+
+/// Verbatim delegation to the app's decode / alignment / download helpers.
+///
+/// Stateless — a single `const` instance serves every enrich run
+/// (ADR-0071/0072 engine policy lives inside `forced_alignment`).
+final class ForcedAlignmentEnrichmentBackend implements EnrichmentBackend {
+  const ForcedAlignmentEnrichmentBackend();
+
+  @override
+  Future<Float32List> decodeFile(String pathOrUri) {
+    return decodeFileToPcm16kMono(pathOrUri);
+  }
+
+  @override
+  Future<Float32List> decodeWindow({
+    required String pathOrUri,
+    required double startSeconds,
+    required double durationSeconds,
+  }) {
+    return decodeFileWindowToPcm16kMono(
+      pathOrUri: pathOrUri,
+      startSeconds: startSeconds,
+      durationSeconds: durationSeconds,
+    );
+  }
+
+  @override
+  Future<AlignmentOutcome> alignSegments({
+    required Float32List sourcePcm16k,
+    required String language,
+    required List<AlignmentSegment> segments,
+    required AlignmentGranularity granularity,
+    AlignmentCancelToken? cancel,
+  }) {
+    return fa.alignSegments(
+      sourcePcm16k: sourcePcm16k,
+      language: language,
+      segments: segments,
+      granularity: granularity,
+      cancel: cancel,
+    );
+  }
+
+  @override
+  Future<AlignmentOutcome> align({
+    required Float32List sourcePcm16k,
+    required String transcript,
+    required String language,
+    AlignmentCancelToken? cancel,
+    required double timeOffset,
+  }) {
+    return fa.align(
+      sourcePcm16k: sourcePcm16k,
+      transcript: transcript,
+      language: language,
+      cancel: cancel,
+      timeOffset: timeOffset,
+    );
+  }
+
+  @override
+  Future<PhonemizeOutcome> phonemize({
+    required List<String> texts,
+    required String language,
+    AlignmentCancelToken? cancel,
+  }) {
+    return phonemizeLines(texts: texts, language: language, cancel: cancel);
+  }
+
+  @override
+  Future<String> downloadHttp(String url, {AlignmentCancelToken? cancel}) {
+    return downloadHttpMediaToTemp(url, cancel: cancel);
+  }
+}

--- a/lib/features/transcript/domain/enrichment_backend.dart
+++ b/lib/features/transcript/domain/enrichment_backend.dart
@@ -1,0 +1,51 @@
+/// The machinery seam behind `TranscriptEnricher`: audio decoding, forced
+/// alignment, phonemization, and HTTP media download.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:forced_alignment/forced_alignment.dart';
+
+/// External machinery the transcript enricher drives during an enrich run.
+///
+/// Two adapters satisfy this port: the production
+/// `ForcedAlignmentEnrichmentBackend` (ffmpeg PCM decode + the
+/// `forced_alignment` engine + HTTP download) and an in-memory test fake.
+abstract interface class EnrichmentBackend {
+  /// Decodes a whole local file or URI to 16 kHz mono float PCM.
+  Future<Float32List> decodeFile(String pathOrUri);
+
+  /// Decodes one `[startSeconds, startSeconds + durationSeconds)` window.
+  Future<Float32List> decodeWindow({
+    required String pathOrUri,
+    required double startSeconds,
+    required double durationSeconds,
+  });
+
+  /// Aligns pre-timed cue segments against the whole-clip PCM.
+  Future<AlignmentOutcome> alignSegments({
+    required Float32List sourcePcm16k,
+    required String language,
+    required List<AlignmentSegment> segments,
+    required AlignmentGranularity granularity,
+    AlignmentCancelToken? cancel,
+  });
+
+  /// Aligns one cue transcript against its padded PCM window.
+  Future<AlignmentOutcome> align({
+    required Float32List sourcePcm16k,
+    required String transcript,
+    required String language,
+    AlignmentCancelToken? cancel,
+    required double timeOffset,
+  });
+
+  /// Untimed IPA phonemization (the YouTube path).
+  Future<PhonemizeOutcome> phonemize({
+    required List<String> texts,
+    required String language,
+    AlignmentCancelToken? cancel,
+  });
+
+  /// Downloads remote media to a local temp path; the enricher deletes it.
+  Future<String> downloadHttp(String url, {AlignmentCancelToken? cancel});
+}

--- a/test/features/transcript/application/fake_enrichment_backend.dart
+++ b/test/features/transcript/application/fake_enrichment_backend.dart
@@ -1,0 +1,148 @@
+/// In-memory [EnrichmentBackend] test adapter: configurable hooks, call
+/// counters, and a hard `fail()` for any unconfigured call.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forced_alignment/forced_alignment.dart';
+
+import 'package:enjoy_player/features/transcript/domain/enrichment_backend.dart';
+
+typedef DecodeFileHook = Future<Float32List> Function(String pathOrUri);
+
+typedef DecodeWindowHook =
+    Future<Float32List> Function({
+      required String pathOrUri,
+      required double startSeconds,
+      required double durationSeconds,
+    });
+
+typedef AlignSegmentsHook =
+    Future<AlignmentOutcome> Function({
+      required Float32List sourcePcm16k,
+      required String language,
+      required List<AlignmentSegment> segments,
+      required AlignmentGranularity granularity,
+      AlignmentCancelToken? cancel,
+    });
+
+typedef AlignHook =
+    Future<AlignmentOutcome> Function({
+      required Float32List sourcePcm16k,
+      required String transcript,
+      required String language,
+      AlignmentCancelToken? cancel,
+      required double timeOffset,
+    });
+
+typedef PhonemizeHook =
+    Future<PhonemizeOutcome> Function({
+      required List<String> texts,
+      required String language,
+      AlignmentCancelToken? cancel,
+    });
+
+typedef DownloadHttpHook =
+    Future<String> Function(String url, {AlignmentCancelToken? cancel});
+
+class FakeEnrichmentBackend implements EnrichmentBackend {
+  DecodeFileHook? decodeFileFn;
+  DecodeWindowHook? decodeWindowFn;
+  AlignSegmentsHook? alignSegmentsFn;
+  AlignHook? alignFn;
+  PhonemizeHook? phonemizeFn;
+  DownloadHttpHook? downloadHttpFn;
+
+  int decodeFileCalls = 0;
+  int decodeWindowCalls = 0;
+  int alignSegmentsCalls = 0;
+  int alignCalls = 0;
+  int phonemizeCalls = 0;
+  int downloadHttpCalls = 0;
+
+  @override
+  Future<Float32List> decodeFile(String pathOrUri) {
+    decodeFileCalls++;
+    final fn = decodeFileFn;
+    if (fn == null) fail('FakeEnrichmentBackend.decodeFile not configured');
+    return fn(pathOrUri);
+  }
+
+  @override
+  Future<Float32List> decodeWindow({
+    required String pathOrUri,
+    required double startSeconds,
+    required double durationSeconds,
+  }) {
+    decodeWindowCalls++;
+    final fn = decodeWindowFn;
+    if (fn == null) fail('FakeEnrichmentBackend.decodeWindow not configured');
+    return fn(
+      pathOrUri: pathOrUri,
+      startSeconds: startSeconds,
+      durationSeconds: durationSeconds,
+    );
+  }
+
+  @override
+  Future<AlignmentOutcome> alignSegments({
+    required Float32List sourcePcm16k,
+    required String language,
+    required List<AlignmentSegment> segments,
+    required AlignmentGranularity granularity,
+    AlignmentCancelToken? cancel,
+  }) {
+    alignSegmentsCalls++;
+    final fn = alignSegmentsFn;
+    if (fn == null) {
+      fail('FakeEnrichmentBackend.alignSegments not configured');
+    }
+    return fn(
+      sourcePcm16k: sourcePcm16k,
+      language: language,
+      segments: segments,
+      granularity: granularity,
+      cancel: cancel,
+    );
+  }
+
+  @override
+  Future<AlignmentOutcome> align({
+    required Float32List sourcePcm16k,
+    required String transcript,
+    required String language,
+    AlignmentCancelToken? cancel,
+    required double timeOffset,
+  }) {
+    alignCalls++;
+    final fn = alignFn;
+    if (fn == null) fail('FakeEnrichmentBackend.align not configured');
+    return fn(
+      sourcePcm16k: sourcePcm16k,
+      transcript: transcript,
+      language: language,
+      cancel: cancel,
+      timeOffset: timeOffset,
+    );
+  }
+
+  @override
+  Future<PhonemizeOutcome> phonemize({
+    required List<String> texts,
+    required String language,
+    AlignmentCancelToken? cancel,
+  }) {
+    phonemizeCalls++;
+    final fn = phonemizeFn;
+    if (fn == null) fail('FakeEnrichmentBackend.phonemize not configured');
+    return fn(texts: texts, language: language, cancel: cancel);
+  }
+
+  @override
+  Future<String> downloadHttp(String url, {AlignmentCancelToken? cancel}) {
+    downloadHttpCalls++;
+    final fn = downloadHttpFn;
+    if (fn == null) fail('FakeEnrichmentBackend.downloadHttp not configured');
+    return fn(url, cancel: cancel);
+  }
+}

--- a/test/features/transcript/application/transcript_enrichment_owned_test.dart
+++ b/test/features/transcript/application/transcript_enrichment_owned_test.dart
@@ -8,6 +8,8 @@ import 'package:enjoy_player/data/subtitle/transcript_display_readiness.dart';
 import 'package:enjoy_player/data/subtitle/transcript_line.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_enrichment_controller.dart';
 
+import 'fake_enrichment_backend.dart';
+
 const _lineOnly = [
   TranscriptLine(text: 'Hello world', startMs: 0, durationMs: 700),
 ];
@@ -49,32 +51,57 @@ AlignmentSuccess _successFor(List<AlignmentSegment> segments) {
   );
 }
 
+AlignmentSuccess _windowSuccess({
+  required String transcript,
+  required String language,
+  required double timeOffset,
+}) {
+  return AlignmentSuccess(
+    AlignmentResult(
+      timeline: [
+        TimelineEntry(
+          type: TimelineEntryType.segment,
+          text: transcript,
+          startTime: timeOffset,
+          endTime: timeOffset + 0.7,
+          timeline: [
+            TimelineEntry(
+              type: TimelineEntryType.word,
+              text: 'Hello',
+              startTime: timeOffset,
+              endTime: timeOffset + 0.7,
+              timeline: [
+                TimelineEntry(
+                  type: TimelineEntryType.phone,
+                  text: 'h',
+                  startTime: timeOffset,
+                  endTime: timeOffset + 0.7,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+      wordTimeline: const [],
+      transcript: transcript,
+      language: language,
+      durationSeconds: 1,
+    ),
+  );
+}
+
 Future<Float32List> _dummyPcm(String _) async =>
     Float32List(kAlignmentSampleRate);
 
 void main() {
   test('owned success persists timed words and phones', () async {
     List<TranscriptLine>? saved;
-    var pcmCalls = 0;
-    final enricher = TranscriptEnricher(
-      replaceTimeline: ({required transcriptId, required lines}) async {
-        saved = lines;
-        return true;
-      },
-      decodeFile: (path) async {
-        pcmCalls++;
+    final backend = FakeEnrichmentBackend()
+      ..decodeFileFn = (path) async {
         expect(path, '/tmp/owned.wav');
         return _dummyPcm(path);
-      },
-      decodeWindow:
-          ({
-            required pathOrUri,
-            required startSeconds,
-            required durationSeconds,
-          }) async {
-            fail('short files must not window-extract');
-          },
-      alignSegmentsFn:
+      }
+      ..alignSegmentsFn =
           ({
             required sourcePcm16k,
             required language,
@@ -84,10 +111,13 @@ void main() {
           }) async {
             expect(language, 'en-US');
             return _successFor(segments);
-          },
-      phonemizeFn: ({required texts, required language, cancel}) async {
-        fail('owned path must not phonemize');
+          };
+    final enricher = TranscriptEnricher(
+      replaceTimeline: ({required transcriptId, required lines}) async {
+        saved = lines;
+        return true;
       },
+      backend: backend,
     );
 
     final outcome = await enricher.enrich(
@@ -99,7 +129,9 @@ void main() {
     );
 
     expect(outcome, isA<TranscriptEnrichmentOk>());
-    expect(pcmCalls, 1);
+    expect(backend.decodeFileCalls, 1);
+    expect(backend.decodeWindowCalls, 0);
+    expect(backend.phonemizeCalls, 0);
     expect(saved, isNotNull);
     expect(saved!.single.text, 'Hello world');
     expect(saved!.single.startMs, 0);
@@ -118,15 +150,11 @@ void main() {
         required bool extractable,
         String? path,
         AlignmentCancelToken? cancel,
-        DecodeFilePcm16k? decodeFile,
+        DecodeFileHook? decodeFile,
       }) {
-        return TranscriptEnricher(
-          replaceTimeline: ({required transcriptId, required lines}) async {
-            replaceCalls++;
-            return true;
-          },
-          decodeFile: decodeFile ?? _dummyPcm,
-          alignSegmentsFn:
+        final backend = FakeEnrichmentBackend()
+          ..decodeFileFn = decodeFile ?? _dummyPcm
+          ..alignSegmentsFn =
               ({
                 required sourcePcm16k,
                 required language,
@@ -135,10 +163,13 @@ void main() {
                 cancel,
               }) async {
                 return _successFor(segments);
-              },
-          phonemizeFn: ({required texts, required language, cancel}) async {
-            fail('should not phonemize');
+              };
+        return TranscriptEnricher(
+          replaceTimeline: ({required transcriptId, required lines}) async {
+            replaceCalls++;
+            return true;
           },
+          backend: backend,
         ).enrich(
           transcriptId: 't1',
           lines: _lineOnly,
@@ -185,6 +216,7 @@ void main() {
               replaceCalls++;
               return true;
             },
+            backend: FakeEnrichmentBackend(),
           ),
         ),
       ],
@@ -203,24 +235,17 @@ void main() {
       const TranscriptLine(text: 'Hello', startMs: 0, durationMs: 1000),
       const TranscriptLine(text: 'Later', startMs: 91000, durationMs: 1000),
     ];
-    var windowCalls = 0;
-    final enricher = TranscriptEnricher(
-      replaceTimeline: ({required transcriptId, required lines}) async {
-        saved = lines;
-        return true;
-      },
-      decodeFile: (path) async => fail('long files must not decode whole clip'),
-      decodeWindow:
+    final backend = FakeEnrichmentBackend()
+      ..decodeWindowFn =
           ({
             required pathOrUri,
             required startSeconds,
             required durationSeconds,
           }) async {
-            windowCalls++;
             if (startSeconds > 10) throw StateError('window missing');
             return Float32List(kAlignmentSampleRate);
-          },
-      alignFn:
+          }
+      ..alignFn =
           ({
             required sourcePcm16k,
             required transcript,
@@ -228,42 +253,18 @@ void main() {
             cancel,
             required timeOffset,
           }) async {
-            return AlignmentSuccess(
-              AlignmentResult(
-                timeline: [
-                  TimelineEntry(
-                    type: TimelineEntryType.segment,
-                    text: transcript,
-                    startTime: timeOffset,
-                    endTime: timeOffset + 0.7,
-                    timeline: [
-                      TimelineEntry(
-                        type: TimelineEntryType.word,
-                        text: 'Hello',
-                        startTime: timeOffset,
-                        endTime: timeOffset + 0.7,
-                        timeline: [
-                          TimelineEntry(
-                            type: TimelineEntryType.phone,
-                            text: 'h',
-                            startTime: timeOffset,
-                            endTime: timeOffset + 0.7,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-                wordTimeline: const [],
-                transcript: transcript,
-                language: language,
-                durationSeconds: 1,
-              ),
+            return _windowSuccess(
+              transcript: transcript,
+              language: language,
+              timeOffset: timeOffset,
             );
-          },
-      phonemizeFn: ({required texts, required language, cancel}) async {
-        fail('owned path must not phonemize');
+          };
+    final enricher = TranscriptEnricher(
+      replaceTimeline: ({required transcriptId, required lines}) async {
+        saved = lines;
+        return true;
       },
+      backend: backend,
     );
 
     final outcome = await enricher.enrich(
@@ -274,7 +275,9 @@ void main() {
       localPath: '/tmp/long.wav',
     );
     expect(outcome, isA<TranscriptEnrichmentOk>());
-    expect(windowCalls, 2);
+    expect(backend.decodeWindowCalls, 2);
+    expect(backend.decodeFileCalls, 0);
+    expect(backend.phonemizeCalls, 0);
     expect(saved, hasLength(2));
     expect(saved!.first.timeline, isNotNull);
     expect(saved!.last.timeline, isNull);
@@ -291,25 +294,16 @@ void main() {
   test('owned HTTP URL downloads then aligns locally', () async {
     var decoded = '';
     var downloaded = '';
-    final enricher = TranscriptEnricher(
-      replaceTimeline: ({required transcriptId, required lines}) async => true,
-      downloadHttp: (url, {cancel}) async {
+    final backend = FakeEnrichmentBackend()
+      ..downloadHttpFn = (url, {cancel}) async {
         downloaded = url;
         return '/tmp/downloaded.mp3';
-      },
-      decodeFile: (path) async {
+      }
+      ..decodeFileFn = (path) async {
         decoded = path;
         return _dummyPcm(path);
-      },
-      decodeWindow:
-          ({
-            required pathOrUri,
-            required startSeconds,
-            required durationSeconds,
-          }) async {
-            fail('short files must not window-extract');
-          },
-      alignSegmentsFn:
+      }
+      ..alignSegmentsFn =
           ({
             required sourcePcm16k,
             required language,
@@ -318,10 +312,10 @@ void main() {
             cancel,
           }) async {
             return _successFor(segments);
-          },
-      phonemizeFn: ({required texts, required language, cancel}) async {
-        fail('owned remote URL must not phonemize');
-      },
+          };
+    final enricher = TranscriptEnricher(
+      replaceTimeline: ({required transcriptId, required lines}) async => true,
+      backend: backend,
     );
 
     final outcome = await enricher.enrich(
@@ -335,6 +329,7 @@ void main() {
     expect(outcome, isA<TranscriptEnrichmentOk>());
     expect(downloaded, 'https://cdn.example/owned.mp3');
     expect(decoded, '/tmp/downloaded.mp3');
+    expect(backend.phonemizeCalls, 0);
   });
 
   test('window path reports cue progress including failed cues', () async {
@@ -343,10 +338,8 @@ void main() {
       const TranscriptLine(text: 'Hello', startMs: 0, durationMs: 1000),
       const TranscriptLine(text: 'Later', startMs: 91000, durationMs: 1000),
     ];
-    final enricher = TranscriptEnricher(
-      replaceTimeline: ({required transcriptId, required lines}) async => true,
-      decodeFile: (path) async => fail('long files must not decode whole clip'),
-      decodeWindow:
+    final backend = FakeEnrichmentBackend()
+      ..decodeWindowFn =
           ({
             required pathOrUri,
             required startSeconds,
@@ -354,8 +347,8 @@ void main() {
           }) async {
             if (startSeconds > 10) throw StateError('window missing');
             return Float32List(kAlignmentSampleRate);
-          },
-      alignFn:
+          }
+      ..alignFn =
           ({
             required sourcePcm16k,
             required transcript,
@@ -363,34 +356,15 @@ void main() {
             cancel,
             required timeOffset,
           }) async {
-            return AlignmentSuccess(
-              AlignmentResult(
-                timeline: [
-                  TimelineEntry(
-                    type: TimelineEntryType.segment,
-                    text: transcript,
-                    startTime: timeOffset,
-                    endTime: timeOffset + 0.7,
-                    timeline: [
-                      TimelineEntry(
-                        type: TimelineEntryType.word,
-                        text: 'Hello',
-                        startTime: timeOffset,
-                        endTime: timeOffset + 0.7,
-                      ),
-                    ],
-                  ),
-                ],
-                wordTimeline: const [],
-                transcript: transcript,
-                language: language,
-                durationSeconds: 1,
-              ),
+            return _windowSuccess(
+              transcript: transcript,
+              language: language,
+              timeOffset: timeOffset,
             );
-          },
-      phonemizeFn: ({required texts, required language, cancel}) async {
-        fail('owned path must not phonemize');
-      },
+          };
+    final enricher = TranscriptEnricher(
+      replaceTimeline: ({required transcriptId, required lines}) async => true,
+      backend: backend,
     );
 
     await enricher.enrich(

--- a/test/features/transcript/application/transcript_enrichment_youtube_test.dart
+++ b/test/features/transcript/application/transcript_enrichment_youtube_test.dart
@@ -5,6 +5,8 @@ import 'package:enjoy_player/data/subtitle/transcript_display_readiness.dart';
 import 'package:enjoy_player/data/subtitle/transcript_line.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_enrichment_controller.dart';
 
+import 'fake_enrichment_backend.dart';
+
 const _lineOnly = [
   TranscriptLine(text: 'Hello world', startMs: 0, durationMs: 700),
 ];
@@ -14,31 +16,8 @@ void main() {
     'YouTube run never calls PCM helpers and persists untimed IPA',
     () async {
       List<TranscriptLine>? saved;
-      final enricher = TranscriptEnricher(
-        replaceTimeline: ({required transcriptId, required lines}) async {
-          saved = lines;
-          return true;
-        },
-        decodeFile: (path) async => fail('YouTube must not decode PCM'),
-        decodeWindow:
-            ({
-              required pathOrUri,
-              required startSeconds,
-              required durationSeconds,
-            }) async {
-              fail('YouTube must not window-extract');
-            },
-        alignSegmentsFn:
-            ({
-              required sourcePcm16k,
-              required language,
-              required segments,
-              required granularity,
-              cancel,
-            }) async {
-              fail('YouTube must not alignSegments');
-            },
-        phonemizeFn: ({required texts, required language, cancel}) async {
+      final backend = FakeEnrichmentBackend()
+        ..phonemizeFn = ({required texts, required language, cancel}) async {
           expect(language, 'en-US');
           return const PhonemizeSuccess([
             PhonemizeLineResult(
@@ -48,7 +27,13 @@ void main() {
               ],
             ),
           ]);
+        };
+      final enricher = TranscriptEnricher(
+        replaceTimeline: ({required transcriptId, required lines}) async {
+          saved = lines;
+          return true;
         },
+        backend: backend,
       );
 
       final outcome = await enricher.enrich(
@@ -60,6 +45,9 @@ void main() {
       );
 
       expect(outcome, isA<TranscriptEnrichmentOk>());
+      expect(backend.decodeFileCalls, 0);
+      expect(backend.decodeWindowCalls, 0);
+      expect(backend.alignSegmentsCalls, 0);
       expect(saved, isNotNull);
       expect(saved!.single.timeline, hasLength(2));
       expect(saved!.single.timeline!.first.startMs, isNull);
@@ -77,28 +65,8 @@ void main() {
 
   test('YouTube phonemize strips subtitle markup before eSpeak', () async {
     late List<String> seen;
-    final enricher = TranscriptEnricher(
-      replaceTimeline: ({required transcriptId, required lines}) async => true,
-      decodeFile: (path) async => fail('YouTube must not decode PCM'),
-      decodeWindow:
-          ({
-            required pathOrUri,
-            required startSeconds,
-            required durationSeconds,
-          }) async {
-            fail('YouTube must not window-extract');
-          },
-      alignSegmentsFn:
-          ({
-            required sourcePcm16k,
-            required language,
-            required segments,
-            required granularity,
-            cancel,
-          }) async {
-            fail('YouTube must not alignSegments');
-          },
-      phonemizeFn: ({required texts, required language, cancel}) async {
+    final backend = FakeEnrichmentBackend()
+      ..phonemizeFn = ({required texts, required language, cancel}) async {
         seen = texts;
         return const PhonemizeSuccess([
           PhonemizeLineResult(
@@ -107,7 +75,10 @@ void main() {
             ],
           ),
         ]);
-      },
+      };
+    final enricher = TranscriptEnricher(
+      replaceTimeline: ({required transcriptId, required lines}) async => true,
+      backend: backend,
     );
 
     final outcome = await enricher.enrich(


### PR DESCRIPTION
Resolves #603 (part of #592 — candidate 6, TranscriptEnricher port).

## Summary

- Replaces `TranscriptEnricher`'s six single-adapter function seams with one `EnrichmentBackend` port (decode file / decode window / alignSegments / align / phonemize / downloadHttp).
- Production adapter `ForcedAlignmentEnrichmentBackend` delegates verbatim to the pcm16k/HTTP helpers and the `forced_alignment` engine — ADR-0071/0072 policy untouched behind the port.
- Tests swap ~37 repeated guard lambdas for a shared `FakeEnrichmentBackend` with configurable hooks, call counters, and hard failures on unconfigured calls.

## Changes

- `lib/features/transcript/domain/enrichment_backend.dart` (new): the port — six machinery methods.
- `lib/features/transcript/data/forced_alignment_enrichment_backend.dart` (new): `const` production adapter; the three `_production*` wrappers and six typedefs are deleted.
- `transcript_enrichment_controller.dart`: `TranscriptEnricher({required replaceTimeline, required backend})` — accepts its machinery instead of defaulting production adapters internally; `transcriptEnricherProvider` wires the production adapter explicitly. `ReplaceTimelineFn` / `EnrichProgressFn` stay (persistence + progress are orthogonal to the machinery seam).
- Both enrichment test files rewritten on the fake — same scenarios, no behavior change.

## Verification

- `bash .github/scripts/validate_ci_gates.sh --fix` — all gates passed
- `flutter analyze` — no issues
- `flutter test` — 5635 tests passed

## Test plan

- [ ] Enrich an owned (local file) transcript — timed words + phones persist
- [ ] Enrich a long owned file — windowed path with per-cue progress
- [ ] Enrich a YouTube transcript — untimed IPA labels, no PCM decode
- [ ] Cancel mid-run — state reports cancelled, no persistence