### PR TITLE
fix(linux): gate YouTube engine mounts behind ADR-0048 opt-out; show coming-soon notice

### DIFF
--- a/docs/features/linux-platform.md
+++ b/docs/features/linux-platform.md
@@ -48,7 +48,7 @@ No `apt install`, no `sudo`, no Snap/Flatpak abstraction layer. The AppImage is 
 
 | Feature | Linux status |
 |---------|-------------|
-| **YouTube import / playback** | **Not available** (coming soon). The YouTube engine depends on `flutter_inappwebview`'s Linux backend, which requires `webkit2gtk-4.0` — not present on a default Ubuntu install. When you try to open a YouTube video on Linux, the app shows "YouTube is not yet available on Linux — coming soon." |
+| **YouTube import / playback** | **Not available** (coming soon). `flutter_inappwebview` ships no Linux backend (Android/iOS/macOS/Windows/web only), so the WebView engine can never mount. Opening a YouTube video — or opening the YouTube sign-in screen — shows the localized "YouTube is not yet available on Linux — coming soon" notice instead ([ADR-0048](../decisions/0048-linux-platform-support.md)). |
 | **In-app auto-update** | **Not available.** The `auto_updater: ^1.0.0` plugin is Windows/macOS-only. To update, download a new AppImage from the landing page. AppImageUpdate integration is planned for a future release. |
 | **Package manager installs (.deb / .rpm / Flatpak / snap)** | Not available. Only AppImage for v1. |
 
@@ -97,7 +97,7 @@ Performance budgets for playback, scrolling, and transcript rendering are identi
 
 ### "YouTube is not yet available on Linux — coming soon"
 
-This is expected. YouTube will be enabled in a future release. In the meantime, download the video locally (e.g., with `yt-dlp`) and import the local file — the transcript and everything else work.
+This is expected. YouTube will be enabled in a future release. The notice replaces the player screen (with a back button) and the YouTube sign-in screen. In the meantime, download the video locally (e.g., with `yt-dlp`) and import the local file — the transcript and everything else work.
 
 ### AppImage won't run: "Permission denied"
 

--- a/lib/core/platform/linux_platform_availability.dart
+++ b/lib/core/platform/linux_platform_availability.dart
@@ -8,6 +8,9 @@ library;
 
 import 'dart:io' show Platform;
 
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
+
 /// True when running on a Linux host.
 bool get isLinux => Platform.isLinux;
 
@@ -17,6 +20,18 @@ bool get isLinux => Platform.isLinux;
 /// `webkit2gtk-4.0` — not present on a default Ubuntu 22.04 LTS install.
 /// Re-evaluate in a follow-up ADR (ADR-0048, R1 / R6).
 const youtubeEngineAvailableOnLinux = false;
+
+/// True when this runtime is Linux **and** the [youtubeEngineAvailableOnLinux]
+/// opt-out applies — every YouTube engine install/mount gate uses this single
+/// predicate (ADR-0048).
+///
+/// Reads [defaultTargetPlatform] (not `Platform.isLinux`) so tests can flip it
+/// with `debugDefaultTargetPlatformOverride` on any host. When a future ADR
+/// flips [youtubeEngineAvailableOnLinux] to `true`, this becomes `false`
+/// everywhere with no call-site changes.
+bool get youTubeEngineOptedOutHere =>
+    !youtubeEngineAvailableOnLinux &&
+    defaultTargetPlatform == TargetPlatform.linux;
 
 /// Google native sign-in is **not available** on Linux.
 ///

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -3,8 +3,6 @@ library;
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart' hide RepeatMode;
 import 'package:flutter/services.dart';
 import 'package:media_kit/media_kit.dart' as mk;
@@ -14,6 +12,7 @@ import 'package:enjoy_player/core/platform/linux_platform_availability.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'package:enjoy_player/features/player/domain/transport_decisions.dart';
+import 'package:enjoy_player/features/player/domain/youtube_playback_unavailable_exception.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/youtube_video_poster.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 import 'youtube_session.dart';
@@ -93,6 +92,9 @@ class YoutubePlayerEngine implements PlayerEngine {
   void markOpenTimingStart() => _webView.markOpenTimingStart();
 
   void _ensureWebViewAttached() {
+    // ADR-0048: on opted-out platforms never request a mount — constructing
+    // InAppWebView without a platform backend asserts on every rebuild.
+    if (youTubeEngineOptedOutHere) return;
     _session.requestMount();
     _logInitPhase('mount_requested');
   }
@@ -101,6 +103,7 @@ class YoutubePlayerEngine implements PlayerEngine {
   Future<bool> _awaitWebViewMounted({
     Duration timeout = const Duration(seconds: 8),
   }) async {
+    if (youTubeEngineOptedOutHere) return false;
     _ensureWebViewAttached();
     if (_session.webViewMounted) return true;
     final deadline = DateTime.now().add(timeout);
@@ -128,9 +131,10 @@ class YoutubePlayerEngine implements PlayerEngine {
 
   @override
   Future<void> open(PlayableSource source) async {
-    if (!youtubeEngineAvailableOnLinux &&
-        defaultTargetPlatform == TargetPlatform.linux) {
-      throw UnsupportedError(
+    if (youTubeEngineOptedOutHere) {
+      // Typed so the player surface can show the ADR-0048 "coming soon"
+      // message instead of the generic open-failure body.
+      throw const YouTubePlaybackUnavailableException(
         'YouTube is not yet available on Linux — coming soon '
         '(ADR-0048, R1 / R6: webview2gtk-4.0 dependency).',
       );
@@ -170,7 +174,11 @@ class YoutubePlayerEngine implements PlayerEngine {
               fit: StackFit.expand,
               children: [
                 const ColoredBox(color: Colors.black),
-                if (_session.shouldMountWebView) _buildWebViewHost(),
+                // ADR-0048: on opted-out platforms the host must never mount
+                // (defense in depth — mount requests are gated too, but the
+                // InAppWebView constructor itself asserts without a backend).
+                if (!youTubeEngineOptedOutHere && _session.shouldMountWebView)
+                  _buildWebViewHost(),
                 if (_session.tapToPlayHintActive && !showPoster)
                   _YoutubeTapToPlayHint(
                     label:

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:cross_file/cross_file.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:enjoy_player/core/platform/linux_platform_availability.dart';
 import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
 import 'package:enjoy_player/features/player/application/completion_loop.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
@@ -284,6 +285,9 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
 
   void warmYoutubeSurface() {
     if (ref.read(playerEngineTestDoubleProvider) != null) return;
+    // ADR-0048: on Linux the YouTube engine has no inappwebview backend and
+    // can never mount — do not install or warm it from feed scrolling.
+    if (youTubeEngineOptedOutHere) return;
     final owned = _ownedEngine;
     if (owned != null && owned.supportsYouTubePlayback) {
       owned.warmVideoSurface();

--- a/lib/features/player/application/player_controller.g.dart
+++ b/lib/features/player/application/player_controller.g.dart
@@ -62,7 +62,7 @@ final class PlayerControllerProvider
   }
 }
 
-String _$playerControllerHash() => r'a939c11066d8a34687eb996bfa67d3abe83ec896';
+String _$playerControllerHash() => r'e43a1b6fd3beb418d05c7e3b12ed2c42d513c0fd';
 
 /// Deterministic end-of-media completion loop (ADR-0044).
 ///

--- a/lib/features/player/domain/youtube_playback_unavailable_exception.dart
+++ b/lib/features/player/domain/youtube_playback_unavailable_exception.dart
@@ -1,0 +1,16 @@
+/// Thrown when [YoutubePlayerEngine] cannot run on this platform (ADR-0048).
+library;
+
+/// YouTube playback is opted out on Linux for v1: `flutter_inappwebview`
+/// ships no Linux backend, so the WebView host can never mount (ADR-0048,
+/// R1 / R6). The player surfaces a localized "coming soon" message for this
+/// exception instead of the generic open-failure body.
+class YouTubePlaybackUnavailableException implements Exception {
+  const YouTubePlaybackUnavailableException(this.message);
+
+  /// Human-readable description (already safe to log).
+  final String message;
+
+  @override
+  String toString() => 'YouTubePlaybackUnavailableException: $message';
+}

--- a/lib/features/player/presentation/expanded_player_screen.dart
+++ b/lib/features/player/presentation/expanded_player_screen.dart
@@ -11,6 +11,7 @@ import 'package:enjoy_player/features/player/application/player_ui_provider.dart
 import 'package:enjoy_player/features/player/domain/media_relocate_exception.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'package:enjoy_player/features/player/domain/player_launch_request.dart';
+import 'package:enjoy_player/features/player/domain/youtube_playback_unavailable_exception.dart';
 
 import 'expanded_player_widgets.dart';
 import 'locate_media_screen.dart';
@@ -57,6 +58,10 @@ class _ExpandedPlayerScreenState extends ConsumerState<ExpandedPlayerScreen> {
       final err = open.error;
       if (err is MediaNeedsRelocateException) {
         return LocateMediaScreen(info: err);
+      }
+      // ADR-0048: dedicated "coming soon" body — not the generic failure.
+      if (err is YouTubePlaybackUnavailableException) {
+        return ExpandedPlayerYoutubeUnavailableBody(colorScheme: cs);
       }
       return ExpandedPlayerGenericErrorBody(colorScheme: cs);
     }

--- a/lib/features/player/presentation/expanded_player_widgets.dart
+++ b/lib/features/player/presentation/expanded_player_widgets.dart
@@ -128,6 +128,45 @@ class ExpandedPlayerGenericErrorBody extends StatelessWidget {
   }
 }
 
+/// YouTube open on an opted-out platform (ADR-0048): localized "coming soon"
+/// notice instead of the generic failure body.
+class ExpandedPlayerYoutubeUnavailableBody extends StatelessWidget {
+  const ExpandedPlayerYoutubeUnavailableBody({
+    super.key,
+    required this.colorScheme,
+  });
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(
+                l10n.youtubeLinuxUnavailable,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+          // The user is stranded without a way back otherwise — mirror the
+          // loading body's collapse-only chrome.
+          const Align(
+            alignment: Alignment.topCenter,
+            child: _VideoCollapseOnlyOverlay(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 /// Main expanded player: AppBar + ambient backdrop + video/audio layout.
 class ExpandedPlayerChromeBody extends ConsumerWidget {
   const ExpandedPlayerChromeBody({

--- a/lib/features/player/presentation/youtube_login_screen.dart
+++ b/lib/features/player/presentation/youtube_login_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:enjoy_player/core/platform/linux_platform_availability.dart';
 import 'package:enjoy_player/core/webview/platform_webview_environment.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_bridge.dart';
 import 'package:enjoy_player/features/player/application/youtube_auth_provider.dart';
@@ -37,6 +38,35 @@ class _YoutubeLoginScreenState extends ConsumerState<YoutubeLoginScreen> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
+
+    // ADR-0048: no inappwebview backend on Linux — the sign-in WebView cannot
+    // mount, so show the "coming soon" notice instead of asserting.
+    if (youTubeEngineOptedOutHere) {
+      return Scaffold(
+        backgroundColor: colorScheme.surface,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          leading: IconButton(
+            icon: const Icon(Icons.close_rounded, size: 24),
+            color: colorScheme.onSurface,
+            onPressed: () {
+              ref.invalidate(youtubeLoginStateProvider);
+              context.pop();
+            },
+            tooltip: l10n.youtubeLoginClose,
+          ),
+        ),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              l10n.youtubeLinuxUnavailable,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       backgroundColor: colorScheme.surface,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -154,6 +154,7 @@
   "youtubeLoginClose": "Close",
   "youtubeLoginScreenTitle": "YouTube sign-in",
   "youtubeLogout": "Sign out (clear cookies)",
+  "youtubeLinuxUnavailable": "YouTube is not yet available on Linux — coming soon.",
   "youtubeTapToPlayHint": "Tap the video to play",
   "@youtubeTapToPlayHint": {
     "description": "Overlay when YouTube autoplay needs a user gesture or playback stopped immediately after play"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -819,6 +819,12 @@ abstract class AppLocalizations {
   /// **'Sign out (clear cookies)'**
   String get youtubeLogout;
 
+  /// No description provided for @youtubeLinuxUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'YouTube is not yet available on Linux — coming soon.'**
+  String get youtubeLinuxUnavailable;
+
   /// Overlay when YouTube autoplay needs a user gesture or playback stopped immediately after play
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -419,6 +419,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get youtubeLogout => 'Sign out (clear cookies)';
 
   @override
+  String get youtubeLinuxUnavailable =>
+      'YouTube is not yet available on Linux — coming soon.';
+
+  @override
   String get youtubeTapToPlayHint => 'Tap the video to play';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -404,6 +404,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get youtubeLogout => '退出登录（清除 Cookie）';
 
   @override
+  String get youtubeLinuxUnavailable => 'YouTube 在 Linux 上尚無法使用——即將推出。';
+
+  @override
   String get youtubeTapToPlayHint => '點一下影片即可播放';
 
   @override
@@ -4147,6 +4150,9 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get youtubeLogout => '退出登录（清除 Cookie）';
+
+  @override
+  String get youtubeLinuxUnavailable => 'YouTube 在 Linux 上暂不可用——即将推出。';
 
   @override
   String get youtubeTapToPlayHint => '点一下视频即可播放';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -117,6 +117,7 @@
   "youtubeLoginClose": "關閉",
   "youtubeLoginScreenTitle": "YouTube 登录",
   "youtubeLogout": "退出登录（清除 Cookie）",
+  "youtubeLinuxUnavailable": "YouTube 在 Linux 上尚無法使用——即將推出。",
   "youtubeTapToPlayHint": "點一下影片即可播放",
   "searchHint": "搜索",
   "transportRepeat": "循环",

--- a/lib/l10n/app_zh_CN.arb
+++ b/lib/l10n/app_zh_CN.arb
@@ -151,6 +151,7 @@
   "youtubeLoginClose": "关闭",
   "youtubeLoginScreenTitle": "YouTube 登录",
   "youtubeLogout": "退出登录（清除 Cookie）",
+  "youtubeLinuxUnavailable": "YouTube 在 Linux 上暂不可用——即将推出。",
   "youtubeTapToPlayHint": "点一下视频即可播放",
   "searchHint": "搜索",
   "transportRepeat": "循环",

--- a/test/core/platform/linux_platform_availability_test.dart
+++ b/test/core/platform/linux_platform_availability_test.dart
@@ -2,12 +2,32 @@ import 'dart:io' show Platform;
 
 import 'package:enjoy_player/core/platform/linux_platform_availability.dart'
     as linux_avail;
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride, TargetPlatform;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('linux_platform_availability predicates', () {
     test('isLinux matches Platform.isLinux', () {
       expect(linux_avail.isLinux, Platform.isLinux);
+    });
+
+    group('youTubeEngineOptedOutHere', () {
+      tearDown(() {
+        debugDefaultTargetPlatformOverride = null;
+      });
+
+      test('is true on the Linux target while the v1 opt-out stands', () {
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        expect(linux_avail.youTubeEngineOptedOutHere, isTrue);
+      });
+
+      test('is false on other targets', () {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        expect(linux_avail.youTubeEngineOptedOutHere, isFalse);
+        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+        expect(linux_avail.youTubeEngineOptedOutHere, isFalse);
+      });
     });
 
     test(

--- a/test/features/player/application/engines/youtube/youtube_engine_availability_linux_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_engine_availability_linux_test.dart
@@ -1,8 +1,10 @@
 import 'package:enjoy_player/core/platform/linux_platform_availability.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
+import 'package:enjoy_player/features/player/domain/youtube_playback_unavailable_exception.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride, TargetPlatform;
+import 'package:flutter/material.dart' show Builder, MaterialApp, Scaffold;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -11,22 +13,27 @@ void main() {
   });
 
   group('YoutubePlayerEngine on Linux', () {
-    test('open throws UnsupportedError on Linux (YouTube not yet available '
-        'per ADR-0048)', () async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
-      final engine = YoutubePlayerEngine();
+    test(
+      'open throws the typed unavailable exception on Linux (ADR-0048)',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        final engine = YoutubePlayerEngine();
 
-      await expectLater(
-        () => engine.open(const YoutubePlayableSource('dQw4w9WgXcQ')),
-        throwsA(
-          isA<UnsupportedError>().having(
-            (e) => e.message,
-            'message',
-            contains('YouTube is not yet available on Linux'),
+        // Typed (not raw UnsupportedError) so ExpandedPlayerScreen can show
+        // the localized "coming soon" body instead of the generic failure.
+        await expectLater(
+          () => engine.open(const YoutubePlayableSource('dQw4w9WgXcQ')),
+          throwsA(
+            isA<YouTubePlaybackUnavailableException>().having(
+              (e) => e.message,
+              'message',
+              contains('YouTube is not yet available on Linux'),
+            ),
           ),
-        ),
-      );
-    });
+        );
+        await engine.dispose();
+      },
+    );
 
     test('youtubeEngineAvailableOnLinux is false (v1 opt-out)', () {
       expect(
@@ -37,5 +44,56 @@ void main() {
             '(webview2gtk-4.0 dependency).',
       );
     });
+
+    test(
+      'awaitSurfaceReady resolves promptly on Linux instead of polling 8s',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        final engine = YoutubePlayerEngine();
+
+        await expectLater(
+          engine.awaitSurfaceReady().timeout(const Duration(seconds: 1)),
+          completes,
+        );
+        await engine.dispose();
+      },
+    );
+
+    testWidgets(
+      'warmVideoSurface + buildVideoStage never mount the WebView host on Linux',
+      (tester) async {
+        final engine = YoutubePlayerEngine();
+        // try/finally so the override is cleared *before* the testWidgets
+        // verification check runs (same pattern as media_card_test).
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        try {
+          // Ungated, this arms the session mount latch; the stage below then
+          // constructs InAppWebView, which asserts — InAppWebViewPlatform
+          // .instance is null on every platform without a plugin backend
+          // (exactly the production Linux failure from the field log).
+          engine.warmVideoSurface();
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => engine.buildVideoStage(
+                    context: context,
+                    maxWidth: 400,
+                    maxHeight: 300,
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(tester.takeException(), isNull);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+        await engine.dispose();
+      },
+    );
   });
 }

--- a/test/features/player/player_controller_test.dart
+++ b/test/features/player/player_controller_test.dart
@@ -14,6 +14,8 @@ import 'package:enjoy_player/features/player/application/player_preferences_prov
 import 'package:enjoy_player/features/player/domain/media_relocate_exception.dart';
 import 'package:enjoy_player/features/player/domain/player_settings.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_repository_provider.dart';
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride, TargetPlatform;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
@@ -885,5 +887,54 @@ void main() {
         // seek is present and not overwritten.
       },
     );
+  });
+
+  group('PlayerController.warmYoutubeSurface Linux opt-out (ADR-0048)', () {
+    // No playerEngineTestDoubleProvider override here — the warm gate under
+    // test sits below the test-double short-circuit in the real controller.
+    late AppDatabase db;
+    late ProviderContainer container;
+
+    setUp(() {
+      db = AppDatabase(executor: NativeDatabase.memory());
+      container = ProviderContainer(
+        overrides: [appDatabaseProvider.overrideWithValue(db)],
+      );
+    });
+
+    tearDown(() async {
+      debugDefaultTargetPlatformOverride = null;
+      await pumpEventQueue();
+      container.dispose();
+      await db.close();
+    });
+
+    test('does not install the YouTube engine when opted out', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+
+      final n = container.read(playerControllerProvider.notifier);
+      n.warmYoutubeSurface();
+
+      expect(
+        n.ownedEngine,
+        isNull,
+        reason: 'feed-scroll warm must not install a YouTube engine on Linux',
+      );
+      expect(
+        container.read(playerEngineRevProvider),
+        0,
+        reason: 'no engine swap happened, so the host rev must not bump',
+      );
+    });
+
+    test('installs and warms a YouTube engine on other targets', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      final n = container.read(playerControllerProvider.notifier);
+      n.warmYoutubeSurface();
+
+      expect(n.ownedEngine, isA<YoutubePlayerEngine>());
+      expect(container.read(playerEngineRevProvider), 1);
+    });
   });
 }

--- a/test/features/player/presentation/expanded_player_screen_test.dart
+++ b/test/features/player/presentation/expanded_player_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/player/application/open_media_provider.dart';
 import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
 import 'package:enjoy_player/features/player/domain/player_launch_request.dart';
+import 'package:enjoy_player/features/player/domain/youtube_playback_unavailable_exception.dart';
 import 'package:enjoy_player/features/player/presentation/expanded_player_screen.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
@@ -130,5 +131,59 @@ void main() {
         expect(find.byType(SkeletonAppBootstrap), findsOneWidget);
       },
     );
+
+    testWidgets('shows the YouTube coming-soon body when open fails with the '
+        'ADR-0048 Linux opt-out exception', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          authCtrlProvider.overrideWith(_SignedInAuthCtrl.new),
+          playerEngineTestDoubleProvider.overrideWithValue(fake),
+          openMediaLaunchProvider.overrideWith((ref, request) async {
+            throw const YouTubePlaybackUnavailableException(
+              'YouTube is not yet available on Linux — coming soon',
+            );
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        _wrap(
+          container: container,
+          child: const ExpandedPlayerScreen(
+            launch: PlayerLaunchRequest(mediaId: 'yt1'),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      // Localized ADR-0048 notice — not the generic open-failure copy.
+      expect(
+        find.text('YouTube is not yet available on Linux — coming soon.'),
+        findsOneWidget,
+      );
+
+      // The override drops the provider's `retry: null`, so Riverpod's
+      // default backoff (10 retries: 200ms×2^n capped at 6.4s) re-runs the
+      // throwing body. Pump through the whole sequence so the error state
+      // settles and no FakeTimer is left pending at teardown.
+      const backoffMs = [
+        200,
+        400,
+        800,
+        1600,
+        3200,
+        6400,
+        6400,
+        6400,
+        6400,
+        6400,
+      ];
+      for (final ms in backoffMs) {
+        await tester.pump(Duration(milliseconds: ms));
+      }
+    });
   });
 }

--- a/test/features/player/presentation/youtube_login_screen_test.dart
+++ b/test/features/player/presentation/youtube_login_screen_test.dart
@@ -1,0 +1,46 @@
+import 'package:enjoy_player/features/player/presentation/youtube_login_screen.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride, TargetPlatform;
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'renders the coming-soon notice on Linux instead of the sign-in WebView',
+    (tester) async {
+      // try/finally so the override is cleared *before* the testWidgets
+      // verification check runs (same pattern as media_card_test).
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      try {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              localizationsDelegates: [
+                AppLocalizations.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+              ],
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: YoutubeLoginScreen(),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.text('YouTube is not yet available on Linux — coming soon.'),
+          findsOneWidget,
+        );
+        // Ungated, the screen constructs InAppWebView, which asserts — no
+        // platform backend exists in the test environment (the same failure
+        // as production Linux).
+        expect(tester.takeException(), isNull);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Problem

Opening a YouTube video on Linux fails with repeated SEVERE logs:

```
A platform implementation for `flutter_inappwebview` has not been set. …
Failed assertion: 'InAppWebViewPlatform.instance != null'
```

followed by `Unsupported operation: YouTube is not yet available on Linux` and the generic open-failure screen. The same assertion also fires from merely scrolling Home/library tiles containing YouTube items (feed warm path).

## Root cause

`flutter_inappwebview` **ships no Linux backend** — 6.1.5 (our pin) declares Android/iOS/macOS/web/Windows only, and no published version (incl. 6.2.0-beta.3) adds one; the `flutter_inappwebview_linux` assumption in ADR-0048's research was wrong. On Linux `InAppWebViewPlatform.instance` is null, so constructing any `InAppWebView` asserts.

ADR-0048 opted YouTube out on Linux, but the opt-out was enforced in exactly **one** place (`YoutubePlayerEngine.open`). Ungated paths still installed + mounted the engine:

| Path | Where |
|------|-------|
| Feed/tile warm | `warmYoutubeSurfaceIfNeeded` → `PlayerController.warmYoutubeSurface()` |
| Open pipeline | `runPlayerOpen` calls `engine.warmVideoSurface()` **before** `open()` throws |
| Loading stage | `YoutubeLoadingVideoStage._scheduleAttach` → `engine.warmVideoSurface()` |
| Sign-in | `YoutubeLoginScreen` builds `InAppWebView` directly |

All converge on `requestMount()` → `InAppWebView` construction → the assertion spam. Users then got the generic error body instead of the localized "coming soon" message ADR-0048 and `docs/features/linux-platform.md` promise.

## Change

- **`youTubeEngineOptedOutHere`** — single testable predicate in `linux_platform_availability.dart` (reads `defaultTargetPlatform` so tests can override it). Flipping `youtubeEngineAvailableOnLinux` in a future ADR re-enables everything with no call-site changes.
- **Engine** — `open()` throws a typed `YouTubePlaybackUnavailableException`; warm/mount paths no-op; `awaitSurfaceReady` returns immediately (was polling 8 s); `buildVideoStage` never builds the WebView host (defense in depth).
- **Controller** — `warmYoutubeSurface()` never installs the YouTube engine on Linux.
- **UI** — `ExpandedPlayerScreen` routes the typed exception to a new `ExpandedPlayerYoutubeUnavailableBody` (localized notice + back button); `YoutubeLoginScreen` shows the same notice instead of the sign-in WebView.
- **l10n** — `youtubeLinuxUnavailable` added to en / zh / zh_CN (no translation debt); generated files committed.
- **Docs** — `docs/features/linux-platform.md` corrected: there is no Linux backend at all (the "requires webkit2gtk-4.0" rationale was inaccurate).

## Tests

Regression tests for every gate (each fails against the ungated code — the stage test reproduces the exact production assertion):

- Engine on Linux: typed exception, `awaitSurfaceReady` prompt, `warmVideoSurface` + `buildVideoStage` mount nothing
- Predicate truth table (linux vs android/windows)
- Controller warm: no engine install / no rev bump on Linux; installs on other targets
- Player: coming-soon body rendered from the typed exception
- Login screen: notice rendered, no `InAppWebView` constructed

## Verification

- `flutter analyze` — clean
- Full suite: **5737 passed, 0 failed**
- `bash .github/scripts/validate_ci_gates.sh --fix` — all gates passed (caught + regenerated a Riverpod provider-hash drift)

## Not addressed (deliberately)

- The caption-fetcher "Client is already closed" cascade seen alongside this failure is a downstream symptom (provider disposal mid-fetch after the failed open); the first profile's content-length error is transient. Separate hardening if wanted.
- Real YouTube playback on Linux requires a different webview stack (e.g. `desktop_webview_window` on webkit2gtk) and a follow-up ADR superseding the opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)