### PR TITLE
refactor(youtube): one owner for audible playback — autoplay-policy module (closes #628)

### DIFF
--- a/lib/features/player/application/engines/youtube/youtube_audible_playback_policy.dart
+++ b/lib/features/player/application/engines/youtube/youtube_audible_playback_policy.dart
@@ -1,0 +1,197 @@
+/// Audible-playback policy for the YouTube watch WebView (issue #628).
+///
+/// One owner for the whole mute-start → restore → heal choreography under
+/// Chromium's autoplay gesture lock, and for every timing constant it
+/// depends on. Previously the policy lived in comments and private helpers
+/// smeared across [YoutubeWebViewEvents], [YoutubeSession], and
+/// [YoutubeWebViewController]; each play-then-pause fix had to coordinate
+/// them in lockstep.
+///
+/// The gesture-lock rules this module encodes:
+///
+/// - A muted start bypasses the gesture lock; a later programmatic unmute
+///   without fresh user activation pauses the element ("Unmuting failed and
+///   the element was paused instead") — the play-then-pause root cause.
+/// - Therefore the unmute runs **at most once per watch document**
+///   (see [YoutubeSession.needsVolumeRestore]), only after playback has
+///   actually started and progressed, and is followed by a one-shot heal
+///   that re-issues play if the unmute tripped the lock.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
+
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+
+final _logPolicy = logNamed('YouTubeAudiblePlaybackPolicy');
+
+/// Re-applies the user's volume to the page player (mute/unmute/setVolume).
+typedef YoutubeReapplyVolumeFn = Future<void> Function();
+
+/// Heal play (defaults to [YoutubeWebViewBridge.play], which preserves
+/// audible state).
+typedef YoutubeHealPlayFn = Future<void> Function();
+
+/// Owns the audible-start choreography and its clock.
+///
+/// The session remains the state store (armed flag, per-document restore
+/// pin, progress ticks); this module drives the transitions and owns every
+/// duration. The joint invariant —
+///
+///     pauseConfirm (pauseConfirmPollTicks × pollTick)
+///       <  postRestoreHealDelay
+///       <  YoutubeSession.tapToPlayHintDelay
+///
+/// — is asserted in `youtube_audible_playback_policy_test.dart` so the three
+/// constraints can no longer drift independently.
+class YoutubeAudiblePlaybackPolicy {
+  YoutubeAudiblePlaybackPolicy({
+    required this.session,
+    required this.reapplyVolume,
+    required this.healPlay,
+    Duration? volumeRestoreDelay,
+    Duration? volumeRestoreFallback,
+    Duration? postRestoreHealDelay,
+  }) : volumeRestoreDelay =
+           volumeRestoreDelay ??
+           (defaultTargetPlatform == TargetPlatform.windows
+               ? windowsVolumeRestoreDelay
+               : Duration.zero),
+       volumeRestoreFallback =
+           volumeRestoreFallback ?? defaultVolumeRestoreFallback,
+       postRestoreHealDelay =
+           postRestoreHealDelay ?? defaultPostRestoreHealDelay;
+
+  /// Poll-loop cadence (canonical home here so the joint invariant above is
+  /// checkable against it).
+  static const Duration pollTick = Duration(milliseconds: 250);
+
+  /// Legacy minimum settle before progress-gated unmute (Windows first play).
+  /// Progress confirmation is preferred; this delay is only a lower bound when
+  /// progress arrives earlier than the platform settle window.
+  static const Duration windowsVolumeRestoreDelay = Duration(milliseconds: 400);
+
+  /// Progress-gated restore gives up after this long without advancement.
+  static const Duration defaultVolumeRestoreFallback = Duration(
+    milliseconds: 1500,
+  );
+
+  /// How long after a volume restore to check whether the unmute tripped the
+  /// WebView's autoplay gesture lock (which pauses the element). Must exceed
+  /// the poll loop's pause-confirmation window
+  /// ([YoutubeSession.pauseConfirmPollTicks] × [pollTick]) so a real pause is
+  /// already reflected in [YoutubeSession.playing]; must stay short enough to
+  /// beat the tap-to-play recovery hint.
+  static const Duration defaultPostRestoreHealDelay = Duration(
+    milliseconds: 900,
+  );
+
+  final Duration volumeRestoreDelay;
+  final Duration volumeRestoreFallback;
+  final Duration postRestoreHealDelay;
+
+  final YoutubeSession session;
+  final YoutubeReapplyVolumeFn reapplyVolume;
+  final YoutubeHealPlayFn healPlay;
+
+  Timer? _volumeRestoreFallbackTimer;
+  DateTime? _volumeRestoreArmedAt;
+
+  /// `playing` observed: arm the per-document restore if this document has
+  /// not been restored yet. Later `playing` events in an already-restored
+  /// document must NOT re-unmute — every programmatic unMute is a pause
+  /// trigger under the gesture lock, so redundancy here is the bug.
+  void onPlaying() {
+    if (session.disposed || !session.needsVolumeRestore) return;
+    _armProgressGatedVolumeRestore();
+  }
+
+  /// DOM `pause` while a restore is pending: the element never got audible
+  /// progress, so the pending unmute is abandoned.
+  void onPause() => cancelPending();
+
+  /// Called from the poll loop when `<video>.currentTime` advances.
+  void onPlaybackProgress(Duration position) {
+    if (!session.volumeRestorePending || session.disposed) return;
+    if (!session.playing) return;
+    final armedAt = _volumeRestoreArmedAt;
+    if (armedAt != null) {
+      final elapsed = DateTime.now().difference(armedAt);
+      if (elapsed < volumeRestoreDelay) return;
+    }
+    if (session.noteProgressForVolumeRestore(position)) {
+      unawaited(_restoreVolume(reason: 'progress'));
+    }
+  }
+
+  /// Abandons any pending restore (explicit play, reload, dispose paths).
+  void cancelPending() {
+    _volumeRestoreFallbackTimer?.cancel();
+    _volumeRestoreFallbackTimer = null;
+    _volumeRestoreArmedAt = null;
+    session.clearVolumeRestorePending();
+  }
+
+  void _armProgressGatedVolumeRestore() {
+    cancelPending();
+    session.armVolumeRestorePending(baseline: session.lastPosition);
+    _volumeRestoreArmedAt = DateTime.now();
+    _logPolicy.fine(
+      'youtube volume restore armed vid=${session.videoId} '
+      'fallbackMs=${volumeRestoreFallback.inMilliseconds} '
+      'minDelayMs=${volumeRestoreDelay.inMilliseconds}',
+    );
+    _volumeRestoreFallbackTimer = Timer(volumeRestoreFallback, () {
+      _volumeRestoreFallbackTimer = null;
+      if (session.disposed ||
+          !session.playing ||
+          !session.volumeRestorePending) {
+        return;
+      }
+      unawaited(_restoreVolume(reason: 'fallback'));
+    });
+  }
+
+  Future<void> _restoreVolume({required String reason}) async {
+    if (session.disposed || !session.playing) return;
+    session.clearVolumeRestorePending();
+    _volumeRestoreFallbackTimer?.cancel();
+    _volumeRestoreFallbackTimer = null;
+    _volumeRestoreArmedAt = null;
+    try {
+      await reapplyVolume();
+      session.noteVolumeRestored();
+      _logPolicy.fine(
+        'youtube volume restored vid=${session.videoId} reason=$reason',
+      );
+      unawaited(_healPostRestorePause());
+    } on Object catch (error, stackTrace) {
+      _logPolicy.warning(
+        'youtube volume restore failed vid=${session.videoId} reason=$reason',
+        error,
+        stackTrace,
+      );
+    }
+  }
+
+  /// One-shot self-heal for the gesture-lock failure mode: the unmute made
+  /// the element audible without user activation and the WebView paused it
+  /// right after. Re-issues play exactly once with audible state preserved —
+  /// on engines that allow audible starts this recovers invisibly; where the
+  /// start is genuinely refused, the poll loop's recovery hint remains the
+  /// fallback.
+  Future<void> _healPostRestorePause() async {
+    await Future<void>.delayed(postRestoreHealDelay);
+    if (session.disposed ||
+        session.playing ||
+        session.playbackCompleted ||
+        session.needsVolumeRestore) {
+      return;
+    }
+    _logPolicy.info('youtube post-restore pause heal vid=${session.videoId}');
+    unawaited(healPlay());
+  }
+}

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -82,12 +82,12 @@ class YoutubePlayerEngine implements PlayerEngine {
   @override
   void setPosterUrl(String? url) => _session.setPosterUrl(url);
 
-  /// Clears the internal [YoutubeSession.playbackCompleted] flag so the next
+  /// Clears the session's end-of-media latch so the next
   /// [play] call drives the `<video>` directly instead of reloading the watch
   /// page. Used by the deterministic completion loop (ADR-0044) to seek + play
   /// from an arbitrary position after end-of-media.
   @override
-  void resetCompletionFlag() => _session.playbackCompleted = false;
+  void resetCompletionFlag() => _session.resetCompletionFlag();
 
   @override
   void markOpenTimingStart() => _webView.markOpenTimingStart();
@@ -207,11 +207,8 @@ class YoutubePlayerEngine implements PlayerEngine {
 
   @override
   Future<void> setVolumeNormalized(double volume) async {
-    _session.volumeNormalized = volume.clamp(0, 1);
-    await YoutubeWebViewBridge.setVolume(
-      _webView.webController,
-      _session.volumeNormalized,
-    );
+    final applied = _session.storeVolumeNormalized(volume);
+    await YoutubeWebViewBridge.setVolume(_webView.webController, applied);
   }
 
   @override
@@ -235,11 +232,8 @@ class YoutubePlayerEngine implements PlayerEngine {
           return;
         }
         _webView.onExplicitPlayAttempt();
-        _session.userPlayInFlight = true;
-        // Clear stale buffering so the transport button stays retryable.
-        if (_session.buffering && !_session.playing) {
-          _session.emitBuffering(false);
-        }
+        // In-flight latch + stale-buffering clear live in the transition.
+        _session.beginUserPlay();
         _logYoutube.fine(
           'youtube playOrPause command vid=${_session.videoId} '
           'sessionPlaying=${_session.playing} '
@@ -279,10 +273,8 @@ class YoutubePlayerEngine implements PlayerEngine {
           return;
         }
         _webView.onExplicitPlayAttempt();
-        _session.userPlayInFlight = true;
-        if (_session.buffering && !_session.playing) {
-          _session.emitBuffering(false);
-        }
+        // In-flight latch + stale-buffering clear live in the transition.
+        _session.beginUserPlay();
         _logYoutube.fine(
           'youtube play command vid=${_session.videoId} '
           'buffering=${_session.buffering} '
@@ -321,7 +313,7 @@ class YoutubePlayerEngine implements PlayerEngine {
     _session.emitPlaying(false);
     _session.emitBuffering(false);
     _session.emitPosition(Duration.zero);
-    _session.playbackCompleted = false;
+    _session.resetCompletionFlag();
   }
 
   @override

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -7,7 +7,6 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart' hide RepeatMode;
 import 'package:flutter/services.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:media_kit/media_kit.dart' as mk;
 
 import 'package:enjoy_player/core/logging/log.dart';
@@ -37,17 +36,11 @@ class YoutubePlayerEngine implements PlayerEngine {
   final YoutubeSession _session;
   late final YoutubeWebViewController _webView;
 
-  GlobalKey get webViewHostKey => _session.webViewHostKey;
-  ValueNotifier<int> get mountTick => _session.mountTick;
-
   @override
   String get currentVideoId => _session.videoId;
 
   @override
   String? get posterUrl => _session.posterUrl;
-  bool get webViewMounted => _session.webViewMounted;
-  bool get shouldMountWebView => _session.shouldMountWebView;
-  bool get tapToPlayHintActive => _session.tapToPlayHintActive;
 
   @override
   bool get supportsYouTubePlayback => true;
@@ -99,34 +92,38 @@ class YoutubePlayerEngine implements PlayerEngine {
   @override
   void markOpenTimingStart() => _webView.markOpenTimingStart();
 
-  void ensureWebViewAttached() {
+  void _ensureWebViewAttached() {
     _session.requestMount();
     _logInitPhase('mount_requested');
   }
 
-  /// Completes when [webViewMounted] is true or [timeout] elapses.
-  Future<bool> awaitWebViewMounted({
+  /// Completes when the WebView is mounted or [timeout] elapses.
+  Future<bool> _awaitWebViewMounted({
     Duration timeout = const Duration(seconds: 8),
   }) async {
-    ensureWebViewAttached();
-    if (webViewMounted) return true;
+    _ensureWebViewAttached();
+    if (_session.webViewMounted) return true;
     final deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline)) {
-      if (webViewMounted) return true;
+      if (_session.webViewMounted) return true;
       await Future<void>.delayed(const Duration(milliseconds: 40));
     }
-    return webViewMounted;
+    return _session.webViewMounted;
   }
 
   @override
-  Future<void> awaitSurfaceReady() => awaitWebViewMounted().then((_) {});
+  Future<void> awaitSurfaceReady() => _awaitWebViewMounted().then((_) {});
 
   @override
   Future<void> teardownAfterClear({required bool keepSurfaceMounted}) =>
-      idleAfterClear(keepMounted: keepSurfaceMounted);
+      _webView.idleAfterClear(keepMounted: keepSurfaceMounted);
 
-  Widget buildWebViewHost() {
-    return YoutubeWebViewHost(key: _session.webViewHostKey, engine: this);
+  Widget _buildWebViewHost() {
+    return YoutubeWebViewHost(
+      key: _session.webViewHostKey,
+      controller: _webView,
+      currentVideoId: () => _session.videoId,
+    );
   }
 
   @override
@@ -167,13 +164,13 @@ class YoutubePlayerEngine implements PlayerEngine {
       builder: (context, snapshot) {
         final showPoster = snapshot.data ?? _session.buffering;
         return ValueListenableBuilder<int>(
-          valueListenable: mountTick,
+          valueListenable: _session.mountTick,
           builder: (context, _, _) {
             return Stack(
               fit: StackFit.expand,
               children: [
                 const ColoredBox(color: Colors.black),
-                if (shouldMountWebView) buildWebViewHost(),
+                if (_session.shouldMountWebView) _buildWebViewHost(),
                 if (_session.tapToPlayHintActive && !showPoster)
                   _YoutubeTapToPlayHint(
                     label:
@@ -327,65 +324,17 @@ class YoutubePlayerEngine implements PlayerEngine {
     _session.playbackCompleted = false;
   }
 
-  Future<void> idleAfterClear({bool keepMounted = false}) =>
-      _webView.idleAfterClear(keepMounted: keepMounted);
-
   @override
   Future<Uint8List?> screenshot({String? format}) async => null;
 
   @override
-  void warmVideoSurface() => ensureWebViewAttached();
+  void warmVideoSurface() => _ensureWebViewAttached();
 
   @override
   Future<void> dispose() async {
     await _webView.dispose();
     await _session.closeStreams();
   }
-
-  Future<void> onSignInNavigationBlocked(InAppWebViewController controller) =>
-      _webView.onSignInNavigationBlocked(controller);
-
-  void onWebResourceHttpError({
-    required String? url,
-    required int? statusCode,
-    required bool isForMainFrame,
-  }) {
-    if (!isForMainFrame) return;
-    _logYoutube.warning('youtube main-frame HTTP $statusCode url=${url ?? ''}');
-  }
-
-  void onWebResourceLoadError({
-    required String url,
-    required String description,
-  }) {
-    _logYoutube.warning('youtube load error url=$url msg=$description');
-  }
-
-  Future<void> onWebViewProcessTerminated() =>
-      _webView.onWebViewProcessTerminated();
-
-  void onWebViewCreated(
-    InAppWebViewController controller, {
-    bool initialWatchUrlRequested = false,
-  }) {
-    _webView.onWebViewCreated(
-      controller,
-      initialWatchUrlRequested: initialWatchUrlRequested,
-    );
-  }
-
-  void onWebViewDisposed(InAppWebViewController? controller) {
-    _webView.onWebViewDisposed(controller);
-  }
-
-  Future<void> onPageFinished(InAppWebViewController controller, String? url) =>
-      _webView.onPageFinished(controller, url);
-
-  Future<void> exitNativeFullscreen(InAppWebViewController controller) =>
-      _webView.exitNativeFullscreen(controller);
-
-  Future<void> onNativeFullscreenExit(InAppWebViewController controller) =>
-      _webView.onNativeFullscreenExit(controller);
 
   void _logInitPhase(String phase) {
     _session.logInitPhase(phase, (m) => _logYoutube.fine(m));

--- a/lib/features/player/application/engines/youtube/youtube_session.dart
+++ b/lib/features/player/application/engines/youtube/youtube_session.dart
@@ -61,7 +61,6 @@ class YoutubeSession {
   Duration? _volumeRestoreBaselinePosition;
   int _progressAdvanceTicks = 0;
   static const int progressConfirmTicks = 2;
-  static const Duration volumeRestoreFallback = Duration(milliseconds: 1500);
 
   /// Generation of the loaded watch document. Bumped on every open and watch
   /// load stop (ads reload the page into a fresh document whose `<video>`
@@ -81,7 +80,12 @@ class YoutubeSession {
   static const Duration immediatePauseWindow = Duration(seconds: 2);
 
   Timer? _tapToPlayHintTimer;
-  static const Duration _tapToPlayHintDelay = Duration(milliseconds: 1200);
+
+  /// Recovery-overlay delay. Part of the audible-playback joint invariant
+  /// (must exceed [YoutubeAudiblePlaybackPolicy.postRestoreHealDelay]'s
+  /// check window) — asserted in the policy's tests, which is why it is
+  /// public.
+  static const Duration tapToPlayHintDelay = Duration(milliseconds: 1200);
 
   Duration _lastPosition = Duration.zero;
   Duration _lastDuration = Duration.zero;
@@ -446,7 +450,7 @@ class YoutubeSession {
     final allowRecovery = _explicitPlayAttempted && !_playing && !_buffering;
     if (_loggedFirstPlaying && !allowRecovery) return;
     _tapToPlayHintTimer?.cancel();
-    _tapToPlayHintTimer = Timer(_tapToPlayHintDelay, () {
+    _tapToPlayHintTimer = Timer(tapToPlayHintDelay, () {
       _tapToPlayHintTimer = null;
       if (_disposed || _playing || _buffering) return;
       if (_loggedFirstPlaying && !_explicitPlayAttempted) return;

--- a/lib/features/player/application/engines/youtube/youtube_session.dart
+++ b/lib/features/player/application/engines/youtube/youtube_session.dart
@@ -1,8 +1,15 @@
-﻿/// Playback state and broadcast streams for [YoutubePlayerEngine].
+/// Playback state and broadcast streams for [YoutubePlayerEngine].
+///
+/// The session owns the Dart-side transport latches; every other module
+/// (engine, events, poll loop, webview controller, navigation) changes them
+/// only through the transition verbs below, so each invariant — what must be
+/// cleared together, what may only transition once — is enforced in exactly
+/// one place instead of at every writer (issue #627).
 library;
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 
 /// Owns YouTube open state, transport snapshot, and engine event streams.
@@ -20,76 +27,76 @@ class YoutubeSession {
       StreamController<void>.broadcast();
 
   final GlobalKey webViewHostKey = GlobalKey();
-  final ValueNotifier<int> mountTick = ValueNotifier(0);
+  final ValueNotifier<int> _mountTick = ValueNotifier(0);
   final Stream<double> aspectStream = Stream<double>.value(16 / 9);
 
-  String videoId = '';
-  String? posterUrl;
-  bool mountRequested = false;
-  bool webViewMounted = false;
-  bool loggedFirstPlaying = false;
-  bool watchPageLoadStopReceived = false;
-  bool awaitingColdInitialNavigation = false;
-  bool nonWatchRecoveryScheduled = false;
-  bool disposed = false;
-  bool playbackCompleted = false;
-  bool firstBufferingOffReceived = false;
+  String _videoId = '';
+  String? _posterUrl;
+  bool _mountRequested = false;
+  bool _webViewMounted = false;
+  bool _loggedFirstPlaying = false;
+  bool _watchPageLoadStopReceived = false;
+  bool _awaitingColdInitialNavigation = false;
+  bool _nonWatchRecoveryScheduled = false;
+  bool _disposed = false;
+  bool _playbackCompleted = false;
+  bool _firstBufferingOffReceived = false;
 
-  bool playing = false;
-  bool buffering = true;
-  bool tapToPlayHintActive = false;
+  bool _playing = false;
+  bool _buffering = true;
+  bool _tapToPlayHintActive = false;
 
   /// User (or app) requested play; cancels autoplay assist and arms recovery UX.
-  bool explicitPlayAttempted = false;
+  bool _explicitPlayAttempted = false;
 
   /// An explicit user play has not yet resolved (playing/rejected/error).
   /// Grants the poll loop exactly one automatic retry when a pause is
   /// confirmed almost immediately after playback started — the page player
   /// state machine can "correct" a freshly started video back to paused
   /// before it settles; one retry after it settles recovers without UX.
-  bool userPlayInFlight = false;
+  bool _userPlayInFlight = false;
 
-  /// First-play unmute is deferred until [currentTime] advances (or fallback).
-  bool volumeRestorePending = false;
-  Duration? volumeRestoreBaselinePosition;
-  int progressAdvanceTicks = 0;
+  /// First-play unmute is deferred until [position] advances (or fallback).
+  bool _volumeRestorePending = false;
+  Duration? _volumeRestoreBaselinePosition;
+  int _progressAdvanceTicks = 0;
   static const int progressConfirmTicks = 2;
   static const Duration volumeRestoreFallback = Duration(milliseconds: 1500);
 
   /// Generation of the loaded watch document. Bumped on every open and watch
   /// load stop (ads reload the page into a fresh document whose `<video>`
   /// starts muted again).
-  int documentGen = 0;
+  int _documentGen = 0;
 
-  /// [documentGen] for which volume was last restored, or `-1` when never.
+  /// [_documentGen] for which volume was last restored, or `-1` when never.
   /// The unmute runs at most once per document: redundant programmatic
   /// unMutes are pause triggers under Chromium's autoplay gesture lock (the
   /// play-then-pause root cause), so later `playing` events in an already
   /// restored document must not touch volume at all.
-  int volumeRestoredDocGen = -1;
+  int _volumeRestoredDocGen = -1;
 
-  /// True when the current document still needs its first volume restore.
-  bool get needsVolumeRestore =>
-      volumeRestoredDocGen != documentGen && !disposed;
-
-  /// Wall-clock when [emitPlaying(true)] last succeeded — for immediate-pause
-  /// diagnostics (pause confirmed within this window after first playing).
-  DateTime? lastPlayingAt;
+  /// Wall-clock when [emitPlaying] last reported playing — for
+  /// immediate-pause diagnostics (pause confirmed within this window).
+  DateTime? _lastPlayingAt;
   static const Duration immediatePauseWindow = Duration(seconds: 2);
 
   Timer? _tapToPlayHintTimer;
   static const Duration _tapToPlayHintDelay = Duration(milliseconds: 1200);
 
-  Duration lastPosition = Duration.zero;
-  Duration lastDuration = Duration.zero;
+  Duration _lastPosition = Duration.zero;
+  Duration _lastDuration = Duration.zero;
 
-  double volumeNormalized = 1;
-  double? pendingSeekSeconds;
+  double _volumeNormalized = 1;
+  double? _pendingSeekSeconds;
 
-  int pausedPollStreak = 0;
+  int _pausedPollStreak = 0;
   static const int pauseConfirmPollTicks = 3;
 
-  Stopwatch? initStopwatch;
+  Stopwatch? _initStopwatch;
+
+  // ---------------------------------------------------------------------------
+  // Read surface — the latches are private; writers must use the verbs below.
+  // ---------------------------------------------------------------------------
 
   Stream<Duration> get position => positionCtrl.stream;
   Stream<Duration> get duration => durationCtrl.stream;
@@ -97,41 +104,76 @@ class YoutubeSession {
   Stream<bool> get bufferingStream => bufferingCtrl.stream;
   Stream<void> get completed => completedCtrl.stream;
 
-  bool get shouldMountWebView => mountRequested && !disposed;
+  /// Read-only view: host-tree rebuilds observe, only the session mutates.
+  ValueListenable<int> get mountTick => _mountTick;
+
+  String get videoId => _videoId;
+  String? get posterUrl => _posterUrl;
+  bool get shouldMountWebView => _mountRequested && !_disposed;
+  bool get webViewMounted => _webViewMounted;
+  bool get disposed => _disposed;
+  bool get playbackCompleted => _playbackCompleted;
+  bool get loggedFirstPlaying => _loggedFirstPlaying;
+  bool get watchPageLoadStopReceived => _watchPageLoadStopReceived;
+  bool get awaitingColdInitialNavigation => _awaitingColdInitialNavigation;
+  bool get nonWatchRecoveryScheduled => _nonWatchRecoveryScheduled;
+  bool get tapToPlayHintActive => _tapToPlayHintActive;
+
+  bool get playing => _playing;
+  bool get buffering => _buffering;
+  bool get explicitPlayAttempted => _explicitPlayAttempted;
+  bool get userPlayInFlight => _userPlayInFlight;
+  bool get volumeRestorePending => _volumeRestorePending;
+  Duration get lastPosition => _lastPosition;
+  Duration get lastDuration => _lastDuration;
+  DateTime? get lastPlayingAt => _lastPlayingAt;
+  double get volumeNormalized => _volumeNormalized;
+  int get pausedPollStreak => _pausedPollStreak;
+  int get documentGen => _documentGen;
+  int get volumeRestoredDocGen => _volumeRestoredDocGen;
 
   ({bool playing, bool buffering}) get transportSnapshot =>
-      (playing: playing, buffering: buffering);
+      (playing: _playing, buffering: _buffering);
 
-  void setPosterUrl(String? url) => posterUrl = url;
+  /// True when the current document still needs its first volume restore.
+  bool get needsVolumeRestore =>
+      _volumeRestoredDocGen != _documentGen && !_disposed;
 
-  /// Transitions [playbackCompleted] to true and emits a [completed] event.
+  // ---------------------------------------------------------------------------
+  // Open / clear lifecycle.
+  // ---------------------------------------------------------------------------
+
+  void setPosterUrl(String? url) => _posterUrl = url;
+
+  /// Transitions [_playbackCompleted] to true and emits a [completed] event.
   /// Idempotent — only the first call emits; subsequent calls are a no-op.
-  /// Callers that reset [playbackCompleted] to false (e.g. [resetForOpen])
-  /// re-arm the emission for the next end-of-media.
+  /// [resetCompletionFlag] re-arms the emission for the next end-of-media.
   void markCompleted() {
-    if (playbackCompleted) return;
-    playbackCompleted = true;
-    if (!disposed && !completedCtrl.isClosed) {
+    if (_playbackCompleted) return;
+    _playbackCompleted = true;
+    if (!_disposed && !completedCtrl.isClosed) {
       completedCtrl.add(null);
     }
   }
 
+  /// Clears the end-of-media latch so the next [play] drives the `<video>`
+  /// directly instead of reloading the watch page (ADR-0044).
+  void resetCompletionFlag() => _playbackCompleted = false;
+
   void resetForOpen(String newVideoId) {
     _cancelHint();
-    tapToPlayHintActive = false;
-    loggedFirstPlaying = false;
-    watchPageLoadStopReceived = false;
-    awaitingColdInitialNavigation = false;
-    nonWatchRecoveryScheduled = false;
-    firstBufferingOffReceived = false;
-    explicitPlayAttempted = false;
-    userPlayInFlight = false;
+    _tapToPlayHintActive = false;
+    _loggedFirstPlaying = false;
+    resetWatchPageExpectations(firstPlaying: false);
+    _firstBufferingOffReceived = false;
+    _explicitPlayAttempted = false;
+    _userPlayInFlight = false;
     clearVolumeRestorePending();
     noteWatchDocumentLoaded();
-    volumeRestoredDocGen = -1;
-    lastPlayingAt = null;
-    videoId = newVideoId;
-    playbackCompleted = false;
+    _volumeRestoredDocGen = -1;
+    _lastPlayingAt = null;
+    _videoId = newVideoId;
+    _playbackCompleted = false;
     emitBuffering(true);
     emitPlaying(false);
     emitPosition(Duration.zero);
@@ -140,123 +182,256 @@ class YoutubeSession {
 
   void resetForClear({bool keepMounted = false}) {
     _cancelHint();
-    tapToPlayHintActive = false;
-    explicitPlayAttempted = false;
-    userPlayInFlight = false;
+    _tapToPlayHintActive = false;
+    _explicitPlayAttempted = false;
+    _userPlayInFlight = false;
     clearVolumeRestorePending();
-    volumeRestoredDocGen = -1;
-    lastPlayingAt = null;
-    videoId = '';
-    mountRequested = keepMounted;
-    playbackCompleted = false;
-    watchPageLoadStopReceived = false;
-    awaitingColdInitialNavigation = false;
-    nonWatchRecoveryScheduled = false;
+    _volumeRestoredDocGen = -1;
+    _lastPlayingAt = null;
+    _videoId = '';
+    _mountRequested = keepMounted;
+    _playbackCompleted = false;
+    resetWatchPageExpectations(firstPlaying: false);
     emitPlaying(false);
     emitBuffering(false);
     emitPosition(Duration.zero);
-    mountTick.value++;
+    bumpMountTick();
   }
+
+  // ---------------------------------------------------------------------------
+  // Transport transitions.
+  //
+  // The DOM event channel, the poll channel, and the engine commands all
+  // funnel through these — the "clear X when Y" rules live here, once.
+  // ---------------------------------------------------------------------------
+
+  /// An explicit play command is on the wire (engine [play]/[playOrPause]).
+  /// Stale buffering clears so the transport button stays retryable.
+  void beginUserPlay() {
+    _userPlayInFlight = true;
+    if (_buffering && !_playing) {
+      emitBuffering(false);
+    }
+  }
+
+  /// `playing` observed (DOM event or poll): the user play resolved.
+  void notePlayingConfirmed() {
+    _pausedPollStreak = 0;
+    _playbackCompleted = false;
+    _userPlayInFlight = false;
+    emitPlaying(true);
+  }
+
+  /// A programmatic play promise rejected (autoplay policy) or the element
+  /// errored: the unresolved user play settles as not-playing.
+  void noteUserPlayUnresolved() {
+    _userPlayInFlight = false;
+    emitPlaying(false);
+    emitBuffering(false);
+  }
+
+  /// End of media observed (DOM `ended` or poll `s` = 2).
+  void noteEnded() {
+    _pausedPollStreak = 0;
+    _userPlayInFlight = false;
+    markCompleted();
+    emitPlaying(false);
+    emitBuffering(false);
+  }
+
+  /// The poll loop confirmed a pause (streak ≥ [pauseConfirmPollTicks]).
+  void notePauseConfirmed() {
+    _pausedPollStreak = 0;
+    emitPlaying(false);
+    emitBuffering(false);
+  }
+
+  /// Consumes the one-shot immediate-pause retry budget (D8) before the poll
+  /// loop re-issues play; a second immediate pause surfaces to the user.
+  void clearUserPlayInFlight() => _userPlayInFlight = false;
 
   /// Marks an intentional play command (transport / autoplay / recovery).
-  void markExplicitPlayAttempt() {
-    explicitPlayAttempted = true;
+  void markExplicitPlayAttempt() => _explicitPlayAttempted = true;
+
+  /// Poll bookkeeping: accumulate toward pause confirmation.
+  void notePauseStreak(int streak) => _pausedPollStreak = streak;
+
+  /// Poll bookkeeping: forget any half-confirmed pause.
+  void resetPauseStreak() => _pausedPollStreak = 0;
+
+  // ---------------------------------------------------------------------------
+  // Watch-page expectations (webview controller / navigation).
+  // ---------------------------------------------------------------------------
+
+  /// Clears the "expect a watch page load stop" latches before (re)loading.
+  /// [firstPlaying] also forgets that playback ever started (full reload).
+  void resetWatchPageExpectations({required bool firstPlaying}) {
+    _watchPageLoadStopReceived = false;
+    _awaitingColdInitialNavigation = false;
+    _nonWatchRecoveryScheduled = false;
+    if (firstPlaying) {
+      _loggedFirstPlaying = false;
+    }
   }
 
+  /// A watch-page load stop arrived: not cold-navigation, no recovery needed.
+  void noteWatchPageLoaded() {
+    _awaitingColdInitialNavigation = false;
+    _watchPageLoadStopReceived = true;
+    _nonWatchRecoveryScheduled = false;
+  }
+
+  /// The WebView mounted with an initial watch URL already navigating.
+  void noteAwaitingColdInitialNavigation() =>
+      _awaitingColdInitialNavigation = true;
+
+  /// The WebView went away; its in-flight initial navigation no longer
+  /// applies. (Deliberately narrow: dispose must not disturb the load-stop
+  /// or recovery latches.)
+  void clearAwaitingColdInitialNavigation() =>
+      _awaitingColdInitialNavigation = false;
+
+  /// First `playing` observed after an open — arms nudge/watchdog cancel.
+  void markFirstPlayingLogged() => _loggedFirstPlaying = true;
+
+  /// A non-watch load stop was seen; verify the watch page once.
+  void scheduleNonWatchRecovery() => _nonWatchRecoveryScheduled = true;
+
+  /// Starts (or restarts) open-time init instrumentation.
+  void startInitTiming() => _initStopwatch = Stopwatch()..start();
+
+  // ---------------------------------------------------------------------------
+  // WebView mount state.
+  // ---------------------------------------------------------------------------
+
+  void noteWebViewMounted() => _webViewMounted = true;
+
+  void noteWebViewUnmounted() => _webViewMounted = false;
+
+  void requestMount() {
+    if (_disposed) return;
+    // Idempotent: re-entrant calls (e.g. loading stage + open coordinator)
+    // must not notify [mountTick] again — that can hit ValueListenableBuilder
+    // listeners during an ancestor build (setState-during-build).
+    if (_mountRequested) return;
+    _mountRequested = true;
+    bumpMountTick();
+  }
+
+  /// Notifies host-tree listeners that session-derived UI changed.
+  void bumpMountTick() => _mountTick.value++;
+
+  /// Deferred variant for teardown paths that run during widget unmount —
+  /// notifying synchronously there locks the tree.
+  void scheduleMountTickBump() {
+    scheduleMicrotask(bumpMountTick);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Volume restore (autoplay-policy latch — see YoutubeWebViewEvents).
+  // ---------------------------------------------------------------------------
+
   void clearVolumeRestorePending() {
-    volumeRestorePending = false;
-    volumeRestoreBaselinePosition = null;
-    progressAdvanceTicks = 0;
+    _volumeRestorePending = false;
+    _volumeRestoreBaselinePosition = null;
+    _progressAdvanceTicks = 0;
   }
 
   /// Pins the current document as volume-restored so later `playing` events
   /// skip the unmute entirely (idempotence against the gesture lock).
-  void noteVolumeRestored() {
-    volumeRestoredDocGen = documentGen;
-  }
+  void noteVolumeRestored() => _volumeRestoredDocGen = _documentGen;
 
   /// Bumps the watch-document generation (open / watch load stop).
-  void noteWatchDocumentLoaded() {
-    documentGen++;
-  }
+  void noteWatchDocumentLoaded() => _documentGen++;
 
   void armVolumeRestorePending({required Duration baseline}) {
-    volumeRestorePending = true;
-    volumeRestoreBaselinePosition = baseline;
-    progressAdvanceTicks = 0;
+    _volumeRestorePending = true;
+    _volumeRestoreBaselinePosition = baseline;
+    _progressAdvanceTicks = 0;
   }
 
   /// Returns true when [position] has advanced enough to safely unmute.
   bool noteProgressForVolumeRestore(Duration position) {
-    if (!volumeRestorePending) return false;
-    final baseline = volumeRestoreBaselinePosition ?? Duration.zero;
+    if (!_volumeRestorePending) return false;
+    final baseline = _volumeRestoreBaselinePosition ?? Duration.zero;
     if (position > baseline) {
-      progressAdvanceTicks++;
-      volumeRestoreBaselinePosition = position;
+      _progressAdvanceTicks++;
+      _volumeRestoreBaselinePosition = position;
     }
-    return progressAdvanceTicks >= progressConfirmTicks;
+    return _progressAdvanceTicks >= progressConfirmTicks;
   }
 
-  void requestMount() {
-    if (disposed) return;
-    // Idempotent: re-entrant calls (e.g. loading stage + open coordinator)
-    // must not notify [mountTick] again — that can hit ValueListenableBuilder
-    // listeners during an ancestor build (setState-during-build).
-    if (mountRequested) return;
-    mountRequested = true;
-    mountTick.value++;
+  // ---------------------------------------------------------------------------
+  // Misc state.
+  // ---------------------------------------------------------------------------
+
+  /// Stores the normalized volume and returns the clamped value applied to
+  /// the page player.
+  double storeVolumeNormalized(double volume) {
+    _volumeNormalized = volume.clamp(0, 1);
+    return _volumeNormalized;
+  }
+
+  /// Seek requested from the page side (ad-reload position hand-off).
+  void setPendingSeekSeconds(double? seconds) => _pendingSeekSeconds = seconds;
+
+  /// Claims and clears the page-side pending seek.
+  double? takePendingSeekSeconds() {
+    final seconds = _pendingSeekSeconds;
+    _pendingSeekSeconds = null;
+    return seconds;
   }
 
   void emitPosition(Duration d) {
-    if (disposed || positionCtrl.isClosed) return;
-    if (d == lastPosition) return;
-    lastPosition = d;
+    if (_disposed || positionCtrl.isClosed) return;
+    if (d == _lastPosition) return;
+    _lastPosition = d;
     positionCtrl.add(d);
   }
 
   void emitDuration(Duration d) {
-    if (disposed || durationCtrl.isClosed) return;
-    if (d == lastDuration) return;
-    lastDuration = d;
+    if (_disposed || durationCtrl.isClosed) return;
+    if (d == _lastDuration) return;
+    _lastDuration = d;
     durationCtrl.add(d);
   }
 
   void emitPlaying(bool v) {
-    if (disposed || playingCtrl.isClosed) return;
-    if (v == playing) return;
-    playing = v;
+    if (_disposed || playingCtrl.isClosed) return;
+    if (v == _playing) return;
+    _playing = v;
     playingCtrl.add(v);
     if (v) {
-      lastPlayingAt = DateTime.now();
+      _lastPlayingAt = DateTime.now();
       _cancelHint();
-      if (tapToPlayHintActive) {
-        tapToPlayHintActive = false;
-        mountTick.value++;
+      if (_tapToPlayHintActive) {
+        _tapToPlayHintActive = false;
+        bumpMountTick();
       }
     }
   }
 
-  /// True when a pause confirmation arrives soon after [emitPlaying(true)].
+  /// True when a pause confirmation arrives soon after playback started.
   bool isImmediatePause(DateTime now) {
-    final started = lastPlayingAt;
+    final started = _lastPlayingAt;
     if (started == null) return false;
     return now.difference(started) <= immediatePauseWindow;
   }
 
   void emitBuffering(bool v) {
-    if (disposed || bufferingCtrl.isClosed) return;
-    if (v == buffering) return;
-    buffering = v;
+    if (_disposed || bufferingCtrl.isClosed) return;
+    if (v == _buffering) return;
+    _buffering = v;
     bufferingCtrl.add(v);
-    if (!v && !firstBufferingOffReceived) {
-      firstBufferingOffReceived = true;
-      mountTick.value++;
+    if (!v && !_firstBufferingOffReceived) {
+      _firstBufferingOffReceived = true;
+      bumpMountTick();
     }
     if (v) {
       _cancelHint();
-      if (tapToPlayHintActive) {
-        tapToPlayHintActive = false;
-        mountTick.value++;
+      if (_tapToPlayHintActive) {
+        _tapToPlayHintActive = false;
+        bumpMountTick();
       }
     } else {
       _scheduleHint();
@@ -264,27 +439,27 @@ class YoutubeSession {
   }
 
   void _scheduleHint() {
-    if (disposed) return;
+    if (_disposed) return;
     // Initial open: hint only before first successful playing.
     // After an explicit play that failed / immediately paused, allow recovery
-    // hint even when [loggedFirstPlaying] is already true.
-    final allowRecovery = explicitPlayAttempted && !playing && !buffering;
-    if (loggedFirstPlaying && !allowRecovery) return;
+    // hint even when [_loggedFirstPlaying] is already true.
+    final allowRecovery = _explicitPlayAttempted && !_playing && !_buffering;
+    if (_loggedFirstPlaying && !allowRecovery) return;
     _tapToPlayHintTimer?.cancel();
     _tapToPlayHintTimer = Timer(_tapToPlayHintDelay, () {
       _tapToPlayHintTimer = null;
-      if (disposed || playing || buffering) return;
-      if (loggedFirstPlaying && !explicitPlayAttempted) return;
-      if (!tapToPlayHintActive) {
-        tapToPlayHintActive = true;
-        mountTick.value++;
+      if (_disposed || _playing || _buffering) return;
+      if (_loggedFirstPlaying && !_explicitPlayAttempted) return;
+      if (!_tapToPlayHintActive) {
+        _tapToPlayHintActive = true;
+        bumpMountTick();
       }
     });
   }
 
   /// Arms the recovery overlay after play rejection or immediate pause.
   void scheduleRecoveryHint() {
-    if (disposed || playing) return;
+    if (_disposed || _playing) return;
     _scheduleHint();
   }
 
@@ -294,7 +469,7 @@ class YoutubeSession {
   }
 
   void logInitPhase(String phase, void Function(String message) log) {
-    final ms = initStopwatch?.elapsedMilliseconds;
+    final ms = _initStopwatch?.elapsedMilliseconds;
     final message = 'youtube init $phase${ms != null ? ' +${ms}ms' : ''}';
     if (phase == 'load_stop' || phase == 'first_playing') {
       log(message);
@@ -303,9 +478,9 @@ class YoutubeSession {
 
   Future<void> closeStreams() async {
     _cancelHint();
-    disposed = true;
-    mountRequested = false;
-    mountTick.value++;
+    _disposed = true;
+    _mountRequested = false;
+    bumpMountTick();
     await positionCtrl.close();
     await durationCtrl.close();
     await playingCtrl.close();

--- a/lib/features/player/application/engines/youtube/youtube_video_event.dart
+++ b/lib/features/player/application/engines/youtube/youtube_video_event.dart
@@ -1,0 +1,64 @@
+/// Canonical string protocol between the watch-page JavaScript and Dart.
+///
+/// The Dart↔JS seam is stringly-typed by necessity (one-way
+/// `callHandler` messages out of the page). These constants are the single
+/// spelling of that protocol on the Dart side: the JS sources emit exactly
+/// these names, and [YoutubeWebViewEvents] handles exactly these names.
+/// `youtube_js_protocol_contract_test.dart` pins both directions so a name
+/// added on one side without the other fails CI instead of vanishing into
+/// the (logged) default branch.
+library;
+
+/// Event names carried on the `onVideoEvent` handler.
+abstract final class YoutubeVideoEventName {
+  /// Optimistic play request (may still be followed by a DOM `pause`).
+  static const String play = 'play';
+
+  /// Playback actually started (`<video>` `playing`).
+  static const String playing = 'playing';
+
+  /// DOM pause (transport waits for poll-streak confirmation).
+  static const String pause = 'pause';
+
+  /// A programmatic play promise rejected (autoplay policy).
+  static const String playRejected = 'playRejected';
+
+  /// End of media.
+  static const String ended = 'ended';
+
+  /// Buffering (`<video>` `waiting`).
+  static const String waiting = 'waiting';
+
+  /// Enough data to play (`<video>` `canplay`).
+  static const String canplay = 'canplay';
+
+  /// Metadata known; second arg carries the duration in seconds.
+  static const String loadedmetadata = 'loadedmetadata';
+
+  /// Element error.
+  static const String error = 'error';
+
+  /// Every name the Dart side switches over — must match the set the JS
+  /// sources emit (see the contract test).
+  static const Set<String> all = {
+    play,
+    playing,
+    pause,
+    playRejected,
+    ended,
+    waiting,
+    canplay,
+    loadedmetadata,
+    error,
+  };
+}
+
+/// Handler names registered by [YoutubeWebViewController] via
+/// `addJavaScriptHandler` and called from the page via
+/// `flutter_inappwebview.callHandler`.
+abstract final class YoutubeJsHandlerName {
+  static const String onVideoEvent = 'onVideoEvent';
+  static const String onAdReload = 'onAdReload';
+
+  static const Set<String> all = {onVideoEvent, onAdReload};
+}

--- a/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
@@ -177,9 +177,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(v) v.currentTime=$seconds;
         })();
       ''',
@@ -209,9 +207,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(v) v.playbackRate=$speed;
         })();
       ''',
@@ -274,11 +270,10 @@ class YoutubeWebViewBridge {
   /// Re-applies `playsinline` on the active `<video>` (iOS WKWebView safety net).
   static Future<void> forceInlinePlayback(InAppWebViewController? web) async {
     await web?.evaluateJavascript(
-      source: '''
+      source:
+          '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideoAndPlayer
           if(!v) return;
           v.setAttribute('playsinline','');
           v.setAttribute('webkit-playsinline','');

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_audible_playback_policy.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_page_inject.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_playback_stall_watchdog.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
@@ -34,23 +35,28 @@ class YoutubeWebViewController {
            unawaited(onStallRecovery());
          },
        ) {
+    _audibility = YoutubeAudiblePlaybackPolicy(
+      session: session,
+      reapplyVolume: reapplyVolume,
+      healPlay: () => YoutubeWebViewBridge.play(_webController),
+    );
     _events = YoutubeWebViewEvents(
       session: session,
       webController: () => _webController,
       onFirstPlaying: onFirstPlayingFromSession,
       startPolling: () => _pollLoop.start(),
       stopPolling: () => _pollLoop.stop(),
-      reapplyVolume: reapplyVolume,
       seekTo: (d) => YoutubeWebViewBridge.seekToSeconds(
         _webController,
         d.inMilliseconds / 1000.0,
       ),
+      audibility: _audibility,
     );
     _pollLoop = YoutubeWebViewPollLoop(
       session: session,
       webController: () => _webController,
       onFirstPlaying: onFirstPlayingFromSession,
-      onPlaybackProgress: _events.onPlaybackProgress,
+      onPlaybackProgress: _audibility.onPlaybackProgress,
     );
     _navigation = YoutubeWebViewNavigation(
       session: session,
@@ -75,6 +81,7 @@ class YoutubeWebViewController {
   static const int maxStallRecoveries = 1;
 
   final YoutubePlaybackStallWatchdog _stallWatchdog;
+  late final YoutubeAudiblePlaybackPolicy _audibility;
   late final YoutubeWebViewEvents _events;
   late final YoutubeWebViewPollLoop _pollLoop;
   late final YoutubeWebViewNavigation _navigation;
@@ -90,7 +97,7 @@ class YoutubeWebViewController {
   void markOpenTimingStart() {
     _stallWatchdog.cancel();
     _navigation.cancelNudge();
-    _events.cancelPendingVolumeRestore();
+    _audibility.cancelPending();
     _bumpVerifyGeneration();
     session.startInitTiming();
     session.resetWatchPageExpectations(firstPlaying: true);
@@ -104,7 +111,7 @@ class YoutubeWebViewController {
   }) {
     _stallWatchdog.cancel();
     _navigation.cancelNudge();
-    _events.cancelPendingVolumeRestore();
+    _audibility.cancelPending();
     _bumpVerifyGeneration();
     session.resetWatchPageExpectations(firstPlaying: resetFirstPlaying);
     if (resetStallRecovery) {
@@ -132,7 +139,7 @@ class YoutubeWebViewController {
   Future<void> idleAfterClear({bool keepMounted = false}) async {
     _stallWatchdog.cancel();
     _navigation.cancelNudge();
-    _events.cancelPendingVolumeRestore();
+    _audibility.cancelPending();
     _bumpVerifyGeneration();
     session.resetForClear(keepMounted: keepMounted);
     _pollLoop.stop();
@@ -150,7 +157,7 @@ class YoutubeWebViewController {
   Future<void> dispose() async {
     _stallWatchdog.cancel();
     _navigation.cancelNudge();
-    _events.cancelPendingVolumeRestore();
+    _audibility.cancelPending();
     _bumpVerifyGeneration();
     _pollLoop.stop();
   }
@@ -235,7 +242,7 @@ class YoutubeWebViewController {
       session.noteWebViewUnmounted();
       session.clearAwaitingColdInitialNavigation();
       _navigation.cancelNudge();
-      _events.cancelPendingVolumeRestore();
+      _audibility.cancelPending();
       _bumpVerifyGeneration();
       _pollLoop.stop();
       // Defer: notifying during StatefulElement.unmount locks the tree

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -169,6 +169,25 @@ class YoutubeWebViewController {
         prepareWatchReload: () => prepareWatchReload(resetFirstPlaying: false),
       );
 
+  /// Main-frame HTTP failures are worth a diagnostic line; sub-frame noise is
+  /// not. Called by [YoutubeWebViewHost].
+  void onWebResourceHttpError({
+    required String? url,
+    required int? statusCode,
+    required bool isForMainFrame,
+  }) {
+    if (!isForMainFrame) return;
+    _logWebView.warning('youtube main-frame HTTP $statusCode url=${url ?? ''}');
+  }
+
+  /// Main-frame load failures (DNS, TLS, …). Called by [YoutubeWebViewHost].
+  void onWebResourceLoadError({
+    required String url,
+    required String description,
+  }) {
+    _logWebView.warning('youtube load error url=$url msg=$description');
+  }
+
   Future<void> onWebViewProcessTerminated() =>
       _navigation.onWebViewProcessTerminated(
         prepareWatchReload: () => prepareWatchReload(resetFirstPlaying: true),

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -61,9 +61,9 @@ class YoutubeWebViewController {
       currentNavGeneration: () => _navGeneration,
       onStaleWebView: () {
         _webController = null;
-        session.webViewMounted = false;
+        session.noteWebViewUnmounted();
         _pollLoop.stop();
-        session.mountTick.value++;
+        session.bumpMountTick();
       },
     );
   }
@@ -92,11 +92,8 @@ class YoutubeWebViewController {
     _navigation.cancelNudge();
     _events.cancelPendingVolumeRestore();
     _bumpVerifyGeneration();
-    session.initStopwatch = Stopwatch()..start();
-    session.loggedFirstPlaying = false;
-    session.watchPageLoadStopReceived = false;
-    session.awaitingColdInitialNavigation = false;
-    session.nonWatchRecoveryScheduled = false;
+    session.startInitTiming();
+    session.resetWatchPageExpectations(firstPlaying: true);
     _stallRecoveryCount = 0;
     onLogInitPhase('open_start');
   }
@@ -109,12 +106,7 @@ class YoutubeWebViewController {
     _navigation.cancelNudge();
     _events.cancelPendingVolumeRestore();
     _bumpVerifyGeneration();
-    session.watchPageLoadStopReceived = false;
-    session.awaitingColdInitialNavigation = false;
-    session.nonWatchRecoveryScheduled = false;
-    if (resetFirstPlaying) {
-      session.loggedFirstPlaying = false;
-    }
+    session.resetWatchPageExpectations(firstPlaying: resetFirstPlaying);
     if (resetStallRecovery) {
       _stallRecoveryCount = 0;
     }
@@ -123,7 +115,7 @@ class YoutubeWebViewController {
   void onFirstPlayingFromSession() {
     _stallWatchdog.onFirstPlaying();
     if (!session.loggedFirstPlaying) {
-      session.loggedFirstPlaying = true;
+      session.markFirstPlayingLogged();
       _navigation.cancelNudge();
       onLogInitPhase('first_playing');
     }
@@ -198,18 +190,18 @@ class YoutubeWebViewController {
     bool initialWatchUrlRequested = false,
   }) {
     _webController = controller;
-    session.webViewMounted = true;
+    session.noteWebViewMounted();
     onLogInitPhase('webview_created');
 
     if (initialWatchUrlRequested && session.videoId.isNotEmpty) {
-      session.awaitingColdInitialNavigation = true;
+      session.noteAwaitingColdInitialNavigation();
     }
 
     controller.addJavaScriptHandler(
       handlerName: YoutubeJsHandlerName.onAdReload,
       callback: (List<dynamic> args) {
         if (args.isNotEmpty) {
-          session.pendingSeekSeconds = (args[0] as num?)?.toDouble() ?? 0;
+          session.setPendingSeekSeconds((args[0] as num?)?.toDouble() ?? 0);
         }
         return null;
       },
@@ -240,17 +232,15 @@ class YoutubeWebViewController {
   void onWebViewDisposed(InAppWebViewController? controller) {
     if (identical(_webController, controller)) {
       _webController = null;
-      session.webViewMounted = false;
-      session.awaitingColdInitialNavigation = false;
+      session.noteWebViewUnmounted();
+      session.clearAwaitingColdInitialNavigation();
       _navigation.cancelNudge();
       _events.cancelPendingVolumeRestore();
       _bumpVerifyGeneration();
       _pollLoop.stop();
       // Defer: notifying during StatefulElement.unmount locks the tree
       // (ValueListenableBuilder markNeedsBuild assertion).
-      scheduleMicrotask(() {
-        session.mountTick.value++;
-      });
+      session.scheduleMountTickBump();
     }
   }
 
@@ -265,9 +255,7 @@ class YoutubeWebViewController {
       _navigation.scheduleNonWatchRecovery();
       return;
     }
-    session.awaitingColdInitialNavigation = false;
-    session.watchPageLoadStopReceived = true;
-    session.nonWatchRecoveryScheduled = false;
+    session.noteWatchPageLoaded();
     // Fresh document: its <video> starts muted, so the next `playing` event
     // re-arms the per-document volume restore (covers cold open AND the
     // post-ad page reload).

--- a/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_controller.dart
@@ -10,6 +10,7 @@ import 'package:enjoy_player/features/player/application/engines/youtube/youtube
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_playback_stall_watchdog.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_watch_navigation_policy.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_events.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_navigation.dart';
@@ -186,7 +187,7 @@ class YoutubeWebViewController {
     }
 
     controller.addJavaScriptHandler(
-      handlerName: 'onAdReload',
+      handlerName: YoutubeJsHandlerName.onAdReload,
       callback: (List<dynamic> args) {
         if (args.isNotEmpty) {
           session.pendingSeekSeconds = (args[0] as num?)?.toDouble() ?? 0;
@@ -196,7 +197,7 @@ class YoutubeWebViewController {
     );
 
     controller.addJavaScriptHandler(
-      handlerName: 'onVideoEvent',
+      handlerName: YoutubeJsHandlerName.onVideoEvent,
       callback: _events.handle,
     );
 

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -96,10 +96,7 @@ class YoutubeWebViewEvents {
         // unMute is a pause trigger under Chromium's autoplay gesture lock
         // (the play-then-pause root cause), so redundancy here is the bug.
         final needsRestore = session.needsVolumeRestore;
-        session.pausedPollStreak = 0;
-        session.playbackCompleted = false;
-        session.userPlayInFlight = false;
-        session.emitPlaying(true);
+        session.notePlayingConfirmed();
         onFirstPlaying();
         session.emitBuffering(false);
         startPolling();
@@ -119,9 +116,7 @@ class YoutubeWebViewEvents {
         break;
       case YoutubeVideoEventName.playRejected:
         cancelPendingVolumeRestore();
-        session.userPlayInFlight = false;
-        session.emitPlaying(false);
-        session.emitBuffering(false);
+        session.noteUserPlayUnresolved();
         final reason = args.length > 1 ? '${args[1]}' : 'unknown';
         _logEvents.warning(
           'youtube play rejected vid=${session.videoId} reason=$reason '
@@ -132,13 +127,9 @@ class YoutubeWebViewEvents {
         session.scheduleRecoveryHint();
         break;
       case YoutubeVideoEventName.ended:
-        session.pausedPollStreak = 0;
-        session.userPlayInFlight = false;
         cancelPendingVolumeRestore();
-        session.markCompleted();
+        session.noteEnded();
         stopPolling();
-        session.emitPlaying(false);
-        session.emitBuffering(false);
         unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));
         break;
       case YoutubeVideoEventName.waiting:
@@ -162,9 +153,7 @@ class YoutubeWebViewEvents {
       case YoutubeVideoEventName.error:
         cancelPendingVolumeRestore();
         _logEvents.warning('YouTube video element error');
-        session.userPlayInFlight = false;
-        session.emitPlaying(false);
-        session.emitBuffering(false);
+        session.noteUserPlayUnresolved();
         break;
       default:
         // A name the Dart side does not switch over cannot reach here without
@@ -258,9 +247,8 @@ class YoutubeWebViewEvents {
   }
 
   void applyPendingSeek() {
-    final secs = session.pendingSeekSeconds;
+    final secs = session.takePendingSeekSeconds();
     if (secs == null || secs <= 0) return;
-    session.pendingSeekSeconds = null;
     unawaited(seekTo(Duration(milliseconds: (secs * 1000).round())));
   }
 }

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -9,6 +9,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 
 final _logEvents = logNamed('YouTubeWebViewEvents');
@@ -83,12 +84,12 @@ class YoutubeWebViewEvents {
     if (args.isEmpty) return null;
     final event = args[0] as String;
     switch (event) {
-      case 'play':
+      case YoutubeVideoEventName.play:
         // Optimistic request only — do not touch pause streak (DOM may still
         // pause before `playing`). Transport waits for authoritative `playing`.
         _logEvents.fine('youtube video play requested vid=${session.videoId}');
         break;
-      case 'playing':
+      case YoutubeVideoEventName.playing:
         // A fresh watch document (cold open or post-ad reload) starts muted;
         // arm the progress-gated restore once. Later `playing` events in an
         // already-restored document must NOT re-unmute: every programmatic
@@ -108,7 +109,7 @@ class YoutubeWebViewEvents {
         }
         _logEvents.fine('youtube video playing vid=${session.videoId}');
         break;
-      case 'pause':
+      case YoutubeVideoEventName.pause:
         // Do NOT reset [pausedPollStreak] — a DOM pause while Dart still thinks
         // playing must accumulate toward poll confirmation. Resetting here
         // previously extended the stale-`playing` window and made the next
@@ -116,7 +117,7 @@ class YoutubeWebViewEvents {
         cancelPendingVolumeRestore();
         _logEvents.fine('youtube video paused vid=${session.videoId}');
         break;
-      case 'playRejected':
+      case YoutubeVideoEventName.playRejected:
         cancelPendingVolumeRestore();
         session.userPlayInFlight = false;
         session.emitPlaying(false);
@@ -130,7 +131,7 @@ class YoutubeWebViewEvents {
         startPolling();
         session.scheduleRecoveryHint();
         break;
-      case 'ended':
+      case YoutubeVideoEventName.ended:
         session.pausedPollStreak = 0;
         session.userPlayInFlight = false;
         cancelPendingVolumeRestore();
@@ -140,15 +141,15 @@ class YoutubeWebViewEvents {
         session.emitBuffering(false);
         unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));
         break;
-      case 'waiting':
+      case YoutubeVideoEventName.waiting:
         session.emitBuffering(true);
         break;
-      case 'canplay':
+      case YoutubeVideoEventName.canplay:
         if (session.buffering) {
           session.emitBuffering(false);
         }
         break;
-      case 'loadedmetadata':
+      case YoutubeVideoEventName.loadedmetadata:
         startPolling();
         if (args.length > 1) {
           final dur = (args[1] as num).toDouble();
@@ -158,7 +159,7 @@ class YoutubeWebViewEvents {
           }
         }
         break;
-      case 'error':
+      case YoutubeVideoEventName.error:
         cancelPendingVolumeRestore();
         _logEvents.warning('YouTube video element error');
         session.userPlayInFlight = false;
@@ -166,6 +167,10 @@ class YoutubeWebViewEvents {
         session.emitBuffering(false);
         break;
       default:
+        // A name the Dart side does not switch over cannot reach here without
+        // failing youtube_js_protocol_contract_test first — log so a stray
+        // name surfaces in diagnostics instead of vanishing.
+        _logEvents.warning('youtube unknown video event name=$event');
         break;
     }
     return null;

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -1,13 +1,15 @@
 /// DOM `<video>` event dispatch for [YoutubeWebViewController].
+///
+/// Dispatch only: transport transitions go to [YoutubeSession], the
+/// audible-start choreography to [YoutubeAudiblePlaybackPolicy] (issue #628).
 library;
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_audible_playback_policy.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
@@ -18,11 +20,6 @@ typedef YoutubeSeekFn = Future<void> Function(Duration target);
 typedef YoutubePollStartFn = void Function();
 typedef YoutubePollStopFn = void Function();
 typedef YoutubeFirstPlayingFn = void Function();
-typedef YoutubeReapplyVolumeFn = Future<void> Function();
-
-/// Injectable post-restore heal play (defaults to
-/// [YoutubeWebViewBridge.play], which preserves audible state).
-typedef YoutubeHealPlayFn = Future<void> Function(InAppWebViewController? web);
 
 /// Handles `onVideoEvent` JavaScript callbacks from the watch page.
 class YoutubeWebViewEvents {
@@ -32,53 +29,19 @@ class YoutubeWebViewEvents {
     required this.onFirstPlaying,
     required this.startPolling,
     required this.stopPolling,
-    required this.reapplyVolume,
     required this.seekTo,
-    Duration? volumeRestoreDelay,
-    Duration? volumeRestoreFallback,
-    Duration? postRestoreHealDelay,
-    YoutubeHealPlayFn? healPlay,
-  }) : volumeRestoreDelay =
-           volumeRestoreDelay ??
-           (defaultTargetPlatform == TargetPlatform.windows
-               ? windowsVolumeRestoreDelay
-               : Duration.zero),
-       volumeRestoreFallback =
-           volumeRestoreFallback ?? YoutubeSession.volumeRestoreFallback,
-       postRestoreHealDelay =
-           postRestoreHealDelay ??
-           YoutubeWebViewEvents.defaultPostRestoreHealDelay,
-       healPlay = healPlay ?? YoutubeWebViewBridge.play;
-
-  /// Legacy minimum settle before progress-gated unmute (Windows first play).
-  /// Progress confirmation is preferred; this delay is only a lower bound when
-  /// progress arrives earlier than the platform settle window.
-  static const Duration windowsVolumeRestoreDelay = Duration(milliseconds: 400);
-
-  /// How long after a volume restore to check whether the unmute tripped the
-  /// WebView's autoplay gesture lock (which pauses the element). Must exceed
-  /// the poll loop's pause-confirmation window (~3 × 250 ms) so a real pause
-  /// is already reflected in [YoutubeSession.playing]; must stay short enough
-  /// to beat the tap-to-play recovery hint.
-  static const Duration defaultPostRestoreHealDelay = Duration(
-    milliseconds: 900,
-  );
-
-  final Duration volumeRestoreDelay;
-  final Duration volumeRestoreFallback;
-  final Duration postRestoreHealDelay;
+    required this.audibility,
+  });
 
   final YoutubeSession session;
   final InAppWebViewController? Function() webController;
   final YoutubeFirstPlayingFn onFirstPlaying;
   final YoutubePollStartFn startPolling;
   final YoutubePollStopFn stopPolling;
-  final YoutubeReapplyVolumeFn reapplyVolume;
   final YoutubeSeekFn seekTo;
-  final YoutubeHealPlayFn healPlay;
 
-  Timer? _volumeRestoreFallbackTimer;
-  DateTime? _volumeRestoreArmedAt;
+  /// Audible-start choreography owner (mute-start → restore → heal).
+  final YoutubeAudiblePlaybackPolicy audibility;
 
   dynamic handle(List<dynamic> args) {
     if (args.isEmpty) return null;
@@ -90,32 +53,24 @@ class YoutubeWebViewEvents {
         _logEvents.fine('youtube video play requested vid=${session.videoId}');
         break;
       case YoutubeVideoEventName.playing:
-        // A fresh watch document (cold open or post-ad reload) starts muted;
-        // arm the progress-gated restore once. Later `playing` events in an
-        // already-restored document must NOT re-unmute: every programmatic
-        // unMute is a pause trigger under Chromium's autoplay gesture lock
-        // (the play-then-pause root cause), so redundancy here is the bug.
-        final needsRestore = session.needsVolumeRestore;
         session.notePlayingConfirmed();
         onFirstPlaying();
         session.emitBuffering(false);
         startPolling();
         applyPendingSeek();
-        if (needsRestore) {
-          _armProgressGatedVolumeRestore();
-        }
+        audibility.onPlaying();
         _logEvents.fine('youtube video playing vid=${session.videoId}');
         break;
       case YoutubeVideoEventName.pause:
-        // Do NOT reset [pausedPollStreak] — a DOM pause while Dart still thinks
+        // Do NOT reset the pause streak — a DOM pause while Dart still thinks
         // playing must accumulate toward poll confirmation. Resetting here
         // previously extended the stale-`playing` window and made the next
         // transport toggle issue `pause()` instead of `play()`.
-        cancelPendingVolumeRestore();
+        audibility.onPause();
         _logEvents.fine('youtube video paused vid=${session.videoId}');
         break;
       case YoutubeVideoEventName.playRejected:
-        cancelPendingVolumeRestore();
+        audibility.cancelPending();
         session.noteUserPlayUnresolved();
         final reason = args.length > 1 ? '${args[1]}' : 'unknown';
         _logEvents.warning(
@@ -127,7 +82,7 @@ class YoutubeWebViewEvents {
         session.scheduleRecoveryHint();
         break;
       case YoutubeVideoEventName.ended:
-        cancelPendingVolumeRestore();
+        audibility.cancelPending();
         session.noteEnded();
         stopPolling();
         unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));
@@ -151,7 +106,7 @@ class YoutubeWebViewEvents {
         }
         break;
       case YoutubeVideoEventName.error:
-        cancelPendingVolumeRestore();
+        audibility.cancelPending();
         _logEvents.warning('YouTube video element error');
         session.noteUserPlayUnresolved();
         break;
@@ -163,87 +118,6 @@ class YoutubeWebViewEvents {
         break;
     }
     return null;
-  }
-
-  /// Called from the poll loop when `<video>.currentTime` advances.
-  void onPlaybackProgress(Duration position) {
-    if (!session.volumeRestorePending || session.disposed) return;
-    if (!session.playing) return;
-    final armedAt = _volumeRestoreArmedAt;
-    if (armedAt != null) {
-      final elapsed = DateTime.now().difference(armedAt);
-      if (elapsed < volumeRestoreDelay) return;
-    }
-    if (session.noteProgressForVolumeRestore(position)) {
-      unawaited(_restoreVolume(reason: 'progress'));
-    }
-  }
-
-  void _armProgressGatedVolumeRestore() {
-    cancelPendingVolumeRestore();
-    session.armVolumeRestorePending(baseline: session.lastPosition);
-    _volumeRestoreArmedAt = DateTime.now();
-    _logEvents.fine(
-      'youtube volume restore armed vid=${session.videoId} '
-      'fallbackMs=${volumeRestoreFallback.inMilliseconds} '
-      'minDelayMs=${volumeRestoreDelay.inMilliseconds}',
-    );
-    _volumeRestoreFallbackTimer = Timer(volumeRestoreFallback, () {
-      _volumeRestoreFallbackTimer = null;
-      if (session.disposed ||
-          !session.playing ||
-          !session.volumeRestorePending) {
-        return;
-      }
-      unawaited(_restoreVolume(reason: 'fallback'));
-    });
-  }
-
-  Future<void> _restoreVolume({required String reason}) async {
-    if (session.disposed || !session.playing) return;
-    session.clearVolumeRestorePending();
-    _volumeRestoreFallbackTimer?.cancel();
-    _volumeRestoreFallbackTimer = null;
-    _volumeRestoreArmedAt = null;
-    try {
-      await reapplyVolume();
-      session.noteVolumeRestored();
-      _logEvents.fine(
-        'youtube volume restored vid=${session.videoId} reason=$reason',
-      );
-      unawaited(_healPostRestorePause());
-    } on Object catch (error, stackTrace) {
-      _logEvents.warning(
-        'youtube volume restore failed vid=${session.videoId} reason=$reason',
-        error,
-        stackTrace,
-      );
-    }
-  }
-
-  /// One-shot self-heal for the gesture-lock failure mode: the unmute made
-  /// the element audible without user activation and the WebView paused it
-  /// right after ("Unmuting failed and the element was paused instead").
-  /// Re-issues play exactly once with audible state preserved — on engines
-  /// that allow audible starts this recovers invisibly; where the start is
-  /// genuinely refused, the poll loop's recovery hint remains the fallback.
-  Future<void> _healPostRestorePause() async {
-    await Future<void>.delayed(postRestoreHealDelay);
-    if (session.disposed ||
-        session.playing ||
-        session.playbackCompleted ||
-        session.needsVolumeRestore) {
-      return;
-    }
-    _logEvents.info('youtube post-restore pause heal vid=${session.videoId}');
-    unawaited(healPlay(webController()));
-  }
-
-  void cancelPendingVolumeRestore() {
-    _volumeRestoreFallbackTimer?.cancel();
-    _volumeRestoreFallbackTimer = null;
-    _volumeRestoreArmedAt = null;
-    session.clearVolumeRestorePending();
   }
 
   void applyPendingSeek() {

--- a/lib/features/player/application/engines/youtube/youtube_webview_host.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_host.dart
@@ -1,4 +1,8 @@
 /// Shared [InAppWebView] host for [YoutubePlayerEngine] (single instance per engine).
+///
+/// Speaks only to [YoutubeWebViewController] — the WebView lifecycle owner —
+/// plus a `currentVideoId` reader for the watch-navigation policy. The engine
+/// itself stays behind the [PlayerEngine] contract (issue #630).
 library;
 
 import 'dart:async';
@@ -8,15 +12,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/webview/platform_webview_environment.dart';
-import 'youtube_player_engine.dart';
 import 'youtube_watch_navigation_policy.dart';
 import 'youtube_webview_bridge.dart';
+import 'youtube_webview_controller.dart';
 
-/// One [InAppWebView] per [YoutubePlayerEngine]; mounted in the video stage slot.
+/// One [InAppWebView] per engine; mounted in the video stage slot.
 class YoutubeWebViewHost extends StatefulWidget {
-  const YoutubeWebViewHost({required this.engine, super.key});
+  const YoutubeWebViewHost({
+    super.key,
+    required this.controller,
+    required this.currentVideoId,
+  });
 
-  final YoutubePlayerEngine engine;
+  final YoutubeWebViewController controller;
+
+  /// Watch-navigation policy needs the id of the video the engine opened.
+  final String Function() currentVideoId;
 
   @override
   State<YoutubeWebViewHost> createState() => _YoutubeWebViewHostState();
@@ -27,7 +38,7 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
 
   @override
   void dispose() {
-    widget.engine.onWebViewDisposed(_controller);
+    widget.controller.onWebViewDisposed(_controller);
     super.dispose();
   }
 
@@ -36,7 +47,7 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
     NavigationAction action,
   ) async {
     final url = action.request.url?.toString() ?? '';
-    final videoId = widget.engine.currentVideoId;
+    final videoId = widget.currentVideoId();
     final allowed = shouldAllowYoutubeWatchNavigation(
       url: url,
       videoId: videoId,
@@ -48,7 +59,7 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
         action.isForMainFrame &&
         url.contains('accounts.google.com') &&
         videoId.isNotEmpty) {
-      unawaited(widget.engine.onSignInNavigationBlocked(controller));
+      unawaited(widget.controller.onSignInNavigationBlocked(controller));
     }
     return allowed
         ? NavigationActionPolicy.ALLOW
@@ -57,8 +68,9 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
 
   @override
   Widget build(BuildContext context) {
-    final e = widget.engine;
-    final vid = e.currentVideoId;
+    // Distinct name from the InAppWebViewController closure parameters.
+    final lifecycle = widget.controller;
+    final vid = widget.currentVideoId();
     final iosInlinePlayback = defaultTargetPlatform == TargetPlatform.iOS;
 
     final initialUrl = vid.isEmpty
@@ -73,26 +85,26 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
           _controller = controller;
           // [initialUrlRequest] already navigates on cold mount when [vid] is set;
           // avoid a second [loadWatchPage] that interrupts the first playback start.
-          e.onWebViewCreated(
+          lifecycle.onWebViewCreated(
             controller,
             initialWatchUrlRequested: vid.isNotEmpty,
           );
         },
         onEnterFullscreen: iosInlinePlayback
             ? (controller) {
-                unawaited(e.exitNativeFullscreen(controller));
+                unawaited(lifecycle.exitNativeFullscreen(controller));
               }
             : null,
         onExitFullscreen: iosInlinePlayback
             ? (controller) {
-                unawaited(e.onNativeFullscreenExit(controller));
+                unawaited(lifecycle.onNativeFullscreenExit(controller));
               }
             : null,
         onLoadStop: (controller, url) async {
-          await e.onPageFinished(controller, url?.toString());
+          await lifecycle.onPageFinished(controller, url?.toString());
         },
         onReceivedHttpError: (controller, request, response) {
-          e.onWebResourceHttpError(
+          lifecycle.onWebResourceHttpError(
             url: request.url.toString(),
             statusCode: response.statusCode,
             isForMainFrame: request.isForMainFrame ?? false,
@@ -100,16 +112,16 @@ class _YoutubeWebViewHostState extends State<YoutubeWebViewHost> {
         },
         onReceivedError: (controller, request, error) {
           if (request.isForMainFrame != true) return;
-          e.onWebResourceLoadError(
+          lifecycle.onWebResourceLoadError(
             url: request.url.toString(),
             description: error.description,
           );
         },
         onWebContentProcessDidTerminate: (controller) {
-          unawaited(e.onWebViewProcessTerminated());
+          unawaited(lifecycle.onWebViewProcessTerminated());
         },
         onRenderProcessGone: (controller, detail) {
-          unawaited(e.onWebViewProcessTerminated());
+          unawaited(lifecycle.onWebViewProcessTerminated());
         },
         shouldOverrideUrlLoading: _onShouldOverrideUrlLoading,
         initialUrlRequest: URLRequest(url: initialUrl),

--- a/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
@@ -87,7 +87,7 @@ class YoutubeWebViewNavigation {
       return;
     }
     if (session.nonWatchRecoveryScheduled) return;
-    session.nonWatchRecoveryScheduled = true;
+    session.scheduleNonWatchRecovery();
     _logNav.info('youtube non-watch load_stop; verifying watch page');
     unawaited(ensureWatchPageLoadedAfterDelay(skipIfLoadStopReceived: true));
   }

--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_audible_playback_policy.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_state_poller.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
@@ -75,7 +76,7 @@ class YoutubeWebViewPollLoop {
     if (_pollTimer != null) return;
     session.resetPauseStreak();
     _pollTimer = Timer.periodic(
-      const Duration(milliseconds: 250),
+      YoutubeAudiblePlaybackPolicy.pollTick,
       (_) => _tick(),
     );
   }

--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -73,7 +73,7 @@ class YoutubeWebViewPollLoop {
 
   void start() {
     if (_pollTimer != null) return;
-    session.pausedPollStreak = 0;
+    session.resetPauseStreak();
     _pollTimer = Timer.periodic(
       const Duration(milliseconds: 250),
       (_) => _tick(),
@@ -122,13 +122,10 @@ class YoutubeWebViewPollLoop {
                 // is the single consumer of `completed` for repeat policy
                 // (ADR-0044). Stop polling; the loop's replay re-arms it via
                 // the explicit-play path.
-                session.pausedPollStreak = 0;
-                session.markCompleted();
+                session.noteEnded();
                 stop();
-                session.emitPlaying(false);
-                session.emitBuffering(false);
               case PauseStreaking(:final confirmed, :final newStreak):
-                session.pausedPollStreak = newStreak;
+                session.notePauseStreak(newStreak);
                 if (confirmed) {
                   final immediate = session.isImmediatePause(DateTime.now());
                   final retry = decideImmediatePauseRetry(
@@ -149,15 +146,13 @@ class YoutubeWebViewPollLoop {
                       'positionMs=${position.inMilliseconds}',
                     );
                   }
-                  session.pausedPollStreak = 0;
-                  session.emitPlaying(false);
-                  session.emitBuffering(false);
+                  session.notePauseConfirmed();
                   switch (retry) {
                     case RetryPlayOnce():
                       // Consume the one-shot budget before re-playing so a
                       // second immediate pause surfaces to the user instead
                       // of looping.
-                      session.userPlayInFlight = false;
+                      session.clearUserPlayInFlight();
                       _logPoll.info(
                         'youtube immediate pause retry vid='
                         '${session.videoId}',
@@ -173,16 +168,13 @@ class YoutubeWebViewPollLoop {
                   // Position updates while paused are cheap; stop only on ended.
                 }
               case PollPlaying():
-                session.pausedPollStreak = 0;
-                session.playbackCompleted = false;
-                session.userPlayInFlight = false;
-                session.emitPlaying(true);
+                session.notePlayingConfirmed();
                 onFirstPlaying();
                 if (session.buffering) {
                   session.emitBuffering(false);
                 }
               case PollIdleTick():
-                session.pausedPollStreak = 0;
+                session.resetPauseStreak();
             }
           },
     );

--- a/test/features/player/application/engines/youtube/youtube_js_protocol_contract_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_js_protocol_contract_test.dart
@@ -1,0 +1,93 @@
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_page_inject.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_video_event.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the string protocol between the watch-page JavaScript and Dart
+/// (issue #629, tier 1).
+///
+/// The JS side cannot be executed in a unit test (tier 2 tracks a runtime
+/// harness), but the protocol *shape* can be pinned: every event name the
+/// JS sources emit must be a name the Dart switch handles, and every handled
+/// name must actually be emitted — otherwise a rename or a new name on one
+/// side drifts silently into the switch's logged default branch.
+void main() {
+  // Every Dart-reachable JS source that can call `flutter_inappwebview
+  // .callHandler`. The bridge's play scripts embed the shared
+  // `_startPlaybackBody`, so `playRejected` is included via interpolation.
+  final jsSources = [
+    kYoutubeMobileWatchInjectScript,
+    YoutubeWebViewBridge.playScript,
+    YoutubeWebViewBridge.playOrPauseScript,
+  ].join('\n===\n');
+
+  /// All handler names the JS side calls, e.g. `callHandler('onVideoEvent',…)`.
+  final jsCalledHandlers = RegExp(
+    r"callHandler\(\s*'([A-Za-z]+)'",
+  ).allMatches(jsSources).map((m) => m.group(1)!).toSet();
+
+  /// Event names emitted with a literal second argument.
+  final literalEventNames = RegExp(
+    r"callHandler\(\s*'onVideoEvent'\s*,\s*'([a-zA-Z]+)'",
+  ).allMatches(jsSources).map((m) => m.group(1)!).toSet();
+
+  /// `hookVideo` emits through a variable: `var events=['play',…]` later
+  /// forwarded as `callHandler('onVideoEvent',args[0],…)`.
+  final arrayEventNames = RegExp(r'var events=\[([^\]]*)\]')
+      .allMatches(jsSources)
+      .expand((m) {
+        return RegExp(
+          r"'([a-zA-Z]+)'",
+        ).allMatches(m.group(1)!).map((inner) => inner.group(1)!);
+      })
+      .toSet();
+
+  test('every event name the JS emits is a name the Dart switch handles', () {
+    final emitted = {...literalEventNames, ...arrayEventNames};
+    // Sanity on the extraction itself: the known emission styles must all
+    // have been found before the comparison means anything.
+    expect(literalEventNames, containsAll(<String>['playRejected', 'ended']));
+    expect(arrayEventNames, isNotEmpty);
+
+    final unhandled = emitted.difference(YoutubeVideoEventName.all);
+    expect(
+      unhandled,
+      isEmpty,
+      reason:
+          'JS emits ${unhandled.toList()} but the Dart switch has no case '
+          '(it would hit the logged default and vanish).',
+    );
+  });
+
+  test(
+    'every event name the Dart switch handles is actually emitted by the JS',
+    () {
+      final emitted = {...literalEventNames, ...arrayEventNames};
+      final dead = YoutubeVideoEventName.all.difference(emitted);
+      expect(
+        dead,
+        isEmpty,
+        reason:
+            'Dart handles ${dead.toList()} but no JS source emits them — '
+            'dead protocol entries.',
+      );
+    },
+  );
+
+  test('handler names called from JS match the handlers Dart registers', () {
+    final unregistered = jsCalledHandlers.difference(YoutubeJsHandlerName.all);
+    expect(
+      unregistered,
+      isEmpty,
+      reason:
+          'JS calls ${unregistered.toList()} but '
+          'YoutubeWebViewController never registers them.',
+    );
+    final neverCalled = YoutubeJsHandlerName.all.difference(jsCalledHandlers);
+    expect(
+      neverCalled,
+      isEmpty,
+      reason: 'Dart registers ${neverCalled.toList()} but no JS calls them.',
+    );
+  });
+}

--- a/test/features/player/application/engines/youtube/youtube_webview_navigation_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_webview_navigation_test.dart
@@ -9,6 +9,8 @@
 // We drive every public method through a fake `PlatformInAppWebViewController`
 // (the same pattern used by `translation_prompt_test.dart`) and assert
 // against the recorded side effects, plus session-state transitions.
+import 'dart:async';
+
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_navigation.dart';
@@ -67,10 +69,11 @@ class _Stub {
 
   YoutubeWebViewNavigation build({bool attach = true}) {
     if (attach) {
-      session.videoId = 'vid';
-    } else {
-      session.videoId = '';
+      session.resetForOpen('vid');
     }
+    // Detached stubs keep the fresh session as-is: videoId is already '' and
+    // skipping transitions avoids arming the recovery-hint timer in
+    // testWidgets (pending-timer assertion).
     nav = YoutubeWebViewNavigation(
       session: session,
       webController: () => attach ? controller : null,
@@ -116,7 +119,7 @@ void main() {
     testWidgets('skips when webController returns null', (tester) async {
       final stub = _Stub();
       stub.build(attach: false);
-      stub.session.videoId = 'vid';
+      stub.session.resetForOpen('vid');
       // Override the controller supplier to return null on this call.
       final nav = YoutubeWebViewNavigation(
         session: stub.session,
@@ -196,7 +199,7 @@ void main() {
     testWidgets('returns when session is disposed', (tester) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.disposed = true;
+      unawaited(stub.session.closeStreams());
       await runDelayed(tester, nav);
       expect(stub.platform.loadUrlCalls, 0);
     });
@@ -204,7 +207,7 @@ void main() {
     testWidgets('returns when web controller missing', (tester) async {
       final stub = _Stub();
       stub.build(attach: false);
-      stub.session.videoId = 'vid';
+      stub.session.resetForOpen('vid');
       final nav = YoutubeWebViewNavigation(
         session: stub.session,
         webController: () => null,
@@ -221,7 +224,7 @@ void main() {
     testWidgets('returns when loggedFirstPlaying already true', (tester) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.loggedFirstPlaying = true;
+      stub.session.markFirstPlayingLogged();
       await runDelayed(tester, nav);
       expect(stub.platform.loadUrlCalls, 0);
     });
@@ -231,7 +234,7 @@ void main() {
     ) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.watchPageLoadStopReceived = true;
+      stub.session.noteWatchPageLoaded();
       await runDelayed(tester, nav, skipIfLoadStopReceived: true);
       expect(stub.platform.loadUrlCalls, 0);
     });
@@ -250,7 +253,7 @@ void main() {
     test('returns early when disposed', () {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.disposed = true;
+      unawaited(stub.session.closeStreams());
       nav.scheduleNonWatchRecovery();
       expect(stub.session.nonWatchRecoveryScheduled, isFalse);
     });
@@ -258,7 +261,6 @@ void main() {
     test('returns early when video id is empty', () {
       final stub = _Stub();
       stub.build(attach: false);
-      stub.session.videoId = '';
       stub.nav!.scheduleNonWatchRecovery();
       expect(stub.session.nonWatchRecoveryScheduled, isFalse);
     });
@@ -266,7 +268,7 @@ void main() {
     test('returns early when already playing', () {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.loggedFirstPlaying = true;
+      stub.session.markFirstPlayingLogged();
       nav.scheduleNonWatchRecovery();
       expect(stub.session.nonWatchRecoveryScheduled, isFalse);
     });
@@ -274,7 +276,7 @@ void main() {
     test('returns early when already scheduled', () {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.nonWatchRecoveryScheduled = true;
+      stub.session.scheduleNonWatchRecovery();
       nav.scheduleNonWatchRecovery();
       // Flag stays true; second call does not reschedule.
       expect(stub.session.nonWatchRecoveryScheduled, isTrue);
@@ -298,7 +300,7 @@ void main() {
       final nav = stub.build();
       nav.schedulePlaybackNudge();
       // Mark session disposed before the nudge would fire.
-      stub.session.disposed = true;
+      unawaited(stub.session.closeStreams());
       // Cancel and reschedule so we can verify the disposed short-circuit
       // without waiting on the real 6-second Timer.
       nav.cancelNudge();
@@ -344,7 +346,7 @@ void main() {
     testWidgets('returns when web controller missing', (tester) async {
       final stub = _Stub();
       stub.build(attach: false);
-      stub.session.videoId = 'vid';
+      stub.session.resetForOpen('vid');
       var prepareCalls = 0;
       final nav = YoutubeWebViewNavigation(
         session: stub.session,
@@ -365,7 +367,7 @@ void main() {
     testWidgets('returns when session is disposed', (tester) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.disposed = true;
+      unawaited(stub.session.closeStreams());
       var prepareCalls = 0;
       await nav.onWebViewProcessTerminated(
         prepareWatchReload: () => prepareCalls++,
@@ -379,9 +381,13 @@ void main() {
     ) async {
       final stub = _Stub();
       final nav = stub.build();
-      // Force buffering to false so emitBuffering(true) actually fires.
-      stub.session.buffering = false;
-      stub.session.playing = true;
+      // Force buffering to false so emitBuffering(true) actually fires. The
+      // first-playing latch is set before the buffering transition so the
+      // hint scheduler stays idle in this test.
+      stub.session
+        ..markFirstPlayingLogged()
+        ..emitBuffering(false)
+        ..emitPlaying(true);
       var prepareCalls = 0;
       final bufferingEvents = <bool>[];
       final playingEvents = <bool>[];
@@ -407,7 +413,6 @@ void main() {
     testWidgets('returns when video id is empty', (tester) async {
       final stub = _Stub();
       stub.build(attach: false);
-      stub.session.videoId = '';
       var prepareCalls = 0;
       await stub.nav!.onSignInNavigationBlocked(
         stub.controller,
@@ -420,7 +425,7 @@ void main() {
     testWidgets('returns when session is disposed', (tester) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.disposed = true;
+      unawaited(stub.session.closeStreams());
       var prepareCalls = 0;
       await nav.onSignInNavigationBlocked(
         stub.controller,
@@ -460,7 +465,7 @@ void main() {
     test('returns early when session is disposed', () async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.disposed = true;
+      unawaited(stub.session.closeStreams());
       await nav.nudgePlaybackStart(stub.controller);
       expect(stub.platform.evaluateCalls, 0);
     });
@@ -468,7 +473,7 @@ void main() {
     test('returns early when loggedFirstPlaying', () async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.loggedFirstPlaying = true;
+      stub.session.markFirstPlayingLogged();
       await nav.nudgePlaybackStart(stub.controller);
       expect(stub.platform.evaluateCalls, 0);
     });
@@ -490,7 +495,7 @@ void main() {
     test('does not nudge after explicitPlayAttempted', () async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.explicitPlayAttempted = true;
+      stub.session.markExplicitPlayAttempt();
       nav.schedulePlaybackNudge();
       await Future<void>.delayed(
         YoutubeWebViewNavigation.playbackNudgeDelay +
@@ -506,7 +511,7 @@ void main() {
     ) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.explicitPlayAttempted = true;
+      stub.session.markExplicitPlayAttempt();
       var prepareCalls = 0;
       var cancelCalls = 0;
       await nav.recoverStalledPlayback(
@@ -526,7 +531,7 @@ void main() {
     testWidgets('returns when web controller missing', (tester) async {
       final stub = _Stub();
       stub.build(attach: false);
-      stub.session.videoId = 'vid';
+      stub.session.resetForOpen('vid');
       var prepareCalls = 0;
       final nav = YoutubeWebViewNavigation(
         session: stub.session,
@@ -550,7 +555,7 @@ void main() {
     testWidgets('returns when session is disposed', (tester) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.disposed = true;
+      unawaited(stub.session.closeStreams());
       var prepareCalls = 0;
       await nav.recoverStalledPlayback(
         maxStallRecoveries: 3,
@@ -565,7 +570,7 @@ void main() {
     testWidgets('cancels watchdog when already playing', (tester) async {
       final stub = _Stub();
       final nav = stub.build();
-      stub.session.playing = true;
+      stub.session.emitPlaying(true);
       var cancelCalls = 0;
       var prepareCalls = 0;
       await nav.recoverStalledPlayback(

--- a/test/features/player/application/engines/youtube/youtube_webview_poll_loop_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_webview_poll_loop_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_poll_loop.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -157,7 +159,7 @@ void main() {
         onFirstPlaying: () => firstPlayingCalls++,
       );
 
-      session.disposed = true;
+      unawaited(session.closeStreams());
       loop.start();
       await Future<void>.delayed(const Duration(milliseconds: 300));
       expect(firstPlayingCalls, 0);
@@ -165,7 +167,7 @@ void main() {
     });
 
     test('resets pausedPollStreak to 0 on start()', () {
-      session.pausedPollStreak = 5;
+      session.notePauseStreak(5);
       final loop = YoutubeWebViewPollLoop(
         session: session,
         webController: () => null,
@@ -180,8 +182,7 @@ void main() {
     test('confirms pause after streak and keeps polling', () async {
       final driver = _FakePollDriver();
       session.emitPlaying(true);
-      session.lastPlayingAt = DateTime.now();
-      session.explicitPlayAttempted = true;
+      session.markExplicitPlayAttempt();
 
       final loop = YoutubeWebViewPollLoop(
         session: session,
@@ -255,8 +256,7 @@ void main() {
       final driver = _FakePollDriver();
       var retryCalls = 0;
       session.emitPlaying(true);
-      session.lastPlayingAt = DateTime.now();
-      session.userPlayInFlight = true;
+      session.beginUserPlay();
 
       final loop = YoutubeWebViewPollLoop(
         session: session,
@@ -283,8 +283,7 @@ void main() {
       final driver = _FakePollDriver();
       var retryCalls = 0;
       session.emitPlaying(true);
-      session.lastPlayingAt = DateTime.now();
-      session.userPlayInFlight = true;
+      session.beginUserPlay();
 
       final loop = YoutubeWebViewPollLoop(
         session: session,
@@ -317,7 +316,6 @@ void main() {
         final driver = _FakePollDriver();
         var retryCalls = 0;
         session.emitPlaying(true);
-        session.lastPlayingAt = DateTime.now();
 
         final loop = YoutubeWebViewPollLoop(
           session: session,

--- a/test/features/player/youtube_player_engine_test.dart
+++ b/test/features/player/youtube_player_engine_test.dart
@@ -6,60 +6,66 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('YoutubePlayerEngine mount lifecycle', () {
-    test(
-      'ensureWebViewAttached sets shouldMountWebView without duplicate hosts',
-      () async {
-        final engine = YoutubePlayerEngine();
-        expect(engine.shouldMountWebView, isFalse);
-        expect(engine.webViewMounted, isFalse);
-
-        engine.ensureWebViewAttached();
-        expect(engine.shouldMountWebView, isTrue);
-        expect(engine.webViewMounted, isFalse);
-
-        await engine.idleAfterClear();
-        expect(engine.shouldMountWebView, isFalse);
-        expect(engine.currentVideoId, isEmpty);
-      },
-    );
-
-    test('ensureWebViewAttached is idempotent for mountTick', () {
-      final engine = YoutubePlayerEngine();
-      engine.ensureWebViewAttached();
-      final tickAfterFirst = engine.mountTick.value;
-      engine.ensureWebViewAttached();
-      engine.ensureWebViewAttached();
-      expect(engine.mountTick.value, tickAfterFirst);
-      expect(engine.shouldMountWebView, isTrue);
-    });
-
-    test('open requests mount and sets video id', () async {
+  group('YoutubePlayerEngine contract surface', () {
+    test('open sets the video id and arms buffering transport', () async {
       final engine = YoutubePlayerEngine();
       await engine.open(const YoutubePlayableSource('abc12345678'));
       expect(engine.currentVideoId, 'abc12345678');
-      expect(engine.shouldMountWebView, isTrue);
+      expect(engine.transportSnapshot.buffering, isTrue);
+      await engine.dispose();
     });
 
-    test('practice clear idles content but keeps WebView mounted', () async {
+    test('teardownAfterClear idles the engine', () async {
       final engine = YoutubePlayerEngine();
       await engine.open(const YoutubePlayableSource('abc12345678'));
 
-      await engine.idleAfterClear(keepMounted: true);
+      await engine.teardownAfterClear(keepSurfaceMounted: false);
 
       expect(engine.currentVideoId, isEmpty);
-      expect(engine.shouldMountWebView, isTrue);
+      expect(engine.transportSnapshot.playing, isFalse);
+      expect(engine.transportSnapshot.buffering, isFalse);
+      await engine.dispose();
     });
 
-    test(
-      'warmVideoSurface only requests mount (no redundant idle navigation)',
-      () {
-        final engine = YoutubePlayerEngine();
-        engine.warmVideoSurface();
-        expect(engine.shouldMountWebView, isTrue);
-        expect(engine.currentVideoId, isEmpty);
-      },
-    );
+    test('warmVideoSurface does not throw and keeps no video open', () {
+      final engine = YoutubePlayerEngine();
+      engine.warmVideoSurface();
+      expect(engine.currentVideoId, isEmpty);
+    });
+  });
+
+  group('YoutubeSession mount lifecycle', () {
+    // The mount latches live on the session; the engine only forwards them
+    // through warmVideoSurface / teardownAfterClear (issue #630).
+    test('requestMount arms the mount without duplicate host ticks', () {
+      final session = YoutubeSession();
+      expect(session.shouldMountWebView, isFalse);
+      expect(session.webViewMounted, isFalse);
+
+      session.requestMount();
+      final tickAfterFirst = session.mountTick.value;
+      session.requestMount();
+      session.requestMount();
+
+      expect(session.shouldMountWebView, isTrue);
+      expect(session.mountTick.value, tickAfterFirst);
+      expect(session.webViewMounted, isFalse);
+    });
+
+    test('resetForClear unmounts unless asked to keep the host', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session.requestMount();
+
+      session.resetForClear();
+      expect(session.shouldMountWebView, isFalse);
+      expect(session.videoId, isEmpty);
+
+      session.resetForOpen('abc12345678');
+      session.requestMount();
+      session.resetForClear(keepMounted: true);
+      expect(session.shouldMountWebView, isTrue);
+      expect(session.videoId, isEmpty);
+    });
   });
 
   group('YoutubeWebViewEvents playback state', () {

--- a/test/features/player/youtube_player_engine_test.dart
+++ b/test/features/player/youtube_player_engine_test.dart
@@ -1,8 +1,8 @@
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_audible_playback_policy.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_events.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -69,6 +69,24 @@ void main() {
   });
 
   group('YoutubeWebViewEvents playback state', () {
+    YoutubeAudiblePlaybackPolicy buildPolicy(
+      YoutubeSession session, {
+      required Future<void> Function() reapplyVolume,
+      Duration? volumeRestoreDelay,
+      Duration? volumeRestoreFallback,
+      Duration? postRestoreHealDelay,
+      Future<void> Function()? healPlay,
+    }) {
+      return YoutubeAudiblePlaybackPolicy(
+        session: session,
+        reapplyVolume: reapplyVolume,
+        healPlay: healPlay ?? () async {},
+        volumeRestoreDelay: volumeRestoreDelay,
+        volumeRestoreFallback: volumeRestoreFallback,
+        postRestoreHealDelay: postRestoreHealDelay,
+      );
+    }
+
     YoutubeWebViewEvents buildEvents(
       YoutubeSession session, {
       required void Function() onFirstPlaying,
@@ -78,23 +96,24 @@ void main() {
       Duration? volumeRestoreDelay,
       Duration? volumeRestoreFallback,
       Duration? postRestoreHealDelay,
-      Future<void> Function(InAppWebViewController? web)? healPlay,
+      Future<void> Function()? healPlay,
     }) {
+      final audibility = buildPolicy(
+        session,
+        reapplyVolume: reapplyVolume,
+        volumeRestoreDelay: volumeRestoreDelay,
+        volumeRestoreFallback: volumeRestoreFallback,
+        postRestoreHealDelay: postRestoreHealDelay,
+        healPlay: healPlay,
+      );
       return YoutubeWebViewEvents(
         session: session,
         webController: () => null,
         onFirstPlaying: onFirstPlaying,
         startPolling: startPolling,
         stopPolling: stopPolling,
-        reapplyVolume: reapplyVolume,
         seekTo: (_) async {},
-        volumeRestoreDelay:
-            volumeRestoreDelay ??
-            YoutubeWebViewEvents.windowsVolumeRestoreDelay,
-        volumeRestoreFallback:
-            volumeRestoreFallback ?? const Duration(seconds: 30),
-        postRestoreHealDelay: postRestoreHealDelay,
-        healPlay: healPlay,
+        audibility: audibility,
       );
     }
 
@@ -128,217 +147,6 @@ void main() {
       expect(volumeRestoreCalls, 0);
       expect(session.volumeRestorePending, isTrue);
 
-      events.cancelPendingVolumeRestore();
-      await session.closeStreams();
-    });
-
-    test('restores volume after playback progress settles', () async {
-      final session = YoutubeSession()..resetForOpen('abc12345678');
-      var volumeRestoreCalls = 0;
-      final events = buildEvents(
-        session,
-        onFirstPlaying: () {},
-        startPolling: () {},
-        stopPolling: () {},
-        reapplyVolume: () async {
-          volumeRestoreCalls++;
-        },
-        volumeRestoreDelay: Duration.zero,
-      );
-
-      events.handle(['playing']);
-      expect(session.volumeRestorePending, isTrue);
-      expect(volumeRestoreCalls, 0);
-
-      // Need [progressConfirmTicks] advancing samples.
-      events.onPlaybackProgress(const Duration(milliseconds: 100));
-      expect(volumeRestoreCalls, 0);
-      events.onPlaybackProgress(const Duration(milliseconds: 200));
-
-      expect(volumeRestoreCalls, 1);
-      expect(session.volumeRestorePending, isFalse);
-
-      events.cancelPendingVolumeRestore();
-      await session.closeStreams();
-    });
-
-    test('restores volume via fallback when progress never arrives', () async {
-      final session = YoutubeSession()..resetForOpen('abc12345678');
-      var volumeRestoreCalls = 0;
-      final events = buildEvents(
-        session,
-        onFirstPlaying: () {},
-        startPolling: () {},
-        stopPolling: () {},
-        reapplyVolume: () async {
-          volumeRestoreCalls++;
-        },
-        volumeRestoreDelay: Duration.zero,
-        volumeRestoreFallback: const Duration(milliseconds: 80),
-      );
-
-      events.handle(['playing']);
-      await Future<void>.delayed(const Duration(milliseconds: 120));
-
-      expect(volumeRestoreCalls, 1);
-
-      events.cancelPendingVolumeRestore();
-      await session.closeStreams();
-    });
-
-    test(
-      'does not touch volume on later playing events in same document',
-      () async {
-        final session = YoutubeSession()
-          ..resetForOpen('abc12345678')
-          ..noteVolumeRestored();
-        var volumeRestoreCalls = 0;
-        final events = buildEvents(
-          session,
-          onFirstPlaying: () {},
-          startPolling: () {},
-          stopPolling: () {},
-          reapplyVolume: () async {
-            volumeRestoreCalls++;
-          },
-        );
-
-        events.handle(['playing']);
-
-        // Redundant programmatic unMutes are pause triggers under Chromium's
-        // autoplay gesture lock (play-then-pause root cause): an already
-        // restored document must skip the restore entirely.
-        expect(volumeRestoreCalls, 0);
-        expect(session.volumeRestorePending, isFalse);
-        expect(session.volumeRestoredDocGen, session.documentGen);
-
-        events.cancelPendingVolumeRestore();
-        await session.closeStreams();
-      },
-    );
-
-    test(
-      're-arms restore for a fresh watch document (post-ad reload)',
-      () async {
-        final session = YoutubeSession()
-          ..resetForOpen('abc12345678')
-          ..noteVolumeRestored();
-        var volumeRestoreCalls = 0;
-        final events = buildEvents(
-          session,
-          onFirstPlaying: () {},
-          startPolling: () {},
-          stopPolling: () {},
-          reapplyVolume: () async {
-            volumeRestoreCalls++;
-          },
-          volumeRestoreDelay: Duration.zero,
-        );
-
-        // Ad reload lands a brand-new document whose <video> starts muted.
-        session.noteWatchDocumentLoaded();
-        events.handle(['playing']);
-        expect(session.volumeRestorePending, isTrue);
-        expect(volumeRestoreCalls, 0);
-
-        // Progress gate still applies within the new document.
-        events.onPlaybackProgress(const Duration(milliseconds: 100));
-        events.onPlaybackProgress(const Duration(milliseconds: 200));
-        expect(volumeRestoreCalls, 1);
-        await Future<void>.delayed(Duration.zero);
-        expect(session.volumeRestoredDocGen, session.documentGen);
-
-        events.cancelPendingVolumeRestore();
-        await session.closeStreams();
-      },
-    );
-
-    test(
-      'heals a pause that immediately followed the volume restore',
-      () async {
-        final session = YoutubeSession()..resetForOpen('abc12345678');
-        var healCalls = 0;
-        final events = buildEvents(
-          session,
-          onFirstPlaying: () {},
-          startPolling: () {},
-          stopPolling: () {},
-          reapplyVolume: () async {},
-          volumeRestoreDelay: Duration.zero,
-          postRestoreHealDelay: const Duration(milliseconds: 20),
-          healPlay: (_) async {
-            healCalls++;
-          },
-        );
-
-        events.handle(['playing']);
-        events.onPlaybackProgress(const Duration(milliseconds: 100));
-        events.onPlaybackProgress(const Duration(milliseconds: 200));
-
-        // The unmute tripped the WebView's autoplay gesture lock and playback
-        // stopped; simulate the poll loop's pause confirmation.
-        await Future<void>.delayed(Duration.zero);
-        session.emitPlaying(false);
-
-        await Future<void>.delayed(const Duration(milliseconds: 60));
-        expect(healCalls, 1);
-        await session.closeStreams();
-      },
-    );
-
-    test('no heal when playback survives the volume restore', () async {
-      final session = YoutubeSession()..resetForOpen('abc12345678');
-      var healCalls = 0;
-      final events = buildEvents(
-        session,
-        onFirstPlaying: () {},
-        startPolling: () {},
-        stopPolling: () {},
-        reapplyVolume: () async {},
-        volumeRestoreDelay: Duration.zero,
-        postRestoreHealDelay: const Duration(milliseconds: 20),
-        healPlay: (_) async {
-          healCalls++;
-        },
-      );
-
-      events.handle(['playing']);
-      events.onPlaybackProgress(const Duration(milliseconds: 100));
-      events.onPlaybackProgress(const Duration(milliseconds: 200));
-
-      // Video kept playing after the unmute (the healthy case).
-      await Future<void>.delayed(const Duration(milliseconds: 60));
-      expect(healCalls, 0);
-      await session.closeStreams();
-    });
-
-    test('stale heal is skipped when a new document re-arms restore', () async {
-      final session = YoutubeSession()..resetForOpen('abc12345678');
-      var healCalls = 0;
-      final events = buildEvents(
-        session,
-        onFirstPlaying: () {},
-        startPolling: () {},
-        stopPolling: () {},
-        reapplyVolume: () async {},
-        volumeRestoreDelay: Duration.zero,
-        postRestoreHealDelay: const Duration(milliseconds: 20),
-        healPlay: (_) async {
-          healCalls++;
-        },
-      );
-
-      events.handle(['playing']);
-      events.onPlaybackProgress(const Duration(milliseconds: 100));
-      events.onPlaybackProgress(const Duration(milliseconds: 200));
-      await Future<void>.delayed(Duration.zero);
-
-      // Ad reload lands a new document before the heal fires.
-      session.noteWatchDocumentLoaded();
-      session.emitPlaying(false);
-
-      await Future<void>.delayed(const Duration(milliseconds: 60));
-      expect(healCalls, 0);
       await session.closeStreams();
     });
 
@@ -367,7 +175,6 @@ void main() {
       expect(volumeRestoreCalls, 0);
       expect(pollStartCalls, greaterThanOrEqualTo(1));
 
-      events.cancelPendingVolumeRestore();
       await session.closeStreams();
     });
 
@@ -397,7 +204,6 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 120));
         expect(volumeRestoreCalls, 0);
 
-        events.cancelPendingVolumeRestore();
         await session.closeStreams();
       },
     );
@@ -416,7 +222,6 @@ void main() {
       events.handle(['pause']);
       expect(session.playing, isTrue);
 
-      events.cancelPendingVolumeRestore();
       await session.closeStreams();
     });
 
@@ -437,7 +242,6 @@ void main() {
       expect(session.playing, isFalse);
       expect(session.buffering, isFalse);
 
-      events.cancelPendingVolumeRestore();
       await session.closeStreams();
     });
 
@@ -459,7 +263,6 @@ void main() {
       events.handle(['playRejected', 'NotAllowedError']);
       expect(session.userPlayInFlight, isFalse);
 
-      events.cancelPendingVolumeRestore();
       await session.closeStreams();
     });
 

--- a/test/features/player/youtube_player_engine_test.dart
+++ b/test/features/player/youtube_player_engine_test.dart
@@ -388,7 +388,7 @@ void main() {
         );
 
         events.handle(['playing']);
-        session.pausedPollStreak = 2;
+        session.notePauseStreak(2);
         events.handle(['pause']);
 
         // Streak must survive so poll confirmation is not delayed.
@@ -451,11 +451,11 @@ void main() {
         reapplyVolume: () async {},
       );
 
-      session.userPlayInFlight = true;
+      session.beginUserPlay();
       events.handle(['playing']);
       expect(session.userPlayInFlight, isFalse);
 
-      session.userPlayInFlight = true;
+      session.beginUserPlay();
       events.handle(['playRejected', 'NotAllowedError']);
       expect(session.userPlayInFlight, isFalse);
 
@@ -465,11 +465,11 @@ void main() {
 
     test('resetForOpen and resetForClear reset userPlayInFlight', () {
       final session = YoutubeSession()..resetForOpen('abc12345678');
-      session.userPlayInFlight = true;
+      session.beginUserPlay();
       session.resetForOpen('other123456');
       expect(session.userPlayInFlight, isFalse);
 
-      session.userPlayInFlight = true;
+      session.beginUserPlay();
       session.resetForClear();
       expect(session.userPlayInFlight, isFalse);
     });

--- a/test/features/player/youtube_session_audible_policy_test.dart
+++ b/test/features/player/youtube_session_audible_policy_test.dart
@@ -1,0 +1,232 @@
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_audible_playback_policy.dart';
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Behaviour coverage for [YoutubeAudiblePlaybackPolicy] — the mute-start →
+/// restore → heal choreography under Chromium's autoplay gesture lock
+/// (issue #628). Drives the policy directly: no WebView, no events dispatch.
+void main() {
+  group('joint timing invariant', () {
+    // The three-way constraint that previously spanned three files with no
+    // owner. If any constant changes, this fails before the play-then-pause
+    // bug ships.
+    test('heal beats pause-confirmation and loses to the recovery hint', () {
+      final confirmWindow =
+          YoutubeAudiblePlaybackPolicy.pollTick *
+          YoutubeSession.pauseConfirmPollTicks;
+      expect(
+        YoutubeAudiblePlaybackPolicy.defaultPostRestoreHealDelay,
+        greaterThan(confirmWindow),
+        reason:
+            'heal must wait until a gesture-lock pause is already reflected '
+            'in session.playing (~$confirmWindow)',
+      );
+      expect(
+        YoutubeSession.tapToPlayHintDelay,
+        greaterThan(YoutubeAudiblePlaybackPolicy.defaultPostRestoreHealDelay),
+        reason: 'heal must recover before the tap-to-play hint shows',
+      );
+    });
+  });
+
+  group('progress-gated restore', () {
+    test('restores volume after playback progress settles', () async {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      var restoreCalls = 0;
+      final policy = YoutubeAudiblePlaybackPolicy(
+        session: session,
+        reapplyVolume: () async => restoreCalls++,
+        healPlay: () async {},
+        volumeRestoreDelay: Duration.zero,
+      );
+
+      session.notePlayingConfirmed();
+      policy.onPlaying();
+      expect(session.volumeRestorePending, isTrue);
+      expect(restoreCalls, 0);
+
+      // Need [progressConfirmTicks] advancing samples.
+      policy.onPlaybackProgress(const Duration(milliseconds: 100));
+      expect(restoreCalls, 0);
+      policy.onPlaybackProgress(const Duration(milliseconds: 200));
+
+      expect(restoreCalls, 1);
+      expect(session.volumeRestorePending, isFalse);
+      await session.closeStreams();
+    });
+
+    test('restores volume via fallback when progress never arrives', () async {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      var restoreCalls = 0;
+      final policy = YoutubeAudiblePlaybackPolicy(
+        session: session,
+        reapplyVolume: () async => restoreCalls++,
+        healPlay: () async {},
+        volumeRestoreDelay: Duration.zero,
+        volumeRestoreFallback: const Duration(milliseconds: 80),
+      );
+
+      session.notePlayingConfirmed();
+      policy.onPlaying();
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+
+      expect(restoreCalls, 1);
+      await session.closeStreams();
+    });
+
+    test(
+      'does not touch volume on later playing in the same document',
+      () async {
+        final session = YoutubeSession()
+          ..resetForOpen('abc12345678')
+          ..noteVolumeRestored();
+        var restoreCalls = 0;
+        final policy = YoutubeAudiblePlaybackPolicy(
+          session: session,
+          reapplyVolume: () async => restoreCalls++,
+          healPlay: () async {},
+        );
+
+        session.notePlayingConfirmed();
+        policy.onPlaying();
+
+        // Redundant programmatic unMutes are pause triggers under Chromium's
+        // autoplay gesture lock (play-then-pause root cause): an already
+        // restored document must skip the restore entirely.
+        expect(restoreCalls, 0);
+        expect(session.volumeRestorePending, isFalse);
+        await session.closeStreams();
+      },
+    );
+
+    test(
+      're-arms restore for a fresh watch document (post-ad reload)',
+      () async {
+        final session = YoutubeSession()
+          ..resetForOpen('abc12345678')
+          ..noteVolumeRestored();
+        var restoreCalls = 0;
+        final policy = YoutubeAudiblePlaybackPolicy(
+          session: session,
+          reapplyVolume: () async => restoreCalls++,
+          healPlay: () async {},
+          volumeRestoreDelay: Duration.zero,
+        );
+
+        // Ad reload lands a brand-new document whose <video> starts muted.
+        session.noteWatchDocumentLoaded();
+        session.notePlayingConfirmed();
+        policy.onPlaying();
+        expect(session.volumeRestorePending, isTrue);
+        expect(restoreCalls, 0);
+
+        // Progress gate still applies within the new document.
+        policy.onPlaybackProgress(const Duration(milliseconds: 100));
+        policy.onPlaybackProgress(const Duration(milliseconds: 200));
+        expect(restoreCalls, 1);
+        await Future<void>.delayed(Duration.zero);
+        expect(session.volumeRestoredDocGen, session.documentGen);
+        await session.closeStreams();
+      },
+    );
+
+    test('DOM pause abandons the pending restore', () async {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      var restoreCalls = 0;
+      final policy = YoutubeAudiblePlaybackPolicy(
+        session: session,
+        reapplyVolume: () async => restoreCalls++,
+        healPlay: () async {},
+        volumeRestoreFallback: const Duration(milliseconds: 80),
+      );
+
+      session.notePlayingConfirmed();
+      policy.onPlaying();
+      policy.onPause();
+
+      expect(session.volumeRestorePending, isFalse);
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+      expect(restoreCalls, 0);
+      await session.closeStreams();
+    });
+  });
+
+  group('post-restore heal', () {
+    test(
+      'heals a pause that immediately followed the volume restore',
+      () async {
+        final session = YoutubeSession()..resetForOpen('abc12345678');
+        var healCalls = 0;
+        final policy = YoutubeAudiblePlaybackPolicy(
+          session: session,
+          reapplyVolume: () async {},
+          healPlay: () async => healCalls++,
+          volumeRestoreDelay: Duration.zero,
+          postRestoreHealDelay: const Duration(milliseconds: 20),
+        );
+
+        session.notePlayingConfirmed();
+        policy.onPlaying();
+        policy.onPlaybackProgress(const Duration(milliseconds: 100));
+        policy.onPlaybackProgress(const Duration(milliseconds: 200));
+
+        // The unmute tripped the WebView's autoplay gesture lock and playback
+        // stopped; simulate the poll loop's pause confirmation.
+        await Future<void>.delayed(Duration.zero);
+        session.notePauseConfirmed();
+
+        await Future<void>.delayed(const Duration(milliseconds: 60));
+        expect(healCalls, 1);
+        await session.closeStreams();
+      },
+    );
+
+    test('no heal when playback survives the volume restore', () async {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      var healCalls = 0;
+      final policy = YoutubeAudiblePlaybackPolicy(
+        session: session,
+        reapplyVolume: () async {},
+        healPlay: () async => healCalls++,
+        volumeRestoreDelay: Duration.zero,
+        postRestoreHealDelay: const Duration(milliseconds: 20),
+      );
+
+      session.notePlayingConfirmed();
+      policy.onPlaying();
+      policy.onPlaybackProgress(const Duration(milliseconds: 100));
+      policy.onPlaybackProgress(const Duration(milliseconds: 200));
+
+      // Video kept playing after the unmute (the healthy case).
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      expect(healCalls, 0);
+      await session.closeStreams();
+    });
+
+    test('stale heal is skipped when a new document re-arms restore', () async {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      var healCalls = 0;
+      final policy = YoutubeAudiblePlaybackPolicy(
+        session: session,
+        reapplyVolume: () async {},
+        healPlay: () async => healCalls++,
+        volumeRestoreDelay: Duration.zero,
+        postRestoreHealDelay: const Duration(milliseconds: 20),
+      );
+
+      session.notePlayingConfirmed();
+      policy.onPlaying();
+      policy.onPlaybackProgress(const Duration(milliseconds: 100));
+      policy.onPlaybackProgress(const Duration(milliseconds: 200));
+      await Future<void>.delayed(Duration.zero);
+
+      // Ad reload lands a new document before the heal fires.
+      session.noteWatchDocumentLoaded();
+      session.notePauseConfirmed();
+
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      expect(healCalls, 0);
+      await session.closeStreams();
+    });
+  });
+}

--- a/test/features/player/youtube_session_completed_test.dart
+++ b/test/features/player/youtube_session_completed_test.dart
@@ -71,8 +71,8 @@ void main() {
       'scheduleRecoveryHint shows overlay after failed explicit play',
       () async {
         session
-          ..loggedFirstPlaying = true
-          ..explicitPlayAttempted = true
+          ..markFirstPlayingLogged()
+          ..markExplicitPlayAttempt()
           ..emitBuffering(false)
           ..emitPlaying(false);
 
@@ -85,8 +85,8 @@ void main() {
 
     test('playing clears the recovery overlay', () async {
       session
-        ..loggedFirstPlaying = true
-        ..explicitPlayAttempted = true
+        ..markFirstPlayingLogged()
+        ..markExplicitPlayAttempt()
         ..emitBuffering(false);
       session.scheduleRecoveryHint();
       await Future<void>.delayed(const Duration(milliseconds: 1300));

--- a/test/features/player/youtube_session_transitions_test.dart
+++ b/test/features/player/youtube_session_transitions_test.dart
@@ -1,0 +1,236 @@
+import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Transition-rule coverage for the encapsulated [YoutubeSession] latches
+/// (issue #627). No WebView, no poll loop — the verbs are the test surface.
+void main() {
+  group('user-play in-flight invariant', () {
+    // The invariant the field's doc comment states: an explicit user play
+    // resolves on ANY of these transitions. Previously hand-enforced at 8
+    // call sites across five modules; now asserted once, here.
+    test('every resolving transition clears the in-flight latch', () {
+      final resolvers = <String, void Function(YoutubeSession)>{
+        'playing confirmed': (s) => s.notePlayingConfirmed(),
+        'play rejected': (s) => s.noteUserPlayUnresolved(),
+        'element error': (s) => s.noteUserPlayUnresolved(),
+        'ended': (s) => s.noteEnded(),
+        'reset for open': (s) => s.resetForOpen('next1234567'),
+        'reset for clear': (s) => s.resetForClear(),
+      };
+      for (final entry in resolvers.entries) {
+        final session = YoutubeSession()..resetForOpen('abc12345678');
+        session.beginUserPlay();
+        expect(session.userPlayInFlight, isTrue, reason: 'seed: ${entry.key}');
+        entry.value(session);
+        expect(
+          session.userPlayInFlight,
+          isFalse,
+          reason: '${entry.key} must resolve the in-flight play',
+        );
+      }
+    });
+
+    test('beginUserPlay clears stale buffering while not playing', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      expect(session.buffering, isTrue); // resetForOpen arms buffering.
+      session.beginUserPlay();
+      expect(session.userPlayInFlight, isTrue);
+      expect(session.buffering, isFalse);
+    });
+
+    test('clearUserPlayInFlight consumes the one-shot retry budget', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session.beginUserPlay();
+      session.clearUserPlayInFlight();
+      expect(session.userPlayInFlight, isFalse);
+    });
+  });
+
+  group('notePlayingConfirmed', () {
+    test(
+      'clears streak, completion latch, and in-flight; emits playing',
+      () async {
+        final session = YoutubeSession()..resetForOpen('abc12345678');
+        session
+          ..notePauseStreak(2)
+          ..markCompleted()
+          ..beginUserPlay();
+
+        final playingEvents = <bool>[];
+        final sub = session.playingStream.listen(playingEvents.add);
+        addTearDown(sub.cancel);
+
+        session.notePlayingConfirmed();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(session.playing, isTrue);
+        expect(session.pausedPollStreak, 0);
+        expect(session.playbackCompleted, isFalse);
+        expect(session.userPlayInFlight, isFalse);
+        expect(playingEvents, [true]);
+      },
+    );
+  });
+
+  group('noteEnded', () {
+    test('emits completed exactly once and clears transport latches', () async {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session
+        ..emitPlaying(true)
+        ..notePauseStreak(1)
+        ..beginUserPlay();
+
+      final completedEvents = <void>[];
+      final sub = session.completed.listen(completedEvents.add);
+      addTearDown(sub.cancel);
+
+      session.noteEnded();
+      session.noteEnded(); // idempotent
+      await Future<void>.delayed(Duration.zero);
+
+      expect(completedEvents, hasLength(1));
+      expect(session.playbackCompleted, isTrue);
+      expect(session.playing, isFalse);
+      expect(session.buffering, isFalse);
+      expect(session.userPlayInFlight, isFalse);
+      expect(session.pausedPollStreak, 0);
+    });
+
+    test('notePlayingConfirmed after end re-arms the completion latch', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session.noteEnded();
+      expect(session.playbackCompleted, isTrue);
+      session.notePlayingConfirmed();
+      expect(session.playbackCompleted, isFalse);
+    });
+
+    test(
+      'resetCompletionFlag lets markCompleted emit again (ADR-0044)',
+      () async {
+        final session = YoutubeSession()..resetForOpen('abc12345678');
+        session.noteEnded();
+        final completedEvents = <void>[];
+        final sub = session.completed.listen(completedEvents.add);
+        addTearDown(sub.cancel);
+
+        session.resetCompletionFlag();
+        session.noteEnded();
+        await Future<void>.delayed(Duration.zero);
+        expect(completedEvents, hasLength(1));
+      },
+    );
+  });
+
+  group('noteUserPlayUnresolved / notePauseConfirmed', () {
+    test('unresolved settles as not playing, not buffering', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session
+        ..emitPlaying(true)
+        ..beginUserPlay();
+      session.noteUserPlayUnresolved();
+      expect(session.playing, isFalse);
+      expect(session.buffering, isFalse);
+      expect(session.userPlayInFlight, isFalse);
+    });
+
+    test('pause confirmation resets the streak and stops transport', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session
+        ..emitPlaying(true)
+        ..notePauseStreak(3);
+      session.notePauseConfirmed();
+      expect(session.pausedPollStreak, 0);
+      expect(session.playing, isFalse);
+      expect(session.buffering, isFalse);
+    });
+  });
+
+  group('watch-page expectations', () {
+    test(
+      'noteWatchPageLoaded records the stop and clears recovery latches',
+      () {
+        final session = YoutubeSession()..resetForOpen('abc12345678');
+        session
+          ..noteAwaitingColdInitialNavigation()
+          ..scheduleNonWatchRecovery();
+
+        session.noteWatchPageLoaded();
+
+        expect(session.watchPageLoadStopReceived, isTrue);
+        expect(session.awaitingColdInitialNavigation, isFalse);
+        expect(session.nonWatchRecoveryScheduled, isFalse);
+      },
+    );
+
+    test(
+      'resetWatchPageExpectations clears latches; firstPlaying optional',
+      () {
+        final session = YoutubeSession()
+          ..resetForOpen('abc12345678')
+          ..markFirstPlayingLogged()
+          ..noteWatchPageLoaded();
+
+        session.resetWatchPageExpectations(firstPlaying: false);
+        expect(session.loggedFirstPlaying, isTrue);
+        expect(session.watchPageLoadStopReceived, isFalse);
+
+        session.resetWatchPageExpectations(firstPlaying: true);
+        expect(session.loggedFirstPlaying, isFalse);
+      },
+    );
+
+    test('clearAwaitingColdInitialNavigation leaves sibling latches alone', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      session
+        ..noteAwaitingColdInitialNavigation()
+        ..noteWatchPageLoaded()
+        ..noteAwaitingColdInitialNavigation();
+
+      session.clearAwaitingColdInitialNavigation();
+
+      expect(session.awaitingColdInitialNavigation, isFalse);
+      expect(session.watchPageLoadStopReceived, isTrue);
+    });
+  });
+
+  group('pending seek + volume', () {
+    test('takePendingSeekSeconds claims and clears', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      expect(session.takePendingSeekSeconds(), isNull);
+
+      session.setPendingSeekSeconds(12.5);
+      expect(session.takePendingSeekSeconds(), 12.5);
+      expect(session.takePendingSeekSeconds(), isNull);
+    });
+
+    test('storeVolumeNormalized clamps into 0..1', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      expect(session.storeVolumeNormalized(1.7), 1.0);
+      expect(session.storeVolumeNormalized(-0.3), 0.0);
+      expect(session.storeVolumeNormalized(0.4), 0.4);
+      expect(session.volumeNormalized, 0.4);
+    });
+  });
+
+  group('mount state', () {
+    test('mount tick notifies exactly once per mount request', () {
+      final session = YoutubeSession()..resetForOpen('abc12345678');
+      var ticks = 0;
+      void onTick() => ticks++;
+      session.mountTick.addListener(onTick);
+      addTearDown(() => session.mountTick.removeListener(onTick));
+
+      session.requestMount();
+      final afterFirst = ticks;
+      session.requestMount();
+      expect(ticks, afterFirst);
+      expect(session.shouldMountWebView, isTrue);
+
+      session.noteWebViewMounted();
+      expect(session.webViewMounted, isTrue);
+      session.noteWebViewUnmounted();
+      expect(session.webViewMounted, isFalse);
+      expect(session.shouldMountWebView, isTrue); // unmount ≠ clear request
+    });
+  });
+}


### PR DESCRIPTION
Closes #628. Part of the 2026-08-27 architecture review #626, candidate 2. **Stacks on #632 → #633 → #634** (merge in that order; this branch contains them).

## What changes

New **`YoutubeAudiblePlaybackPolicy`** — one owner for the whole mute-start → restore → heal choreography under Chromium's autoplay gesture lock, and for every timing constant it depends on:

- `onPlaying()` arms the per-document progress-gated restore (at most one unmute per watch document — redundant unMutes are pause triggers under the gesture lock); `onPlaybackProgress()` gates on advancing samples plus the platform settle delay; a fallback timer restores when progress never arrives; the restore re-applies volume, pins the document, and schedules the one-shot post-restore heal; `onPause()` / `cancelPending()` abandon pending restores.
- Constants moved in: `windowsVolumeRestoreDelay` (400 ms, was on events), `volumeRestoreFallback` (1500 ms, was on the session), `postRestoreHealDelay` (900 ms), and `pollTick` (250 ms) as the canonical poll cadence — **the poll loop now ticks on the policy's constant**.
- **The joint invariant is asserted as a test**: `pauseConfirmPollTicks × pollTick < postRestoreHealDelay < tapToPlayHintDelay`. The three-way constraint that previously spanned three files with no owner can no longer drift independently.

`YoutubeWebViewEvents` shrinks to pure dispatch — transport transitions go to the session (#627), audibility to the policy; it loses its volume ctor params, two timers, and five private helpers. The session remains the state store; its `tapToPlayHintDelay` is public so the invariant test can reference it.

## Why

de29a5be's commit message called the fdb22092 fix "structurally doomed" — it fixed the *route* while the muted-start→unmute *cycle* stayed split across modules. This gives the cycle a single home, so the next autoplay-policy bug lands in one file.

## Verification

- `flutter analyze` — no issues
- `bash .github/scripts/validate_ci_gates.sh --fix` — clean
- Full `flutter test` — 5,723 passing (volume/heal behaviour tests moved from the engine test file into the new `youtube_session_audible_policy_test.dart`, driving the policy directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
