### PR TITLE
fix(player): pop route before teardown — exit stranded on placeholder, entry flash, snackbar layout aborts

### DIFF
--- a/lib/core/notices/app_notice.dart
+++ b/lib/core/notices/app_notice.dart
@@ -126,8 +126,13 @@ abstract final class AppNotice {
       final mq = MediaQuery.of(context);
       final shellExtra = RootShellBottomInset.clearanceOf(context);
       final horizontal = tokens?.space16 ?? 16.0;
-      final bottomPad =
-          mq.padding.bottom + shellExtra + (tokens?.space16 ?? 16.0);
+      // padding.bottom can exceed the physical safe inset when an ancestor
+      // Scaffold reports an over-tall bottomNavigationBar (extendBody feeds
+      // max(padding, bottomWidgetsHeight) into the body MediaQuery). Clamp to
+      // viewPadding so a leaked inset can never push the notice off screen —
+      // a floating SnackBar taller than the screen aborts every layout.
+      final safeBottom = math.min(mq.padding.bottom, mq.viewPadding.bottom);
+      final bottomPad = safeBottom + shellExtra + (tokens?.space16 ?? 16.0);
       final maxW = mq.size.width;
       final innerMax = math.max(0.0, maxW - horizontal * 2);
       final snackMaxWidth = maxW >= 600 && innerMax > 0

--- a/lib/core/theme/widgets/enjoy_bottom_nav.dart
+++ b/lib/core/theme/widgets/enjoy_bottom_nav.dart
@@ -64,6 +64,15 @@ class EnjoyBottomNav extends StatelessWidget {
       minimum: EdgeInsets.fromLTRB(t.space16, t.space4, t.space16, t.space12),
       child: Align(
         alignment: Alignment.bottomCenter,
+        // Unconstrained Align expands to the bottomNavigationBar slot's loose
+        // maxHeight (the whole screen). Scaffold then reports a full-height
+        // bottom widget: contentBottom collapses to 0 — so every floating
+        // SnackBar presented on the shell Scaffold trips the "Floating
+        // SnackBar presented off screen" layout assert (which aborts the
+        // frame in debug and froze the player-exit transition) — and the
+        // body's MediaQuery.padding.bottom leaks the full screen height into
+        // AppNotice margins. heightFactor sizes this box to the capsule.
+        heightFactor: 1,
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 520),
           child: Container(

--- a/lib/features/player/application/player_collapse.dart
+++ b/lib/features/player/application/player_collapse.dart
@@ -11,6 +11,20 @@ import 'package:enjoy_player/features/player/application/player_controller.dart'
 import 'package:enjoy_player/features/player/application/player_ui_provider.dart';
 
 Future<void> collapseExpandedPlayer(WidgetRef ref, BuildContext context) async {
+  // Pop BEFORE the teardown awaits. clear() nulls the session mid-flight,
+  // which rebuilds the player page into its loading placeholder and swaps the
+  // permanent surface overlay that hosts the collapse control — the calling
+  // context is deactivated, so the old `if (context.mounted) context.pop()`
+  // silently skipped the pop and stranded the learner on the placeholder
+  // (only the system back gesture could leave). Popping first also keeps the
+  // chrome body mounted for the whole reverse transition instead of flashing
+  // the placeholder while the engine tears down.
+  final router = GoRouter.of(context);
+  // Guard against a second tap (or hotkey) while the first pop's transition
+  // is still running: the overlay control stays mounted during it.
+  if (router.state.uri.path.startsWith('/player/')) {
+    router.pop();
+  }
   await ref.read(windowFullscreenProvider.notifier).setFullscreen(false);
   ref.read(playerUiProvider.notifier).collapse();
   if (ref.read(playerControllerProvider) == null) {
@@ -18,5 +32,4 @@ Future<void> collapseExpandedPlayer(WidgetRef ref, BuildContext context) async {
   } else {
     await clearLivePlaybackSessionIfNeeded(ref, onPlayerRoute: false);
   }
-  if (context.mounted) context.pop();
 }

--- a/lib/features/player/presentation/expanded_player_widgets.dart
+++ b/lib/features/player/presentation/expanded_player_widgets.dart
@@ -8,12 +8,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/theme/widgets/app_background.dart';
 import 'package:enjoy_player/core/theme/widgets/skeleton.dart';
+import 'package:enjoy_player/core/utils/local_thumbnail.dart';
 import 'package:enjoy_player/features/player/application/player_collapse.dart';
 import 'package:enjoy_player/features/player/application/player_engine_provider.dart';
 import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'package:enjoy_player/features/player/presentation/layouts/audio_player_layout.dart';
 import 'package:enjoy_player/features/player/presentation/layouts/video_player_layout.dart';
+import 'package:enjoy_player/features/transcript/application/video_row_for_media_provider.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 import 'package:enjoy_player/features/player/application/player_surface_registry.dart';
@@ -42,6 +44,13 @@ class ExpandedPlayerLoadingBody extends ConsumerWidget {
       data: (p) => p != null,
       orElse: () => false,
     );
+    // Video rows only — audio has no 16:9 stage to claim, and flashing a
+    // black video box before the audio layout reads as a broken player.
+    final videoRow = ref.watch(videoRowForMediaProvider(mediaId));
+    final isLocalVideo = videoRow.maybeWhen(
+      data: (row) => row != null,
+      orElse: () => false,
+    );
 
     return Scaffold(
       backgroundColor: colorScheme.surface,
@@ -57,13 +66,17 @@ class ExpandedPlayerLoadingBody extends ConsumerWidget {
                     const _VideoCollapseOnlyOverlay(useSafeArea: false),
               ),
             )
-          else
+          else if (isLocalVideo)
             // Claim the chrome viewport during open (ADR-0057) so Video is
             // not unmounted for the whole resolve → open window.
-            const Align(
+            Align(
               alignment: Alignment.topCenter,
-              child: _LocalLoadingVideoStage(),
-            ),
+              child: _LocalLoadingVideoStage(
+                thumbnailUrl: videoRow.value!.thumbnailUrl,
+              ),
+            )
+          else
+            const Center(child: SkeletonAppBootstrap()),
           if (!isYoutube)
             const Align(
               alignment: Alignment.topCenter,
@@ -77,13 +90,19 @@ class ExpandedPlayerLoadingBody extends ConsumerWidget {
 
 /// 16:9 portal target while local / URL [openMedia] is in flight.
 class _LocalLoadingVideoStage extends StatelessWidget {
-  const _LocalLoadingVideoStage();
+  const _LocalLoadingVideoStage({this.thumbnailUrl});
 
   static const double aspectWidth = 16;
   static const double aspectHeight = 9;
 
+  /// Local artwork for the media being opened, shown under the skeleton so
+  /// the open window reads as "this video is loading" instead of a black
+  /// flash.
+  final String? thumbnailUrl;
+
   @override
   Widget build(BuildContext context) {
+    final thumb = localThumbnailFile(thumbnailUrl);
     return SafeArea(
       top: true,
       bottom: false,
@@ -97,9 +116,16 @@ class _LocalLoadingVideoStage extends StatelessWidget {
           // and left ~1s of picture then a black stage until resize.
           id: PlayerSurfaceIds.expandedPlayer,
           overlayBuilder: (_) => const SizedBox.shrink(),
-          child: const ColoredBox(
+          child: ColoredBox(
             color: Colors.black,
-            child: Center(child: SkeletonAppBootstrap()),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (thumb != null)
+                  Image.file(thumb, fit: BoxFit.cover, gaplessPlayback: true),
+                const Center(child: SkeletonAppBootstrap()),
+              ],
+            ),
           ),
         ),
       ),

--- a/test/core/notices/app_notice_test.dart
+++ b/test/core/notices/app_notice_test.dart
@@ -170,5 +170,73 @@ void main() {
         );
       },
     );
+
+    // Regression: an ancestor Scaffold can leak padding.bottom greater than
+    // the physical safe inset into the body MediaQuery (extendBody feeds
+    // max(padding, bottomWidgetHeight)). The notice margin must clamp to
+    // viewPadding so the floating SnackBar can never be taller than the
+    // screen — a SnackBar that cannot fit trips the "Floating SnackBar
+    // presented off screen" layout assert on every frame (frozen UI in
+    // debug builds).
+    testWidgets('clamps leaked bottom padding to the view inset', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(392.7 * 3, 850.9 * 3);
+      tester.view.devicePixelRatio = 3;
+      tester.view.padding = FakeViewPadding(
+        left: 0,
+        top: 72,
+        right: 0,
+        bottom: 102,
+      );
+      tester.view.viewPadding = FakeViewPadding(
+        left: 0,
+        top: 72,
+        right: 0,
+        bottom: 102,
+      );
+      addTearDown(tester.view.reset);
+
+      final messengerKey = GlobalKey<ScaffoldMessengerState>();
+      final scheme = ColorScheme.fromSeed(seedColor: const Color(0xFF7B61FF));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: scheme,
+            extensions: [EnjoyThemeTokens.build(scheme)],
+          ),
+          scaffoldMessengerKey: messengerKey,
+          home: MediaQuery(
+            data: const MediaQueryData(
+              size: Size(392.7, 850.9),
+              padding: EdgeInsets.only(bottom: 850.9),
+              viewPadding: EdgeInsets.only(bottom: 34),
+            ),
+            child: Scaffold(
+              body: Builder(
+                builder: (context) => Center(
+                  child: TextButton(
+                    onPressed: () => AppNotice.success(context, 'clamped'),
+                    child: const Text('show'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('show'));
+      await tester.pump(); // post-frame notice
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+      // 34 (view inset) + 0 (no shell inset here) + 16 (spacing) — not 850.9+.
+      expect(snackBar.margin, const EdgeInsets.fromLTRB(16, 0, 16, 50));
+      final box = tester.renderObject<RenderBox>(find.byType(SnackBar));
+      expect(box.size.height, lessThan(200));
+      expect(tester.takeException(), isNull);
+    });
   });
 }

--- a/test/core/theme/widgets/enjoy_bottom_nav_test.dart
+++ b/test/core/theme/widgets/enjoy_bottom_nav_test.dart
@@ -259,5 +259,75 @@ void main() {
       expect(find.text('Home'), findsOneWidget);
       expect(tester.takeException(), isNull);
     });
+
+    // Regression: the nav's root Align used to expand to the
+    // bottomNavigationBar slot's loose maxHeight (the whole screen). Scaffold
+    // then reported a full-height bottom widget: contentBottom collapsed to 0,
+    // so every floating SnackBar on the shell tripped the "Floating SnackBar
+    // presented off screen" layout assert (which aborts frames in debug and
+    // froze the player-exit transition), and the body MediaQuery leaked
+    // padding.bottom = screen height into AppNotice margins.
+    testWidgets(
+      'in a bottomNavigationBar slot measures intrinsic height, not the screen',
+      (tester) async {
+        tester.view.physicalSize = const Size(392.7 * 3, 850.9 * 3);
+        tester.view.devicePixelRatio = 3;
+        tester.view.padding = FakeViewPadding(
+          left: 0,
+          top: 72,
+          right: 0,
+          bottom: 102,
+        );
+        tester.view.viewPadding = FakeViewPadding(
+          left: 0,
+          top: 72,
+          right: 0,
+          bottom: 102,
+        );
+        addTearDown(tester.view.reset);
+
+        final scheme = ColorScheme.fromSeed(seedColor: const Color(0xFF7B61FF));
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: scheme,
+              useMaterial3: true,
+              extensions: [EnjoyThemeTokens.build(scheme)],
+            ),
+            home: Scaffold(
+              extendBody: true,
+              body: Builder(
+                builder: (context) => Center(
+                  child: Text('pad:${MediaQuery.of(context).padding.bottom}'),
+                ),
+              ),
+              bottomNavigationBar: EnjoyBottomNav(
+                selectedIndex: 0,
+                onDestinationSelected: (_) {},
+                destinations: _sampleDestinations(),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final navBox = tester.renderObject<RenderBox>(
+          find.byType(EnjoyBottomNav),
+        );
+        // Capsule + SafeArea insets — far below the 850.9 logical screen.
+        expect(navBox.size.height, lessThan(200));
+        // extendBody feeds max(padding.bottom, bottomWidgetHeight) into the
+        // body MediaQuery; with an intrinsic nav this stays sane too.
+        expect(
+          double.parse(
+            tester
+                .widget<Text>(find.textContaining('pad:'))
+                .data!
+                .split(':')[1],
+          ),
+          lessThan(200),
+        );
+      },
+    );
   });
 }

--- a/test/features/player/player_collapse_unmount_test.dart
+++ b/test/features/player/player_collapse_unmount_test.dart
@@ -1,0 +1,170 @@
+// Regression test: the collapse (back) control lives inside the player chrome
+// body. clear() nulls the session mid-flight, which rebuilds the player page
+// from the chrome body into the loading placeholder and unmounts the control's
+// context. The route pop must not depend on that context surviving the
+// teardown awaits — otherwise the learner is stranded on the placeholder
+// (only the system back gesture could leave, since the route never popped).
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:enjoy_player/core/window/window_fullscreen_provider.dart';
+import 'package:enjoy_player/features/player/application/player_collapse.dart';
+import 'package:enjoy_player/features/player/application/player_controller.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:enjoy_player/features/vocabulary/application/vocabulary_review_session.dart';
+
+class _RecordingFullscreen extends WindowFullscreen {
+  var setFullscreenCalled = false;
+
+  @override
+  bool build() => false;
+
+  @override
+  Future<void> setFullscreen(bool value) async {
+    setFullscreenCalled = true;
+    state = value;
+  }
+}
+
+PlaybackSession _session() {
+  final now = DateTime.utc(2026, 1, 1);
+  return PlaybackSession(
+    mediaId: 'unmount-media',
+    dexieTargetType: 'Video',
+    mediaType: 'video',
+    mediaTitle: 't',
+    durationSeconds: 10,
+    currentTimeSeconds: 1,
+    currentSegmentIndex: 0,
+    language: 'en',
+    startedAt: now,
+    lastActiveAt: now,
+  );
+}
+
+/// Mirrors ExpandedPlayerScreen: chrome body (with the collapse control)
+/// while a session exists, loading placeholder once clear() nulls it.
+class _PlayerPage extends ConsumerWidget {
+  const _PlayerPage();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final hasSession = ref.watch(
+      playerControllerProvider.select((s) => s != null),
+    );
+    if (!hasSession) {
+      return const Scaffold(body: Center(child: Text('player-placeholder')));
+    }
+    return Scaffold(
+      body: Center(
+        child: Builder(
+          builder: (buttonCtx) => TextButton(
+            // Same shape as _VideoBackButton: context captured from inside
+            // the chrome body subtree that unmounts on session clear.
+            onPressed: () => collapseExpandedPlayer(ref, buttonCtx),
+            child: const Text('collapse'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyVocabSession extends VocabularyReviewSession {
+  @override
+  ReviewSessionState build() => const ReviewSessionState(queue: []);
+}
+
+/// clear() suspends on a real async boundary (position tracker cancel, drift
+/// flush, engine stop) so a frame can interleave and unmount the button —
+/// like the real controller on device.
+class _SlowClearPlayerController extends PlayerController {
+  _SlowClearPlayerController(this._session);
+  PlaybackSession? _session;
+
+  @override
+  PlaybackSession? build() => _session;
+
+  @override
+  Future<void> clear({bool keepVideoSurface = false}) async {
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    _session = null;
+    state = null;
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+
+  @override
+  void abandonPendingOpen() {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'collapse pops the route even when the chrome body unmounts mid-clear',
+    (tester) async {
+      final fullscreen = _RecordingFullscreen();
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const Scaffold(body: Text('home')),
+          ),
+          GoRoute(
+            path: '/player/:mediaId',
+            builder: (_, _) => const _PlayerPage(),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            windowFullscreenProvider.overrideWith(() => fullscreen),
+            playerControllerProvider.overrideWith(
+              () => _SlowClearPlayerController(_session()),
+            ),
+            vocabularyReviewSessionProvider.overrideWith(
+              _EmptyVocabSession.new,
+            ),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      unawaited(router.push('/player/unmount-media'));
+      await tester.pumpAndSettle();
+      expect(find.text('collapse'), findsOneWidget);
+
+      await tester.tap(find.text('collapse'));
+      // Let the interleaved frames run through the slow clear.
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // The chrome body swapped to the placeholder mid-clear…
+      expect(find.text('player-placeholder'), findsOneWidget);
+      // …but the route must still have popped back home.
+      expect(
+        router.state.uri.path,
+        '/',
+        reason:
+            'collapseExpandedPlayer skipped its pop because the calling '
+            'context unmounted while clear() was in flight — the learner is '
+            'stranded on the loading placeholder.',
+      );
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/');
+    },
+  );
+}

--- a/test/features/player/presentation/expanded_player_widgets_test.dart
+++ b/test/features/player/presentation/expanded_player_widgets_test.dart
@@ -7,6 +7,7 @@ import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'package:enjoy_player/features/player/presentation/expanded_player_widgets.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_frosted_back_button.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/player_surface_target.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
@@ -72,8 +73,28 @@ void main() {
   });
 
   testWidgets(
-    'ExpandedPlayerLoadingBody shows the local loading stage for non-YouTube',
+    'ExpandedPlayerLoadingBody shows the local loading stage for a video row',
     (tester) async {
+      final now = DateTime(2026, 1, 1);
+      await db.videoDao.insertRow(
+        VideoRow(
+          id: 'm1',
+          vid: 'vid-1',
+          provider: 'user',
+          title: 'Local video',
+          durationSeconds: 0,
+          language: 'und',
+          source: null,
+          localUri: '/tmp/foo.mp4',
+          bookmarkData: null,
+          md5: 'deadbeef',
+          size: 1024,
+          localMtimeMs: now.millisecondsSinceEpoch,
+          mediaUrl: null,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
       final container = _containerFor(db);
       addTearDown(container.dispose);
       final scheme = ColorScheme.fromSeed(seedColor: Colors.blue);
@@ -84,12 +105,38 @@ void main() {
           child: ExpandedPlayerLoadingBody(colorScheme: scheme, mediaId: 'm1'),
         ),
       );
-      // Two pumps to settle the AsyncValue's loading -> data (null for non-YouTube).
+      // Pumps to settle the preview / row AsyncValues (loading -> data).
+      await tester.pump();
       await tester.pump();
       await tester.pump();
 
-      // Non-YouTube path → PlayerSurfaceTarget for the loading viewport.
+      // Local video → PlayerSurfaceTarget claims the loading viewport.
       expect(find.byType(PlayerSurfaceTarget), findsWidgets);
+    },
+  );
+
+  // Audio has no 16:9 video stage to claim — flashing a black video box
+  // before the audio layout reads as a broken player.
+  testWidgets(
+    'ExpandedPlayerLoadingBody shows no video stage for audio (no video row)',
+    (tester) async {
+      final container = _containerFor(db);
+      addTearDown(container.dispose);
+      final scheme = ColorScheme.fromSeed(seedColor: Colors.blue);
+
+      await tester.pumpWidget(
+        _wrap(
+          container: container,
+          child: ExpandedPlayerLoadingBody(colorScheme: scheme, mediaId: 'a1'),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(PlayerSurfaceTarget), findsNothing);
+      // The collapse control must still be reachable while opening.
+      expect(find.byType(PlayerFrostedBackButton), findsOneWidget);
     },
   );
 

--- a/test/features/player/presentation/root_shell_player_exit_notice_test.dart
+++ b/test/features/player/presentation/root_shell_player_exit_notice_test.dart
@@ -1,0 +1,294 @@
+// Regression test for the player-exit UI freeze.
+//
+// A floating AppNotice alive across a player-route exit used to trip the
+// "Floating SnackBar presented off screen" layout assert on the shell
+// Scaffold: EnjoyBottomNav expanded to the full screen height inside the
+// bottomNavigationBar slot, so the scaffold's contentBottom collapsed to 0
+// and any floating SnackBar was un-fittable. The thrown assert aborts the
+// frame before paint, and with the exit transition + loading skeleton
+// rescheduling frames the UI froze on the player page (black 16:9 stage).
+//
+// This exercises the real RootShell: enter /player/:id with a live session,
+// show a notice, then exit (clear() then pop()) — no snackbar layout error.
+library;
+
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:enjoy_player/core/notices/app_notice.dart';
+import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/auth/domain/user_profile.dart';
+import 'package:enjoy_player/features/discover/application/discover_providers.dart';
+import 'package:enjoy_player/features/player/application/player_controller.dart';
+import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
+import 'package:enjoy_player/features/player/application/player_state_providers.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:enjoy_player/features/player/presentation/root_shell.dart';
+import 'package:enjoy_player/features/subscription/application/subscription_status_provider.dart';
+import 'package:enjoy_player/features/subscription/domain/subscription_status.dart';
+import 'package:enjoy_player/features/sync/application/sync_controller.dart';
+import 'package:enjoy_player/features/transcript/application/all_transcripts_provider.dart';
+import 'package:enjoy_player/features/transcript/application/transcript_blur_mode_provider.dart';
+import 'package:enjoy_player/features/transcript/application/transcript_fetch_controller.dart';
+import 'package:enjoy_player/features/transcript/application/transcript_lines_provider.dart';
+import 'package:enjoy_player/features/transcript/domain/transcript_fetch_status.dart';
+import 'package:enjoy_player/features/transcript/domain/transcript_track.dart';
+import 'package:enjoy_player/features/update/application/update_controller.dart';
+import 'package:enjoy_player/features/vocabulary/application/vocabulary_review_session.dart';
+import 'package:enjoy_player/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../support/fake_player_engine.dart';
+
+const _kMediaId = 'exit-freeze-media';
+
+PlaybackSession _session() {
+  final now = DateTime(2026, 1, 1);
+  return PlaybackSession(
+    mediaId: _kMediaId,
+    dexieTargetType: 'Video',
+    mediaType: 'video',
+    mediaTitle: 'Exit freeze probe',
+    durationSeconds: 120,
+    currentTimeSeconds: 0,
+    currentSegmentIndex: 0,
+    language: 'en',
+    startedAt: now,
+    lastActiveAt: now,
+  );
+}
+
+class _FakeVocabSession extends VocabularyReviewSession {
+  @override
+  ReviewSessionState build() => const ReviewSessionState(queue: []);
+}
+
+class _SessionPlayerController extends PlayerController {
+  _SessionPlayerController(this._session);
+  PlaybackSession? _session;
+
+  @override
+  PlaybackSession? build() => _session;
+
+  @override
+  Future<void> clear({bool keepVideoSurface = false}) async {
+    _session = null;
+    state = null;
+  }
+}
+
+class _BlurModeOff extends TranscriptBlurMode {
+  @override
+  bool build() => false;
+}
+
+class _HomeWithNoticeButton extends StatelessWidget {
+  const _HomeWithNoticeButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Builder(
+          builder: (inner) => TextButton(
+            onPressed: () => AppNotice.success(inner, 'exit probe notice'),
+            child: const Text('show-notice'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Mirrors [collapseExpandedPlayer] ordering: clear() (which nulls the
+/// session) then pop() — the window where the shell flips scaffold variants
+/// while the notice snackbar is still alive.
+class _PlayerPageWithExit extends ConsumerWidget {
+  const _PlayerPageWithExit();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: Center(
+        child: Builder(
+          builder: (inner) => TextButton(
+            onPressed: () async {
+              await ref.read(playerControllerProvider.notifier).clear();
+              if (inner.mounted) inner.pop();
+            },
+            child: const Text('exit-player'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      ShellRoute(
+        builder: (context, state, child) => RootShell(child: child),
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const _HomeWithNoticeButton()),
+          GoRoute(
+            path: '/player/:mediaId',
+            builder: (_, _) => const _PlayerPageWithExit(),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late FakePlayerEngine fakeEngine;
+
+  setUp(() {
+    db = AppDatabase(executor: NativeDatabase.memory());
+    fakeEngine = FakePlayerEngine();
+  });
+
+  tearDown(() async {
+    await db.close();
+    await fakeEngine.dispose();
+  });
+
+  Future<void> pumpShell(
+    WidgetTester tester, {
+    required GoRouter router,
+    required List<Override> overrides,
+  }) async {
+    // Consistent view metrics (logical 392.7x850.9 @ dpr 3, gesture-inset
+    // bottom) — a mismatched setSurfaceSize desyncs MediaQuery.fromView.
+    tester.view.physicalSize = const Size(392.7 * 3, 850.9 * 3);
+    tester.view.devicePixelRatio = 3;
+    tester.view.padding = const FakeViewPadding(
+      left: 0,
+      top: 72,
+      right: 0,
+      bottom: 102,
+    );
+    tester.view.viewPadding = const FakeViewPadding(
+      left: 0,
+      top: 72,
+      right: 0,
+      bottom: 102,
+    );
+    addTearDown(tester.view.reset);
+
+    final scheme = ColorScheme.fromSeed(seedColor: const Color(0xFF7B61FF));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: overrides,
+        child: MaterialApp.router(
+          scaffoldMessengerKey: appScaffoldMessengerKey,
+          theme: ThemeData(
+            colorScheme: scheme,
+            extensions: [EnjoyThemeTokens.build(scheme)],
+          ),
+          locale: const Locale('en', 'US'),
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  testWidgets(
+    'notice alive across player exit never trips the floating snackbar assert',
+    (tester) async {
+      final errors = <FlutterErrorDetails>[];
+      final original = FlutterError.onError;
+      FlutterError.onError = errors.add;
+      addTearDown(() => FlutterError.onError = original);
+
+      final session = _session();
+      final overrides = <Override>[
+        appDatabaseProvider.overrideWithValue(db),
+        deviceGlobalAppDatabaseProvider.overrideWithValue(db),
+        syncCtrlProvider.overrideWithValue(0),
+        discoverFeedRefreshSchedulerProvider.overrideWithValue(0),
+        updateAvailableBadgeProvider.overrideWithValue(false),
+        subscriptionStatusProvider.overrideWith(
+          (ref) async => const SubscriptionStatus(
+            subscriptionActive: false,
+            subscriptionTier: SubscriptionTier.free,
+          ),
+        ),
+        vocabularyReviewSessionProvider.overrideWith(_FakeVocabSession.new),
+        playerEngineTestDoubleProvider.overrideWithValue(fakeEngine),
+        playerControllerProvider.overrideWith(
+          () => _SessionPlayerController(session),
+        ),
+        transcriptHasLinesForMediaProvider(
+          session.mediaId,
+        ).overrideWith((ref) => Stream.value(false)),
+        playerIsPlayingProvider.overrideWith((ref) => Stream.value(false)),
+        playerIsBufferingProvider.overrideWith((ref) => Stream.value(false)),
+        allTranscriptsForMediaProvider(
+          session.mediaId,
+        ).overrideWith((ref) => Stream.value(const <TranscriptTrack>[])),
+        transcriptFetchCtrlProvider(session.mediaId).overrideWithValue(
+          const TranscriptFetchUiState(status: TranscriptFetchStatus.idle),
+        ),
+        transcriptBlurModeProvider.overrideWith(_BlurModeOff.new),
+      ];
+
+      final router = _router();
+      addTearDown(router.dispose);
+      await pumpShell(tester, router: router, overrides: overrides);
+
+      // A notice is shown on the home shell and stays alive (3s duration).
+      await tester.tap(find.text('show-notice'));
+      await tester.pump(); // notice post-frame callback
+      await tester.pump(const Duration(milliseconds: 250)); // entrance
+
+      // Enter the player, then exit while the notice is still presented.
+      unawaited(router.push('/player/$_kMediaId'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('exit-player'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300)); // reverse fade
+
+      final offScreen = errors.where(
+        (e) => '${e.exception}'.contains('Floating SnackBar'),
+      );
+      expect(
+        offScreen,
+        isEmpty,
+        reason:
+            'A floating notice must stay fittable while the shell flips '
+            'scaffold variants during player exit; the layout assert aborts '
+            'frames in debug and freezes the screen.',
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text('exit probe notice'), findsOneWidget);
+
+      // The notice must also be on screen, not just error-free.
+      final box = tester.renderObject<RenderBox>(find.byType(SnackBar));
+      expect(box.localToGlobal(Offset.zero).dy, greaterThanOrEqualTo(0));
+      expect(router.routerDelegate.currentConfiguration.uri.path, '/');
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Fixes three connected player exit/entry bugs, two reported on Android debug builds:

### 1. Back button strands the screen on the player placeholder (primary)

Tapping the player's back control left the app on the loading placeholder (black 16:9 stage on top, blank below), fully responsive — only the system back gesture could leave. The pop wasn't hung; it was **silently skipped**:

- `collapseExpandedPlayer` ended with `if (context.mounted) context.pop()` **after** `await clear()`.
- `clear()` nulls the session mid-flight → `ExpandedPlayerScreen` rebuilds from the chrome body into the loading placeholder, and the permanent surface overlay that hosts the collapse control swaps its `overlayBuilder` (→ `SizedBox.shrink`).
- The calling context deactivates mid-await → `context.mounted` is false → pop skipped. Surfaced after d55b7381 made the collapse control always visible during playback.

**Fix:** pop **before** the teardown awaits, guarded by a "still on `/player/`" path check (no double-pop on a second tap during the exit transition). Bonus: the chrome body now stays mounted through the reverse transition, so exiting no longer flashes the placeholder at all.

### 2. Placeholder flash on every player entry

The loading body claimed a 16:9 black video stage for **every** media kind:

- **Audio** has no video surface to claim (the audio layout mounts no `PlayerSurfaceTarget`) → now shows only the skeleton + collapse chevron.
- **Local video** now shows its thumbnail behind the skeleton (same pattern as the YouTube poster stage) instead of flat black.

### 3. `Floating SnackBar presented off screen` layout aborts

The bottom nav's root `Align` expanded to the **full screen height** inside the `bottomNavigationBar` slot (verified: `navSize = 392.7×850.9`). Scaffold then reported a full-height bottom widget:

- `contentBottom` collapsed to `0` → every floating SnackBar on the shell was un-fittable → the SDK assert throws inside `_ScaffoldLayout.performLayout` → **the frame aborts before paint in debug**; with transitions/skeletons rescheduling frames, the UI froze on the player placeholder (the original report).
- `MediaQuery.padding.bottom` leaked the full screen height under the shell body (extendBody feeds `max(padding, bottomWidgetsHeight)`), making `AppNotice` margins taller than the screen.

**Fix:** size the nav to its capsule (`heightFactor: 1`), and defensively clamp `AppNotice`'s bottom pad to `viewPadding`.

## Tests

- `player_collapse_unmount_test.dart` — new: chrome body swaps to the placeholder mid-clear with async boundaries in `clear()`; asserts the route still pops (failed before the fix).
- `root_shell_player_exit_notice_test.dart` — new: end-to-end against the real `RootShell`; notice alive across a player exit must not trip the floating-snackbar assert (5 errors before, 0 after).
- `enjoy_bottom_nav_test.dart` — new: nav measures intrinsic height in the slot; body `padding.bottom` stays sane.
- `app_notice_test.dart` — new: leaked bottom padding clamps to the view inset.
- `expanded_player_widgets_test.dart` — updated: video row → stage present; audio → no stage, back button still reachable.

## Verification

- Full `test/features/player/` suite: 606 passing
- `test/core/` + `test/features/player/presentation/`: 753 passing; routing + hotkeys: 313 passing
- `flutter analyze` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)