### PR TITLE
test(youtube): pin the Dart-JS event-name contract (tier 1 of #629)

### DIFF
--- a/lib/features/player/application/engines/youtube/youtube_video_event.dart
+++ b/lib/features/player/application/engines/youtube/youtube_video_event.dart
@@ -1,0 +1,64 @@
+/// Canonical string protocol between the watch-page JavaScript and Dart.
+///
+/// The Dart↔JS seam is stringly-typed by necessity (one-way
+/// `callHandler` messages out of the page). These constants are the single
+/// spelling of that protocol on the Dart side: the JS sources emit exactly
+/// these names, and [YoutubeWebViewEvents] handles exactly these names.
+/// `youtube_js_protocol_contract_test.dart` pins both directions so a name
+/// added on one side without the other fails CI instead of vanishing into
+/// the (logged) default branch.
+library;
+
+/// Event names carried on the `onVideoEvent` handler.
+abstract final class YoutubeVideoEventName {
+  /// Optimistic play request (may still be followed by a DOM `pause`).
+  static const String play = 'play';
+
+  /// Playback actually started (`<video>` `playing`).
+  static const String playing = 'playing';
+
+  /// DOM pause (transport waits for poll-streak confirmation).
+  static const String pause = 'pause';
+
+  /// A programmatic play promise rejected (autoplay policy).
+  static const String playRejected = 'playRejected';
+
+  /// End of media.
+  static const String ended = 'ended';
+
+  /// Buffering (`<video>` `waiting`).
+  static const String waiting = 'waiting';
+
+  /// Enough data to play (`<video>` `canplay`).
+  static const String canplay = 'canplay';
+
+  /// Metadata known; second arg carries the duration in seconds.
+  static const String loadedmetadata = 'loadedmetadata';
+
+  /// Element error.
+  static const String error = 'error';
+
+  /// Every name the Dart side switches over — must match the set the JS
+  /// sources emit (see the contract test).
+  static const Set<String> all = {
+    play,
+    playing,
+    pause,
+    playRejected,
+    ended,
+    waiting,
+    canplay,
+    loadedmetadata,
+    error,
+  };
+}
+
+/// Handler names registered by [YoutubeWebViewController] via
+/// `addJavaScriptHandler` and called from the page via
+/// `flutter_inappwebview.callHandler`.
+abstract final class YoutubeJsHandlerName {
+  static const String onVideoEvent = 'onVideoEvent';
+  static const String onAdReload = 'onAdReload';
+
+  static const Set<String> all = {onVideoEvent, onAdReload};
+}

--- a/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
@@ -177,9 +177,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(v) v.currentTime=$seconds;
         })();
       ''',
@@ -209,9 +207,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(v) v.playbackRate=$speed;
         })();
       ''',
@@ -274,11 +270,10 @@ class YoutubeWebViewBridge {
   /// Re-applies `playsinline` on the active `<video>` (iOS WKWebView safety net).
   static Future<void> forceInlinePlayback(InAppWebViewController? web) async {
     await web?.evaluateJavascript(
-      source: '''
+      source:
+          '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(!v) return;
           v.setAttribute('playsinline','');
           v.setAttribute('webkit-playsinline','');

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -10,6 +10,7 @@ import 'package:enjoy_player/features/player/application/engines/youtube/youtube
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_playback_stall_watchdog.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_watch_navigation_policy.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_events.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_navigation.dart';
@@ -186,7 +187,7 @@ class YoutubeWebViewController {
     }
 
     controller.addJavaScriptHandler(
-      handlerName: 'onAdReload',
+      handlerName: YoutubeJsHandlerName.onAdReload,
       callback: (List<dynamic> args) {
         if (args.isNotEmpty) {
           session.pendingSeekSeconds = (args[0] as num?)?.toDouble() ?? 0;
@@ -196,7 +197,7 @@ class YoutubeWebViewController {
     );
 
     controller.addJavaScriptHandler(
-      handlerName: 'onVideoEvent',
+      handlerName: YoutubeJsHandlerName.onVideoEvent,
       callback: _events.handle,
     );
 

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -9,6 +9,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 
 final _logEvents = logNamed('YouTubeWebViewEvents');
@@ -83,12 +84,12 @@ class YoutubeWebViewEvents {
     if (args.isEmpty) return null;
     final event = args[0] as String;
     switch (event) {
-      case 'play':
+      case YoutubeVideoEventName.play:
         // Optimistic request only — do not touch pause streak (DOM may still
         // pause before `playing`). Transport waits for authoritative `playing`.
         _logEvents.fine('youtube video play requested vid=${session.videoId}');
         break;
-      case 'playing':
+      case YoutubeVideoEventName.playing:
         // A fresh watch document (cold open or post-ad reload) starts muted;
         // arm the progress-gated restore once. Later `playing` events in an
         // already-restored document must NOT re-unmute: every programmatic
@@ -108,7 +109,7 @@ class YoutubeWebViewEvents {
         }
         _logEvents.fine('youtube video playing vid=${session.videoId}');
         break;
-      case 'pause':
+      case YoutubeVideoEventName.pause:
         // Do NOT reset [pausedPollStreak] — a DOM pause while Dart still thinks
         // playing must accumulate toward poll confirmation. Resetting here
         // previously extended the stale-`playing` window and made the next
@@ -116,7 +117,7 @@ class YoutubeWebViewEvents {
         cancelPendingVolumeRestore();
         _logEvents.fine('youtube video paused vid=${session.videoId}');
         break;
-      case 'playRejected':
+      case YoutubeVideoEventName.playRejected:
         cancelPendingVolumeRestore();
         session.userPlayInFlight = false;
         session.emitPlaying(false);
@@ -130,7 +131,7 @@ class YoutubeWebViewEvents {
         startPolling();
         session.scheduleRecoveryHint();
         break;
-      case 'ended':
+      case YoutubeVideoEventName.ended:
         session.pausedPollStreak = 0;
         session.userPlayInFlight = false;
         cancelPendingVolumeRestore();
@@ -140,15 +141,15 @@ class YoutubeWebViewEvents {
         session.emitBuffering(false);
         unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));
         break;
-      case 'waiting':
+      case YoutubeVideoEventName.waiting:
         session.emitBuffering(true);
         break;
-      case 'canplay':
+      case YoutubeVideoEventName.canplay:
         if (session.buffering) {
           session.emitBuffering(false);
         }
         break;
-      case 'loadedmetadata':
+      case YoutubeVideoEventName.loadedmetadata:
         startPolling();
         if (args.length > 1) {
           final dur = (args[1] as num).toDouble();
@@ -158,7 +159,7 @@ class YoutubeWebViewEvents {
           }
         }
         break;
-      case 'error':
+      case YoutubeVideoEventName.error:
         cancelPendingVolumeRestore();
         _logEvents.warning('YouTube video element error');
         session.userPlayInFlight = false;
@@ -166,6 +167,10 @@ class YoutubeWebViewEvents {
         session.emitBuffering(false);
         break;
       default:
+        // A name the Dart side does not switch over cannot reach here without
+        // failing youtube_js_protocol_contract_test first — log so a stray
+        // name surfaces in diagnostics instead of vanishing.
+        _logEvents.warning('youtube unknown video event name=$event');
         break;
     }
     return null;

--- a/test/features/player/application/engines/youtube/youtube_js_protocol_contract_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_js_protocol_contract_test.dart
@@ -1,0 +1,93 @@
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_page_inject.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the string protocol between the watch-page JavaScript and Dart
+/// (issue #629, tier 1).
+///
+/// The JS side cannot be executed in a unit test (tier 2 tracks a runtime
+/// harness), but the protocol *shape* can be pinned: every event name the
+/// JS sources emit must be a name the Dart switch handles, and every handled
+/// name must actually be emitted — otherwise a rename or a new name on one
+/// side drifts silently into the switch's logged default branch.
+void main() {
+  // Every Dart-reachable JS source that can call `flutter_inappwebview
+  // .callHandler`. The bridge's play scripts embed the shared
+  // `_startPlaybackBody`, so `playRejected` is included via interpolation.
+  final jsSources = [
+    kYoutubeMobileWatchInjectScript,
+    YoutubeWebViewBridge.playScript,
+    YoutubeWebViewBridge.playOrPauseScript,
+  ].join('\n===\n');
+
+  /// All handler names the JS side calls, e.g. `callHandler('onVideoEvent',…)`.
+  final jsCalledHandlers = RegExp(
+    r"callHandler\(\s*'([A-Za-z]+)'",
+  ).allMatches(jsSources).map((m) => m.group(1)!).toSet();
+
+  /// Event names emitted with a literal second argument.
+  final literalEventNames = RegExp(
+    r"callHandler\(\s*'onVideoEvent'\s*,\s*'([a-zA-Z]+)'",
+  ).allMatches(jsSources).map((m) => m.group(1)!).toSet();
+
+  /// `hookVideo` emits through a variable: `var events=['play',…]` later
+  /// forwarded as `callHandler('onVideoEvent',args[0],…)`.
+  final arrayEventNames = RegExp(r'var events=\[([^\]]*)\]')
+      .allMatches(jsSources)
+      .expand((m) {
+        return RegExp(
+          r"'([a-zA-Z]+)'",
+        ).allMatches(m.group(1)!).map((inner) => inner.group(1)!);
+      })
+      .toSet();
+
+  test('every event name the JS emits is a name the Dart switch handles', () {
+    final emitted = {...literalEventNames, ...arrayEventNames};
+    // Sanity on the extraction itself: the known emission styles must all
+    // have been found before the comparison means anything.
+    expect(literalEventNames, containsAll(<String>['playRejected', 'ended']));
+    expect(arrayEventNames, isNotEmpty);
+
+    final unhandled = emitted.difference(YoutubeVideoEventName.all);
+    expect(
+      unhandled,
+      isEmpty,
+      reason:
+          'JS emits ${unhandled.toList()} but the Dart switch has no case '
+          '(it would hit the logged default and vanish).',
+    );
+  });
+
+  test(
+    'every event name the Dart switch handles is actually emitted by the JS',
+    () {
+      final emitted = {...literalEventNames, ...arrayEventNames};
+      final dead = YoutubeVideoEventName.all.difference(emitted);
+      expect(
+        dead,
+        isEmpty,
+        reason:
+            'Dart handles ${dead.toList()} but no JS source emits them — '
+            'dead protocol entries.',
+      );
+    },
+  );
+
+  test('handler names called from JS match the handlers Dart registers', () {
+    final unregistered = jsCalledHandlers.difference(YoutubeJsHandlerName.all);
+    expect(
+      unregistered,
+      isEmpty,
+      reason:
+          'JS calls ${unregistered.toList()} but '
+          'YoutubeWebViewController never registers them.',
+    );
+    final neverCalled = YoutubeJsHandlerName.all.difference(jsCalledHandlers);
+    expect(
+      neverCalled,
+      isEmpty,
+      reason: 'Dart registers ${neverCalled.toList()} but no JS calls them.',
+    );
+  });
+}


### PR DESCRIPTION
Closes #629 (tier 1 — event-name contract symmetry; tier 2 split to #631). Part of the 2026-08-27 architecture review #626, candidate 3.

## What changes

- **New `youtube_video_event.dart`** — one spelling for the `onVideoEvent` string protocol: `YoutubeVideoEventName` (9 event names) and `YoutubeJsHandlerName` (2 handler names). `YoutubeWebViewEvents.handle` now switches over these constants; `YoutubeWebViewController` registers handlers by constant.
- **New contract test** (`youtube_js_protocol_contract_test.dart`) — extracts every event name the JS sources emit (literal second args + the `var events=[…]` array in `hookVideo`) and asserts both directions against `YoutubeVideoEventName.all`, plus handler-name symmetry with the registered set. A name added on one side without the other now fails CI instead of vanishing into the switch's default.
- **Unknown runtime names log** instead of hitting a silent `default: break`.
- **Selector preamble dedup** — `seekToSeconds`, `setPlaybackRate`, and `forceInlinePlayback` carried verbatim inline copies of the `_findVideoAndPlayer` preamble; they now interpolate the shared const.

No behavior change: same scripts execute in the page, same switch arms run.

## Why

The Dart↔JS seam is where all three shipped play-then-pause bugs lived (63429de7, fdb22092, de29a5be), and its only "regression guard" was `isNot(matches(RegExp('mute')))` against source text. Tier 1 gives the protocol an executable definition; tier 2 (executing the JS against a fake page) is tracked in #631.

## Verification

- `bash .github/scripts/validate_ci_gates.sh --fix` — format + codegen clean
- `flutter analyze` — no issues
- Full `flutter test` — 5,706 passing (includes the 3 new contract tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
