### PR TITLE
refactor(youtube): hide the engine's second interface behind the WebView lifecycle owner (closes #630)

### DIFF
--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -7,7 +7,6 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart' hide RepeatMode;
 import 'package:flutter/services.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:media_kit/media_kit.dart' as mk;
 
 import 'package:enjoy_player/core/logging/log.dart';
@@ -37,17 +36,11 @@ class YoutubePlayerEngine implements PlayerEngine {
   final YoutubeSession _session;
   late final YoutubeWebViewController _webView;
 
-  GlobalKey get webViewHostKey => _session.webViewHostKey;
-  ValueNotifier<int> get mountTick => _session.mountTick;
-
   @override
   String get currentVideoId => _session.videoId;
 
   @override
   String? get posterUrl => _session.posterUrl;
-  bool get webViewMounted => _session.webViewMounted;
-  bool get shouldMountWebView => _session.shouldMountWebView;
-  bool get tapToPlayHintActive => _session.tapToPlayHintActive;
 
   @override
   bool get supportsYouTubePlayback => true;
@@ -99,34 +92,38 @@ class YoutubePlayerEngine implements PlayerEngine {
   @override
   void markOpenTimingStart() => _webView.markOpenTimingStart();
 
-  void ensureWebViewAttached() {
+  void _ensureWebViewAttached() {
     _session.requestMount();
     _logInitPhase('mount_requested');
   }
 
-  /// Completes when [webViewMounted] is true or [timeout] elapses.
-  Future<bool> awaitWebViewMounted({
+  /// Completes when the WebView is mounted or [timeout] elapses.
+  Future<bool> _awaitWebViewMounted({
     Duration timeout = const Duration(seconds: 8),
   }) async {
-    ensureWebViewAttached();
-    if (webViewMounted) return true;
+    _ensureWebViewAttached();
+    if (_session.webViewMounted) return true;
     final deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline)) {
-      if (webViewMounted) return true;
+      if (_session.webViewMounted) return true;
       await Future<void>.delayed(const Duration(milliseconds: 40));
     }
-    return webViewMounted;
+    return _session.webViewMounted;
   }
 
   @override
-  Future<void> awaitSurfaceReady() => awaitWebViewMounted().then((_) {});
+  Future<void> awaitSurfaceReady() => _awaitWebViewMounted().then((_) {});
 
   @override
   Future<void> teardownAfterClear({required bool keepSurfaceMounted}) =>
-      idleAfterClear(keepMounted: keepSurfaceMounted);
+      _webView.idleAfterClear(keepMounted: keepSurfaceMounted);
 
-  Widget buildWebViewHost() {
-    return YoutubeWebViewHost(key: _session.webViewHostKey, engine: this);
+  Widget _buildWebViewHost() {
+    return YoutubeWebViewHost(
+      key: _session.webViewHostKey,
+      controller: _webView,
+      currentVideoId: () => _session.videoId,
+    );
   }
 
   @override
@@ -167,13 +164,13 @@ class YoutubePlayerEngine implements PlayerEngine {
       builder: (context, snapshot) {
         final showPoster = snapshot.data ?? _session.buffering;
         return ValueListenableBuilder<int>(
-          valueListenable: mountTick,
+          valueListenable: _session.mountTick,
           builder: (context, _, _) {
             return Stack(
               fit: StackFit.expand,
               children: [
                 const ColoredBox(color: Colors.black),
-                if (shouldMountWebView) buildWebViewHost(),
+                if (_session.shouldMountWebView) _buildWebViewHost(),
                 if (_session.tapToPlayHintActive && !showPoster)
                   _YoutubeTapToPlayHint(
                     label:
@@ -327,65 +324,17 @@ class YoutubePlayerEngine implements PlayerEngine {
     _session.playbackCompleted = false;
   }
 
-  Future<void> idleAfterClear({bool keepMounted = false}) =>
-      _webView.idleAfterClear(keepMounted: keepMounted);
-
   @override
   Future<Uint8List?> screenshot({String? format}) async => null;
 
   @override
-  void warmVideoSurface() => ensureWebViewAttached();
+  void warmVideoSurface() => _ensureWebViewAttached();
 
   @override
   Future<void> dispose() async {
     await _webView.dispose();
     await _session.closeStreams();
   }
-
-  Future<void> onSignInNavigationBlocked(InAppWebViewController controller) =>
-      _webView.onSignInNavigationBlocked(controller);
-
-  void onWebResourceHttpError({
-    required String? url,
-    required int? statusCode,
-    required bool isForMainFrame,
-  }) {
-    if (!isForMainFrame) return;
-    _logYoutube.warning('youtube main-frame HTTP $statusCode url=${url ?? ''}');
-  }
-
-  void onWebResourceLoadError({
-    required String url,
-    required String description,
-  }) {
-    _logYoutube.warning('youtube load error url=$url msg=$description');
-  }
-
-  Future<void> onWebViewProcessTerminated() =>
-      _webView.onWebViewProcessTerminated();
-
-  void onWebViewCreated(
-    InAppWebViewController controller, {
-    bool initialWatchUrlRequested = false,
-  }) {
-    _webView.onWebViewCreated(
-      controller,
-      initialWatchUrlRequested: initialWatchUrlRequested,
-    );
-  }
-
-  void onWebViewDisposed(InAppWebViewController? controller) {
-    _webView.onWebViewDisposed(controller);
-  }
-
-  Future<void> onPageFinished(InAppWebViewController controller, String? url) =>
-      _webView.onPageFinished(controller, url);
-
-  Future<void> exitNativeFullscreen(InAppWebViewController controller) =>
-      _webView.exitNativeFullscreen(controller);
-
-  Future<void> onNativeFullscreenExit(InAppWebViewController controller) =>
-      _webView.onNativeFullscreenExit(controller);
 
   void _logInitPhase(String phase) {
     _session.logInitPhase(phase, (m) => _logYoutube.fine(m));

--- a/lib/features/player/application/engines/youtube/youtube_video_event.dart
+++ b/lib/features/player/application/engines/youtube/youtube_video_event.dart
@@ -1,0 +1,64 @@
+/// Canonical string protocol between the watch-page JavaScript and Dart.
+///
+/// The Dart↔JS seam is stringly-typed by necessity (one-way
+/// `callHandler` messages out of the page). These constants are the single
+/// spelling of that protocol on the Dart side: the JS sources emit exactly
+/// these names, and [YoutubeWebViewEvents] handles exactly these names.
+/// `youtube_js_protocol_contract_test.dart` pins both directions so a name
+/// added on one side without the other fails CI instead of vanishing into
+/// the (logged) default branch.
+library;
+
+/// Event names carried on the `onVideoEvent` handler.
+abstract final class YoutubeVideoEventName {
+  /// Optimistic play request (may still be followed by a DOM `pause`).
+  static const String play = 'play';
+
+  /// Playback actually started (`<video>` `playing`).
+  static const String playing = 'playing';
+
+  /// DOM pause (transport waits for poll-streak confirmation).
+  static const String pause = 'pause';
+
+  /// A programmatic play promise rejected (autoplay policy).
+  static const String playRejected = 'playRejected';
+
+  /// End of media.
+  static const String ended = 'ended';
+
+  /// Buffering (`<video>` `waiting`).
+  static const String waiting = 'waiting';
+
+  /// Enough data to play (`<video>` `canplay`).
+  static const String canplay = 'canplay';
+
+  /// Metadata known; second arg carries the duration in seconds.
+  static const String loadedmetadata = 'loadedmetadata';
+
+  /// Element error.
+  static const String error = 'error';
+
+  /// Every name the Dart side switches over — must match the set the JS
+  /// sources emit (see the contract test).
+  static const Set<String> all = {
+    play,
+    playing,
+    pause,
+    playRejected,
+    ended,
+    waiting,
+    canplay,
+    loadedmetadata,
+    error,
+  };
+}
+
+/// Handler names registered by [YoutubeWebViewController] via
+/// `addJavaScriptHandler` and called from the page via
+/// `flutter_inappwebview.callHandler`.
+abstract final class YoutubeJsHandlerName {
+  static const String onVideoEvent = 'onVideoEvent';
+  static const String onAdReload = 'onAdReload';
+
+  static const Set<String> all = {onVideoEvent, onAdReload};
+}

--- a/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
@@ -177,9 +177,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(v) v.currentTime=$seconds;
         })();
       ''',
@@ -209,9 +207,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(v) v.playbackRate=$speed;
         })();
       ''',
@@ -274,11 +270,10 @@ class YoutubeWebViewBridge {
   /// Re-applies `playsinline` on the active `<video>` (iOS WKWebView safety net).
   static Future<void> forceInlinePlayback(InAppWebViewController? web) async {
     await web?.evaluateJavascript(
-      source: '''
+      source:
+          '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(!v) return;
           v.setAttribute('playsinline','');
           v.setAttribute('webkit-playsinline','');

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -169,6 +169,25 @@ class YoutubeWebViewController {
         prepareWatchReload: () => prepareWatchReload(resetFirstPlaying: false),
       );
 
+  /// Main-frame HTTP failures are worth a diagnostic line; sub-frame noise is
+  /// not. Called by [YoutubeWebViewHost].
+  void onWebResourceHttpError({
+    required String? url,
+    required int? statusCode,
+    required bool isForMainFrame,
+  }) {
+    if (!isForMainFrame) return;
+    _logWebView.warning('youtube main-frame HTTP $statusCode url=${url ?? ''}');
+  }
+
+  /// Main-frame load failures (DNS, TLS, …). Called by [YoutubeWebViewHost].
+  void onWebResourceLoadError({
+    required String url,
+    required String description,
+  }) {
+    _logWebView.warning('youtube load error url=$url msg=$description');
+  }
+
   Future<void> onWebViewProcessTerminated() =>
       _navigation.onWebViewProcessTerminated(
         prepareWatchReload: () => prepareWatchReload(resetFirstPlaying: true),

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -10,6 +10,7 @@ import 'package:enjoy_player/features/player/application/engines/youtube/youtube
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_playback_stall_watchdog.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_watch_navigation_policy.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_events.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_navigation.dart';
@@ -186,7 +187,7 @@ class YoutubeWebViewController {
     }
 
     controller.addJavaScriptHandler(
-      handlerName: 'onAdReload',
+      handlerName: YoutubeJsHandlerName.onAdReload,
       callback: (List<dynamic> args) {
         if (args.isNotEmpty) {
           session.pendingSeekSeconds = (args[0] as num?)?.toDouble() ?? 0;
@@ -196,7 +197,7 @@ class YoutubeWebViewController {
     );
 
     controller.addJavaScriptHandler(
-      handlerName: 'onVideoEvent',
+      handlerName: YoutubeJsHandlerName.onVideoEvent,
       callback: _events.handle,
     );
 

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -9,6 +9,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 
 final _logEvents = logNamed('YouTubeWebViewEvents');
@@ -83,12 +84,12 @@ class YoutubeWebViewEvents {
     if (args.isEmpty) return null;
     final event = args[0] as String;
     switch (event) {
-      case 'play':
+      case YoutubeVideoEventName.play:
         // Optimistic request only — do not touch pause streak (DOM may still
         // pause before `playing`). Transport waits for authoritative `playing`.
         _logEvents.fine('youtube video play requested vid=${session.videoId}');
         break;
-      case 'playing':
+      case YoutubeVideoEventName.playing:
         // A fresh watch document (cold open or post-ad reload) starts muted;
         // arm the progress-gated restore once. Later `playing` events in an
         // already-restored document must NOT re-unmute: every programmatic
@@ -108,7 +109,7 @@ class YoutubeWebViewEvents {
         }
         _logEvents.fine('youtube video playing vid=${session.videoId}');
         break;
-      case 'pause':
+      case YoutubeVideoEventName.pause:
         // Do NOT reset [pausedPollStreak] — a DOM pause while Dart still thinks
         // playing must accumulate toward poll confirmation. Resetting here
         // previously extended the stale-`playing` window and made the next
@@ -116,7 +117,7 @@ class YoutubeWebViewEvents {
         cancelPendingVolumeRestore();
         _logEvents.fine('youtube video paused vid=${session.videoId}');
         break;
-      case 'playRejected':
+      case YoutubeVideoEventName.playRejected:
         cancelPendingVolumeRestore();
         session.userPlayInFlight = false;
         session.emitPlaying(false);
@@ -130,7 +131,7 @@ class YoutubeWebViewEvents {
         startPolling();
         session.scheduleRecoveryHint();
         break;
-      case 'ended':
+      case YoutubeVideoEventName.ended:
         session.pausedPollStreak = 0;
         session.userPlayInFlight = false;
         cancelPendingVolumeRestore();
@@ -140,15 +141,15 @@ class YoutubeWebViewEvents {
         session.emitBuffering(false);
         unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));
         break;
-      case 'waiting':
+      case YoutubeVideoEventName.waiting:
         session.emitBuffering(true);
         break;
-      case 'canplay':
+      case YoutubeVideoEventName.canplay:
         if (session.buffering) {
           session.emitBuffering(false);
         }
         break;
-      case 'loadedmetadata':
+      case YoutubeVideoEventName.loadedmetadata:
         startPolling();
         if (args.length > 1) {
           final dur = (args[1] as num).toDouble();
@@ -158,7 +159,7 @@ class YoutubeWebViewEvents {
           }
         }
         break;
-      case 'error':
+      case YoutubeVideoEventName.error:
         cancelPendingVolumeRestore();
         _logEvents.warning('YouTube video element error');
         session.userPlayInFlight = false;
@@ -166,6 +167,10 @@ class YoutubeWebViewEvents {
         session.emitBuffering(false);
         break;
       default:
+        // A name the Dart side does not switch over cannot reach here without
+        // failing youtube_js_protocol_contract_test first — log so a stray
+        // name surfaces in diagnostics instead of vanishing.
+        _logEvents.warning('youtube unknown video event name=$event');
         break;
     }
     return null;

--- a/lib/features/player/application/engines/youtube/youtube_webview_host.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_host.dart
@@ -1,4 +1,8 @@
 /// Shared [InAppWebView] host for [YoutubePlayerEngine] (single instance per engine).
+///
+/// Speaks only to [YoutubeWebViewController] — the WebView lifecycle owner —
+/// plus a `currentVideoId` reader for the watch-navigation policy. The engine
+/// itself stays behind the [PlayerEngine] contract (issue #630).
 library;
 
 import 'dart:async';
@@ -8,15 +12,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/webview/platform_webview_environment.dart';
-import 'youtube_player_engine.dart';
 import 'youtube_watch_navigation_policy.dart';
 import 'youtube_webview_bridge.dart';
+import 'youtube_webview_controller.dart';
 
-/// One [InAppWebView] per [YoutubePlayerEngine]; mounted in the video stage slot.
+/// One [InAppWebView] per engine; mounted in the video stage slot.
 class YoutubeWebViewHost extends StatefulWidget {
-  const YoutubeWebViewHost({required this.engine, super.key});
+  const YoutubeWebViewHost({
+    super.key,
+    required this.controller,
+    required this.currentVideoId,
+  });
 
-  final YoutubePlayerEngine engine;
+  final YoutubeWebViewController controller;
+
+  /// Watch-navigation policy needs the id of the video the engine opened.
+  final String Function() currentVideoId;
 
   @override
   State<YoutubeWebViewHost> createState() => _YoutubeWebViewHostState();
@@ -27,7 +38,7 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
 
   @override
   void dispose() {
-    widget.engine.onWebViewDisposed(_controller);
+    widget.controller.onWebViewDisposed(_controller);
     super.dispose();
   }
 
@@ -36,7 +47,7 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
     NavigationAction action,
   ) async {
     final url = action.request.url?.toString() ?? '';
-    final videoId = widget.engine.currentVideoId;
+    final videoId = widget.currentVideoId();
     final allowed = shouldAllowYoutubeWatchNavigation(
       url: url,
       videoId: videoId,
@@ -48,7 +59,7 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
         action.isForMainFrame &&
         url.contains('accounts.google.com') &&
         videoId.isNotEmpty) {
-      unawaited(widget.engine.onSignInNavigationBlocked(controller));
+      unawaited(widget.controller.onSignInNavigationBlocked(controller));
     }
     return allowed
         ? NavigationActionPolicy.ALLOW
@@ -57,8 +68,9 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
 
   @override
   Widget build(BuildContext context) {
-    final e = widget.engine;
-    final vid = e.currentVideoId;
+    // Distinct name from the InAppWebViewController closure parameters.
+    final lifecycle = widget.controller;
+    final vid = widget.currentVideoId();
     final iosInlinePlayback = defaultTargetPlatform == TargetPlatform.iOS;
 
     final initialUrl = vid.isEmpty
@@ -73,26 +85,26 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
           _controller = controller;
           // [initialUrlRequest] already navigates on cold mount when [vid] is set;
           // avoid a second [loadWatchPage] that interrupts the first playback start.
-          e.onWebViewCreated(
+          lifecycle.onWebViewCreated(
             controller,
             initialWatchUrlRequested: vid.isNotEmpty,
           );
         },
         onEnterFullscreen: iosInlinePlayback
             ? (controller) {
-                unawaited(e.exitNativeFullscreen(controller));
+                unawaited(lifecycle.exitNativeFullscreen(controller));
               }
             : null,
         onExitFullscreen: iosInlinePlayback
             ? (controller) {
-                unawaited(e.onNativeFullscreenExit(controller));
+                unawaited(lifecycle.onNativeFullscreenExit(controller));
               }
             : null,
         onLoadStop: (controller, url) async {
-          await e.onPageFinished(controller, url?.toString());
+          await lifecycle.onPageFinished(controller, url?.toString());
         },
         onReceivedHttpError: (controller, request, response) {
-          e.onWebResourceHttpError(
+          lifecycle.onWebResourceHttpError(
             url: request.url.toString(),
             statusCode: response.statusCode,
             isForMainFrame: request.isForMainFrame ?? false,
@@ -100,16 +112,16 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
         },
         onReceivedError: (controller, request, error) {
           if (request.isForMainFrame != true) return;
-          e.onWebResourceLoadError(
+          lifecycle.onWebResourceLoadError(
             url: request.url.toString(),
             description: error.description,
           );
         },
         onWebContentProcessDidTerminate: (controller) {
-          unawaited(e.onWebViewProcessTerminated());
+          unawaited(lifecycle.onWebViewProcessTerminated());
         },
         onRenderProcessGone: (controller, detail) {
-          unawaited(e.onWebViewProcessTerminated());
+          unawaited(lifecycle.onWebViewProcessTerminated());
         },
         shouldOverrideUrlLoading: _onShouldOverrideUrlLoading,
         initialUrlRequest: URLRequest(url: initialUrl),

--- a/test/features/player/application/engines/youtube/youtube_js_protocol_contract_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_js_protocol_contract_test.dart
@@ -1,0 +1,93 @@
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_page_inject.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the string protocol between the watch-page JavaScript and Dart
+/// (issue #629, tier 1).
+///
+/// The JS side cannot be executed in a unit test (tier 2 tracks a runtime
+/// harness), but the protocol *shape* can be pinned: every event name the
+/// JS sources emit must be a name the Dart switch handles, and every handled
+/// name must actually be emitted — otherwise a rename or a new name on one
+/// side drifts silently into the switch's logged default branch.
+void main() {
+  // Every Dart-reachable JS source that can call `flutter_inappwebview
+  // .callHandler`. The bridge's play scripts embed the shared
+  // `_startPlaybackBody`, so `playRejected` is included via interpolation.
+  final jsSources = [
+    kYoutubeMobileWatchInjectScript,
+    YoutubeWebViewBridge.playScript,
+    YoutubeWebViewBridge.playOrPauseScript,
+  ].join('\n===\n');
+
+  /// All handler names the JS side calls, e.g. `callHandler('onVideoEvent',…)`.
+  final jsCalledHandlers = RegExp(
+    r"callHandler\(\s*'([A-Za-z]+)'",
+  ).allMatches(jsSources).map((m) => m.group(1)!).toSet();
+
+  /// Event names emitted with a literal second argument.
+  final literalEventNames = RegExp(
+    r"callHandler\(\s*'onVideoEvent'\s*,\s*'([a-zA-Z]+)'",
+  ).allMatches(jsSources).map((m) => m.group(1)!).toSet();
+
+  /// `hookVideo` emits through a variable: `var events=['play',…]` later
+  /// forwarded as `callHandler('onVideoEvent',args[0],…)`.
+  final arrayEventNames = RegExp(r'var events=\[([^\]]*)\]')
+      .allMatches(jsSources)
+      .expand((m) {
+        return RegExp(
+          r"'([a-zA-Z]+)'",
+        ).allMatches(m.group(1)!).map((inner) => inner.group(1)!);
+      })
+      .toSet();
+
+  test('every event name the JS emits is a name the Dart switch handles', () {
+    final emitted = {...literalEventNames, ...arrayEventNames};
+    // Sanity on the extraction itself: the known emission styles must all
+    // have been found before the comparison means anything.
+    expect(literalEventNames, containsAll(<String>['playRejected', 'ended']));
+    expect(arrayEventNames, isNotEmpty);
+
+    final unhandled = emitted.difference(YoutubeVideoEventName.all);
+    expect(
+      unhandled,
+      isEmpty,
+      reason:
+          'JS emits ${unhandled.toList()} but the Dart switch has no case '
+          '(it would hit the logged default and vanish).',
+    );
+  });
+
+  test(
+    'every event name the Dart switch handles is actually emitted by the JS',
+    () {
+      final emitted = {...literalEventNames, ...arrayEventNames};
+      final dead = YoutubeVideoEventName.all.difference(emitted);
+      expect(
+        dead,
+        isEmpty,
+        reason:
+            'Dart handles ${dead.toList()} but no JS source emits them — '
+            'dead protocol entries.',
+      );
+    },
+  );
+
+  test('handler names called from JS match the handlers Dart registers', () {
+    final unregistered = jsCalledHandlers.difference(YoutubeJsHandlerName.all);
+    expect(
+      unregistered,
+      isEmpty,
+      reason:
+          'JS calls ${unregistered.toList()} but '
+          'YoutubeWebViewController never registers them.',
+    );
+    final neverCalled = YoutubeJsHandlerName.all.difference(jsCalledHandlers);
+    expect(
+      neverCalled,
+      isEmpty,
+      reason: 'Dart registers ${neverCalled.toList()} but no JS calls them.',
+    );
+  });
+}

--- a/test/features/player/youtube_player_engine_test.dart
+++ b/test/features/player/youtube_player_engine_test.dart
@@ -6,60 +6,66 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('YoutubePlayerEngine mount lifecycle', () {
-    test(
-      'ensureWebViewAttached sets shouldMountWebView without duplicate hosts',
-      () async {
-        final engine = YoutubePlayerEngine();
-        expect(engine.shouldMountWebView, isFalse);
-        expect(engine.webViewMounted, isFalse);
-
-        engine.ensureWebViewAttached();
-        expect(engine.shouldMountWebView, isTrue);
-        expect(engine.webViewMounted, isFalse);
-
-        await engine.idleAfterClear();
-        expect(engine.shouldMountWebView, isFalse);
-        expect(engine.currentVideoId, isEmpty);
-      },
-    );
-
-    test('ensureWebViewAttached is idempotent for mountTick', () {
-      final engine = YoutubePlayerEngine();
-      engine.ensureWebViewAttached();
-      final tickAfterFirst = engine.mountTick.value;
-      engine.ensureWebViewAttached();
-      engine.ensureWebViewAttached();
-      expect(engine.mountTick.value, tickAfterFirst);
-      expect(engine.shouldMountWebView, isTrue);
-    });
-
-    test('open requests mount and sets video id', () async {
+  group('YoutubePlayerEngine contract surface', () {
+    test('open sets the video id and arms buffering transport', () async {
       final engine = YoutubePlayerEngine();
       await engine.open(const YoutubePlayableSource('abc12345678'));
       expect(engine.currentVideoId, 'abc12345678');
-      expect(engine.shouldMountWebView, isTrue);
+      expect(engine.transportSnapshot.buffering, isTrue);
+      await engine.dispose();
     });
 
-    test('practice clear idles content but keeps WebView mounted', () async {
+    test('teardownAfterClear idles the engine', () async {
       final engine = YoutubePlayerEngine();
       await engine.open(const YoutubePlayableSource('abc12345678'));
 
-      await engine.idleAfterClear(keepMounted: true);
+      await engine.teardownAfterClear(keepSurfaceMounted: false);
 
       expect(engine.currentVideoId, isEmpty);
-      expect(engine.shouldMountWebView, isTrue);
+      expect(engine.transportSnapshot.playing, isFalse);
+      expect(engine.transportSnapshot.buffering, isFalse);
+      await engine.dispose();
     });
 
-    test(
-      'warmVideoSurface only requests mount (no redundant idle navigation)',
-      () {
-        final engine = YoutubePlayerEngine();
-        engine.warmVideoSurface();
-        expect(engine.shouldMountWebView, isTrue);
-        expect(engine.currentVideoId, isEmpty);
-      },
-    );
+    test('warmVideoSurface does not throw and keeps no video open', () {
+      final engine = YoutubePlayerEngine();
+      engine.warmVideoSurface();
+      expect(engine.currentVideoId, isEmpty);
+    });
+  });
+
+  group('YoutubeSession mount lifecycle', () {
+    // The mount latches live on the session; the engine only forwards them
+    // through warmVideoSurface / teardownAfterClear (issue #630).
+    test('requestMount arms the mount without duplicate host ticks', () {
+      final session = YoutubeSession();
+      expect(session.shouldMountWebView, isFalse);
+      expect(session.webViewMounted, isFalse);
+
+      session.requestMount();
+      final tickAfterFirst = session.mountTick.value;
+      session.requestMount();
+      session.requestMount();
+
+      expect(session.shouldMountWebView, isTrue);
+      expect(session.mountTick.value, tickAfterFirst);
+      expect(session.webViewMounted, isFalse);
+    });
+
+    test('resetForClear unmounts unless asked to keep the host', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session.requestMount();
+
+      session.resetForClear();
+      expect(session.shouldMountWebView, isFalse);
+      expect(session.videoId, isEmpty);
+
+      session.resetForOpen('abc12345678');
+      session.requestMount();
+      session.resetForClear(keepMounted: true);
+      expect(session.shouldMountWebView, isTrue);
+      expect(session.videoId, isEmpty);
+    });
   });
 
   group('YoutubeWebViewEvents playback state', () {


### PR DESCRIPTION
Closes #630. Part of the 2026-08-27 architecture review #626, candidate 4. **Stacks on #632** (both touch `youtube_webview_controller.dart`; merge #632 first).

## What changes

`YoutubePlayerEngine` exposed ~18 public members beyond the `PlayerEngine` contract — a second, implicit interface that existed only so `YoutubeWebViewHost` could reach the `YoutubeWebViewController` through the engine. Every WebView callback was engine-forwarding.

- **`YoutubeWebViewHost` now speaks to the lifecycle owner directly**: it takes `YoutubeWebViewController` + a `currentVideoId` reader (for the watch-navigation policy). Created/disposed/page-finished/fullscreen/process-terminated callbacks land in one hop.
- **Resource-error logging moves onto the controller** (`onWebResourceHttpError` / `onWebResourceLoadError`); their log lines now tag `YouTubeWebViewController` instead of `YouTubePlayerEngine`.
- **The engine's public surface is exactly `PlayerEngine`**: `webViewHostKey`, `mountTick`, `webViewMounted`, `shouldMountWebView`, `tapToPlayHintActive`, `ensureWebViewAttached`, `awaitWebViewMounted`, `idleAfterClear`, `buildWebViewHost`, and the nine WebView callback forwarders are all deleted or private. Internally the engine reads the session directly.
- **Tests follow the state**: engine tests assert through the contract (`open`, `teardownAfterClear`, `warmVideoSurface`, `transportSnapshot`); mount-latch assertions (`requestMount` idempotency, `keepMounted` teardown) moved to a session group where the latches live.

## Why

The `PlayerEngine` seam is real — two adapters plus a test double. But the leaked host half meant surface-hosting behavior was untestable through the contract, and the engine was two facades glued together (lines 40–130 were pure forwarding to `_session`, 345–388 to `_webView`). Builds on #595 (capabilities on the contract) and ADR-0057 (permanent surface host) — extends both, revisits neither.

## Verification

- `flutter analyze` — no issues
- `bash .github/scripts/validate_ci_gates.sh --fix` — format + codegen clean
- Full `flutter test` — 5,706 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
