### PR TITLE
refactor(youtube): dedupe pause scripts and video lookup in bridge

### DIFF
--- a/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_bridge.dart
@@ -53,17 +53,25 @@ class YoutubeWebViewBridge {
   static WebUri watchUri(String videoId) =>
       WebUri('https://m.youtube.com/watch?v=$videoId');
 
-  /// Locates the `<video>` element and YouTube's own page player object.
+  /// Locates the `<video>` element inside YouTube's player container,
+  /// falling back to any `<video>` on the page. For commands that target the
+  /// raw element directly (seek, playback rate, inline-mode attributes).
+  static const String _findVideo = '''
+      var p=document.querySelector('.html5-video-player');
+      var v=p?p.querySelector('video'):null;
+      if(!v) v=document.querySelector('video');
+  ''';
+
+  /// [_findVideo] plus YouTube's own page player object.
   ///
   /// Transport and volume commands must go through the page player
   /// (`mp.playVideo()` / `mp.unMute()` / …) whenever it is available:
   /// mutating the raw element (especially `video.muted`) behind the page's
   /// back lets its autoplay-policy/state machine re-pause the element shortly
   /// after playback starts — the play-then-pause symptom.
-  static const String _findVideoAndPlayer = '''
-      var p=document.querySelector('.html5-video-player');
-      var v=p?p.querySelector('video'):null;
-      if(!v) v=document.querySelector('video');
+  static const String _findVideoAndPlayer =
+      '''
+      $_findVideo
       var mp=document.querySelector('#movie_player')||p;
       if(!mp||typeof mp.playVideo!=='function') mp=null;
   ''';
@@ -101,6 +109,16 @@ class YoutubeWebViewBridge {
       }
   ''';
 
+  /// Pause body shared by [pauseScript], [stopScript], and the pause branch
+  /// of [playOrPauseScript]. Bumping `__enjoyYtPlayAttempt` invalidates any
+  /// in-flight play attempt's rejection callback (see [_startPlaybackBody]),
+  /// so a stale play error cannot surface after the pause already won.
+  static const String _pauseBody = '''
+      window.__enjoyYtPlayAttempt=(window.__enjoyYtPlayAttempt||0)+1;
+      if(mp){try{mp.pauseVideo();}catch(e){}}
+      else if(v){v.pause();}
+  ''';
+
   static const String playScript =
       '''
     (function(){
@@ -125,10 +143,28 @@ class YoutubeWebViewBridge {
       if(paused){
         $_startPlaybackBody
       } else {
-        window.__enjoyYtPlayAttempt=(window.__enjoyYtPlayAttempt||0)+1;
-        if(mp){try{mp.pauseVideo();}catch(e){}}
-        else{v.pause();}
+        $_pauseBody
       }
+    })();
+  ''';
+
+  /// Pause script — routes through the page player when available, falling
+  /// back to the raw element (see [_findVideoAndPlayer]).
+  static const String pauseScript =
+      '''
+    (function(){
+      $_findVideoAndPlayer
+      $_pauseBody
+    })();
+  ''';
+
+  /// [pauseScript] plus a position reset to the start of the video.
+  static const String stopScript =
+      '''
+    (function(){
+      $_findVideoAndPlayer
+      $_pauseBody
+      if(v){v.currentTime=0;}
     })();
   ''';
 
@@ -142,31 +178,7 @@ class YoutubeWebViewBridge {
   }
 
   static Future<void> pause(InAppWebViewController? web) async {
-    await web?.evaluateJavascript(
-      source:
-          '''
-        (function(){
-          $_findVideoAndPlayer
-          window.__enjoyYtPlayAttempt=(window.__enjoyYtPlayAttempt||0)+1;
-          if(mp){try{mp.pauseVideo();}catch(e){}}
-          else if(v){v.pause();}
-        })();
-      ''',
-    );
-  }
-
-  static Future<void> pauseVideoElement(InAppWebViewController? web) async {
-    await web?.evaluateJavascript(
-      source:
-          '''
-        (function(){
-          $_findVideoAndPlayer
-          window.__enjoyYtPlayAttempt=(window.__enjoyYtPlayAttempt||0)+1;
-          if(mp){try{mp.pauseVideo();}catch(e){}}
-          else if(v){v.pause();}
-        })();
-      ''',
-    );
+    await web?.evaluateJavascript(source: pauseScript);
   }
 
   static Future<void> seekToSeconds(
@@ -177,9 +189,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideo
           if(v) v.currentTime=$seconds;
         })();
       ''',
@@ -187,18 +197,7 @@ class YoutubeWebViewBridge {
   }
 
   static Future<void> stop(InAppWebViewController? web) async {
-    await web?.evaluateJavascript(
-      source:
-          '''
-        (function(){
-          $_findVideoAndPlayer
-          window.__enjoyYtPlayAttempt=(window.__enjoyYtPlayAttempt||0)+1;
-          if(mp){try{mp.pauseVideo();}catch(e){}}
-          else if(v){v.pause();}
-          if(v){v.currentTime=0;}
-        })();
-      ''',
-    );
+    await web?.evaluateJavascript(source: stopScript);
   }
 
   static Future<void> setPlaybackRate(
@@ -209,9 +208,7 @@ class YoutubeWebViewBridge {
       source:
           '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideo
           if(v) v.playbackRate=$speed;
         })();
       ''',
@@ -274,11 +271,10 @@ class YoutubeWebViewBridge {
   /// Re-applies `playsinline` on the active `<video>` (iOS WKWebView safety net).
   static Future<void> forceInlinePlayback(InAppWebViewController? web) async {
     await web?.evaluateJavascript(
-      source: '''
+      source:
+          '''
         (function(){
-          var p=document.querySelector('.html5-video-player');
-          var v=p?p.querySelector('video'):null;
-          if(!v) v=document.querySelector('video');
+          $_findVideo
           if(!v) return;
           v.setAttribute('playsinline','');
           v.setAttribute('webkit-playsinline','');

--- a/lib/features/player/application/engines/youtube/youtube_webview_events.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_events.dart
@@ -138,7 +138,7 @@ class YoutubeWebViewEvents {
         stopPolling();
         session.emitPlaying(false);
         session.emitBuffering(false);
-        unawaited(YoutubeWebViewBridge.pauseVideoElement(webController()));
+        unawaited(YoutubeWebViewBridge.pause(webController()));
         break;
       case 'waiting':
         session.emitBuffering(true);

--- a/test/features/player/application/engines/youtube/youtube_webview_bridge_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_webview_bridge_test.dart
@@ -102,6 +102,28 @@ void main() {
     });
   });
 
+  group('pauseScript / stopScript', () {
+    test('pause routes through the page player with element fallback', () {
+      expect(YoutubeWebViewBridge.pauseScript, contains('#movie_player'));
+      expect(YoutubeWebViewBridge.pauseScript, contains('mp.pauseVideo()'));
+      expect(YoutubeWebViewBridge.pauseScript, contains('v.pause()'));
+    });
+
+    test('pause bumps the play-attempt counter (stale rejection guard)', () {
+      // A pause must invalidate any in-flight play attempt's rejection
+      // callback, or a late play error could surface after the pause won.
+      expect(
+        YoutubeWebViewBridge.pauseScript,
+        contains('__enjoyYtPlayAttempt'),
+      );
+    });
+
+    test('stop is the pause body plus a position reset', () {
+      expect(YoutubeWebViewBridge.stopScript, contains('mp.pauseVideo()'));
+      expect(YoutubeWebViewBridge.stopScript, contains('v.currentTime=0;'));
+    });
+  });
+
   group('setVolumeScript', () {
     test('unmute prefers the page player API over element muted=false', () {
       final script = YoutubeWebViewBridge.setVolumeScript(1.0);


### PR DESCRIPTION
Resolves the duplication reported by the duplicate-code detector in #622 and #624 (both children of #623).

## Audit verdict

Both issues were valid:

- **#622** — `pause()` and `pauseVideoElement()` were byte-identical (verified with an exact diff of the two bodies). Git history explains why: `pauseVideoElement` was introduced in 558e47ad as a raw-element-only pause (`v.pause()`), but a later change routed it through `_findVideoAndPlayer` + the page player, making it converge with `pause()`. The name had become misleading — it does *not* pause "only the video element". `stop()` repeated the same preamble plus `currentTime=0`.
- **#624** — `seekToSeconds`, `setPlaybackRate`, and `forceInlinePlayback` each inlined the 3-line video lookup duplicating the head of `_findVideoAndPlayer`.

## Merge note (rebase onto main)

Main has since landed 1f85bfa5 (PR #632, refs #629), which already deduped the three inline lookups from #624 by interpolating `$_findVideoAndPlayer` (the "unused `mp` binding is harmless" option). This PR **adopts main's resolution** and drops its competing `_findVideo` variant; relative to main it now carries only the #622 fix:

- Extract `_pauseBody` (mirroring `_startPlaybackBody` from #620), shared by the new public `pauseScript` / `stopScript` constants and the pause branch of `playOrPauseScript`.
- Remove `pauseVideoElement`; its only caller (the `ended` handler in `youtube_webview_events.dart`) now calls `pause()`.
- Add `pauseScript` / `stopScript` tests covering page-player routing, the stale-rejection counter, and the stop position reset.

The `ended`-handler merge also picks up main's #627 refactor (`session.noteEnded()` absorbed the old `emitPlaying(false)` / `emitBuffering(false)` lines).

## Semantics

Generated JS is unchanged (the interpolated scripts were syntax-checked with `new Function()` and content-asserted). The only behavioral delta is a redundant `v` truthiness guard (`else{v.pause();}` → `else if(v){v.pause();}`) in the `playOrPauseScript` pause branch, which is a no-op after its existing `if(!v) return;`.

## Checks (post-merge)

- `check_dart_format.sh` ✅
- `check_codegen_drift.sh` ✅
- `flutter analyze` ✅ no issues
- `flutter test` ✅ 5726 passed, 2 skipped (incl. main's new JS protocol contract and session transition suites)

Fixes #622
Fixes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)