### PR TITLE
fix(player): gate Linux YouTube open before engine swap; bound engine.open

### DIFF
--- a/docs/features/linux-platform.md
+++ b/docs/features/linux-platform.md
@@ -99,6 +99,8 @@ Performance budgets for playback, scrolling, and transcript rendering are identi
 
 This is expected. YouTube will be enabled in a future release. The notice replaces the player screen (with a back button) and the YouTube sign-in screen. In the meantime, download the video locally (e.g., with `yt-dlp`) and import the local file — the transcript and everything else work.
 
+The open fails **before any engine swap**: a YouTube open never installs the WebView engine and never disposes the running `media_kit` engine, so audio/video playback opened afterwards keeps working (the 2026-08-29 regression briefly left every later open stuck on the loading skeleton after a failed YouTube open). Local/URL opens are additionally bounded by a 30 s `engine.open` timeout that surfaces a wedged native layer as an open failure instead of an infinite spinner.
+
 ### AppImage won't run: "Permission denied"
 
 Run `chmod +x enjoy-player-*.AppImage` first.

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -133,11 +133,10 @@ class YoutubePlayerEngine implements PlayerEngine {
   Future<void> open(PlayableSource source) async {
     if (youTubeEngineOptedOutHere) {
       // Typed so the player surface can show the ADR-0048 "coming soon"
-      // message instead of the generic open-failure body.
-      throw const YouTubePlaybackUnavailableException(
-        'YouTube is not yet available on Linux — coming soon '
-        '(ADR-0048, R1 / R6: webview2gtk-4.0 dependency).',
-      );
+      // message instead of the generic open-failure body. The open
+      // coordinator gates Linux YouTube opens before any engine swap; this
+      // guard is defense in depth.
+      throw const YouTubePlaybackUnavailableException.linuxOptedOut();
     }
     if (source is! YoutubePlayableSource) {
       throw UnsupportedError(

--- a/lib/features/player/application/player_engine_binding.dart
+++ b/lib/features/player/application/player_engine_binding.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:enjoy_player/core/platform/linux_platform_availability.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
@@ -39,6 +40,15 @@ Future<void> ensureEngineForPlayableSource(
   final wantYt = playable is YoutubePlayableSource;
   final owned = getOwnedEngine();
   final haveYt = owned?.supportsYouTubePlayback ?? false;
+
+  // ADR-0048 defense in depth: no WebView backend exists on opted-out
+  // platforms, so a YouTube engine can never mount. Installing one would
+  // dispose the live MediaKit engine (and its native mpv player) for
+  // nothing — the 2026-08-29 field report traced every later audio open
+  // hanging on the loading skeleton back to exactly that swap. The open
+  // coordinator gates YouTube opens before this call; callers that open the
+  // source anyway fail with the typed unavailable exception.
+  if (wantYt && youTubeEngineOptedOutHere) return;
 
   if (owned != null && haveYt == wantYt) return;
   if (currentOpenGeneration() != openGeneration) return;

--- a/lib/features/player/application/player_engine_constants.dart
+++ b/lib/features/player/application/player_engine_constants.dart
@@ -21,3 +21,13 @@ const double kVideoTextureKickMinViewportDelta = 32;
 
 /// Temporary inset applied for one frame to force a Texture present.
 const double kVideoTextureKickInset = 1;
+
+/// Ceiling for [PlayerEngine.open] before the open fails with a timeout.
+///
+/// `media_kit`'s `open` completes on the mpv `loadlist` command ACK (not on
+/// buffering), so even slow network sources settle far below this. The bound
+/// exists for the wedge class where the native event pump stops delivering
+/// events: without it `openMedia` awaits forever and the player screen shows
+/// the loading skeleton indefinitely (issue: YouTube open on Linux wedged
+/// every later audio open — 2026-08-29 field report).
+const Duration kEngineOpenTimeout = Duration(seconds: 30);

--- a/lib/features/player/application/player_open_coordinator.dart
+++ b/lib/features/player/application/player_open_coordinator.dart
@@ -6,11 +6,14 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/core/platform/linux_platform_availability.dart';
 import 'package:enjoy_player/core/utils/remote_thumbnail_url.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
 import 'package:enjoy_player/features/library/domain/media.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
+import 'package:enjoy_player/features/player/application/player_controller.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/player_engine_constants.dart';
 import 'package:enjoy_player/features/player/application/playback_open_resolver.dart';
 import 'package:enjoy_player/features/player/application/player_engine_binding.dart';
 import 'package:enjoy_player/features/player/application/player_open_side_effects.dart';
@@ -21,6 +24,7 @@ import 'package:enjoy_player/features/player/domain/media_relocate_exception.dar
 import 'package:enjoy_player/features/player/domain/open_media_options.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:enjoy_player/features/player/domain/youtube_playback_unavailable_exception.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_blur_mode_provider.dart';
 
 final _openLog = logNamed('PlayerOpenCoordinator');
@@ -42,6 +46,7 @@ Future<void> runPlayerOpen(
   Ref ref,
   String mediaId, {
   OpenMediaOptions options = OpenMediaOptions.defaults,
+  Duration openTimeout = kEngineOpenTimeout,
 }) async {
   final gen = host.openGeneration;
 
@@ -60,6 +65,17 @@ Future<void> runPlayerOpen(
   final dexie = resolved.dexieTargetType;
   final title = resolved.title;
   final playable = resolved.playable;
+
+  // ADR-0048: Linux has no YouTube WebView backend, so the open can never
+  // proceed. Fail with the typed exception BEFORE any engine swap — the
+  // swap would dispose the live MediaKit engine (and its native mpv
+  // player) to install a YouTube engine that can never mount, and after it
+  // every later local/URL open rebuilds MediaKit against a wedged native
+  // event pump: `engine.open` never completes and the player screen stays
+  // on the loading skeleton forever (2026-08-29 field report).
+  if (playable is YoutubePlayableSource && youTubeEngineOptedOutHere) {
+    throw const YouTubePlaybackUnavailableException.linuxOptedOut();
+  }
 
   schedulePlayerOpenSideEffects(
     ref,
@@ -99,7 +115,21 @@ Future<void> runPlayerOpen(
 
   await host.positionTracker.cancel();
 
-  await engine.open(playable);
+  try {
+    await engine.open(playable).timeout(openTimeout);
+  } on TimeoutException {
+    // The native event pump can stop delivering events (wedged mpv). Without
+    // this bound the await — and therefore openMedia and the loading screen —
+    // hangs forever. Bump the generation so everything still in flight for
+    // this open (side effects, tracker) observes a stale generation, and the
+    // engine left half-open cannot leak state into the next open's checks.
+    _openLog.severe(
+      'engine.open timed out after $openTimeout for media $mediaId '
+      '(${engine.runtimeType}); invalidating open generation',
+    );
+    ref.read(playerControllerProvider.notifier).abandonPendingOpen();
+    rethrow;
+  }
   if (host.isOpenStale(gen)) {
     try {
       await engine.stop();

--- a/lib/features/player/domain/youtube_playback_unavailable_exception.dart
+++ b/lib/features/player/domain/youtube_playback_unavailable_exception.dart
@@ -8,6 +8,14 @@ library;
 class YouTubePlaybackUnavailableException implements Exception {
   const YouTubePlaybackUnavailableException(this.message);
 
+  /// The canonical ADR-0048 opt-out failure, shared by the open coordinator's
+  /// pre-swap gate and [YoutubePlayerEngine.open]'s own guard so the two
+  /// cannot drift.
+  const YouTubePlaybackUnavailableException.linuxOptedOut()
+    : message =
+          'YouTube is not yet available on Linux — coming soon '
+          '(ADR-0048, R1 / R6: webview2gtk-4.0 dependency).';
+
   /// Human-readable description (already safe to log).
   final String message;
 

--- a/test/features/player/application/player_engine_binding_test.dart
+++ b/test/features/player/application/player_engine_binding_test.dart
@@ -3,6 +3,8 @@ import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_engine_binding.dart';
 import 'package:enjoy_player/features/player/application/player_engine_rev.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride, TargetPlatform;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -96,6 +98,42 @@ void main() {
       expect(container.read(playerEngineRevProvider), revBefore + 1);
 
       await owned?.dispose();
+    },
+  );
+
+  test(
+    'opted-out Linux never swaps the live MediaKit engine for YouTube',
+    () async {
+      // 2026-08-29 field report regression guard: the Linux YouTube open used
+      // to swap in YoutubePlayerEngine (disposing the live MediaKit/mpv
+      // player); the open then threw, and every later audio open rebuilt
+      // MediaKit against a wedged native layer — infinite loading. The open
+      // coordinator now gates before this call; the binding itself must stay
+      // a no-op for YouTube sources on opted-out platforms as well.
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final ref = _refOf(container);
+
+      final existing = MediaKitPlayerEngine();
+      addTearDown(existing.dispose);
+      PlayerEngine? owned = existing;
+      var gen = 1;
+      final revBefore = container.read(playerEngineRevProvider);
+
+      await ensureEngineForPlayableSource(
+        ref,
+        playable: const YoutubePlayableSource('dQw4w9WgXcQ'),
+        openGeneration: gen,
+        currentOpenGeneration: () => gen,
+        getOwnedEngine: () => owned,
+        setOwnedEngine: (next) => owned = next,
+      );
+
+      expect(owned, same(existing));
+      expect(container.read(playerEngineRevProvider), revBefore);
     },
   );
 }

--- a/test/features/player/application/player_open_coordinator_test.dart
+++ b/test/features/player/application/player_open_coordinator_test.dart
@@ -1,0 +1,170 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/player/application/player_controller.dart';
+import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
+import 'package:enjoy_player/features/player/application/player_open_coordinator.dart';
+import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:enjoy_player/features/transcript/application/transcript_repository_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../../../support/fake_player_engine.dart';
+import '../../../support/test_path_provider.dart';
+
+/// Minimal [PlayerOpenHost] driving [runPlayerOpen] without the controller.
+class _Host implements PlayerOpenHost {
+  _Host(this.ref, this.engine);
+
+  final Ref ref;
+  final PlayerEngine engine;
+
+  @override
+  int openGeneration = 1;
+
+  @override
+  bool isOpenStale(int gen) => gen != openGeneration;
+
+  @override
+  PlayerEngine get activeEngine => engine;
+
+  PlayerEngine? _ownedEngine;
+
+  @override
+  PlayerEngine? get ownedEngine => _ownedEngine;
+
+  @override
+  set ownedEngine(PlayerEngine? engine) => _ownedEngine = engine;
+
+  @override
+  PlaybackSession? session;
+
+  @override
+  PlayerPositionTracker get positionTracker => PlayerPositionTracker(
+    ref: ref,
+    getEngine: () => engine,
+    getSession: () => session,
+    setSession: (next) => session = next,
+    currentOpenGeneration: () => openGeneration,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('runPlayerOpen engine.open timeout', () {
+    late AppDatabase db;
+    late FakePlayerEngine fake;
+    late ProviderContainer container;
+    late PathProviderPlatform originalPathProvider;
+
+    setUp(() async {
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = TestPathProvider(
+        Directory.systemTemp.createTempSync('enjoy_player_open_coord').path,
+      );
+      db = AppDatabase(executor: NativeDatabase.memory());
+      fake = FakePlayerEngine();
+      container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          playerEngineTestDoubleProvider.overrideWithValue(fake),
+          transcriptRepositoryProvider.overrideWithValue(
+            TranscriptRepository(db),
+          ),
+        ],
+      );
+
+      final now = DateTime.now();
+      final file = File(
+        p.join(
+          Directory.systemTemp.path,
+          'enjoy_open_coord_${DateTime.now().microsecondsSinceEpoch}.mp3',
+        ),
+      );
+      await file.writeAsBytes([1]);
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+      await db.audioDao.insertRow(
+        AudioRow(
+          id: 'hang-1',
+          aid: 'x',
+          provider: 'user',
+          title: 't',
+          description: null,
+          thumbnailUrl: null,
+          durationSeconds: 600,
+          language: 'en',
+          translationKey: null,
+          sourceText: null,
+          voice: null,
+          source: null,
+          localUri: Uri.file(file.path).toString(),
+          md5: null,
+          size: 1,
+          mediaUrl: null,
+          syncStatus: null,
+          serverUpdatedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      await pumpEventQueue();
+      container.dispose();
+      await db.close();
+      await fake.dispose();
+    });
+
+    test('a wedged engine.open fails with TimeoutException instead of hanging, '
+        'and invalidates the open generation', () async {
+      final hang = Completer<void>();
+      fake.openDelay = () => hang.future;
+
+      final host = _Host(_refOf(container), fake);
+      final controller = container.read(playerControllerProvider.notifier);
+      final genBefore = controller.openGeneration;
+
+      await expectLater(
+        runPlayerOpen(
+          host,
+          _refOf(container),
+          'hang-1',
+          openTimeout: const Duration(milliseconds: 50),
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      expect(host.session, isNull);
+      // The zombie open's continuation must be stale at its next check.
+      expect(controller.openGeneration, greaterThan(genBefore));
+
+      // Releasing the wedged open later must not publish a session.
+      hang.complete();
+      await pumpEventQueue();
+      expect(host.session, isNull);
+    });
+  });
+}
+
+Ref _refOf(ProviderContainer container) {
+  late Ref captured;
+  container.read(
+    Provider<int>((ref) {
+      captured = ref;
+      return 0;
+    }),
+  );
+  return captured;
+}

--- a/test/features/player/player_controller_test.dart
+++ b/test/features/player/player_controller_test.dart
@@ -13,6 +13,7 @@ import 'package:enjoy_player/features/player/application/player_engine_test_doub
 import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
 import 'package:enjoy_player/features/player/domain/media_relocate_exception.dart';
 import 'package:enjoy_player/features/player/domain/player_settings.dart';
+import 'package:enjoy_player/features/player/domain/youtube_playback_unavailable_exception.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_repository_provider.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride, TargetPlatform;
@@ -608,6 +609,62 @@ void main() {
       expect(container.read(playerControllerProvider), isNull);
       expect(fake.stopCallCount, greaterThan(0));
     });
+
+    test(
+      'Linux YouTube open throws typed unavailable, keeps engines untouched, '
+      'and later audio still opens (ADR-0048 regression)',
+      () async {
+        // 2026-08-29 field report: opening a YouTube item on Linux swapped the
+        // live MediaKit engine for a YouTube engine that can never mount and
+        // threw; every later audio open then rebuilt MediaKit against the
+        // wedged native mpv layer and stayed on the loading skeleton forever.
+        // The gate must fail the open BEFORE any engine swap.
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        final now = DateTime.now();
+        await db.videoDao.insertRow(
+          VideoRow(
+            id: 'yt-linux-1',
+            vid: 'dQw4w9WgXcQ',
+            provider: 'youtube',
+            title: 'YouTube on Linux',
+            description: null,
+            thumbnailUrl: null,
+            durationSeconds: 212,
+            language: 'en',
+            source: 'youtube',
+            localUri: null,
+            md5: null,
+            size: null,
+            mediaUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            syncStatus: null,
+            serverUpdatedAt: null,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+        final audioId = await insertMedia(id: 'audio-after-yt');
+
+        final n = container.read(playerControllerProvider.notifier);
+        final revBefore = container.read(playerEngineRevProvider);
+
+        await expectLater(
+          n.openMedia('yt-linux-1'),
+          throwsA(isA<YouTubePlaybackUnavailableException>()),
+        );
+
+        // No engine was installed or swapped for the failed YouTube open.
+        expect(n.ownedEngine, isNull);
+        expect(container.read(playerEngineRevProvider), revBefore);
+        expect(fake.openUris, isEmpty);
+
+        // The follow-up local open must still succeed — the regression that
+        // stranded the learner on the loading skeleton.
+        await n.openMedia(audioId);
+        expect(container.read(playerControllerProvider)?.mediaId, audioId);
+        expect(fake.openUris, isNotEmpty);
+      },
+    );
 
     test('clear retains YoutubePlayerEngine without rev bump', () async {
       Future<String> insertYoutube({required String id}) async {


### PR DESCRIPTION
## Symptom (Linux, 2026-08-29 field report)

1. Open audio A → works. Exit, open audio B → works.
2. Exit, open a YouTube video → "not available" notice (expected, ADR-0048).
3. Exit, open audio A → **stuck on loading forever**. Audio B → stuck.
4. Open the YouTube video again → shows only the cover preview (the YouTube loading stage), no notice.

## Root cause

The Linux opt-out gated WebView mounting and `YoutubePlayerEngine.open`, but the open coordinator still ran the engine **binding first**:

- `ensureEngineForPlayableSource` swapped the live `MediaKitPlayerEngine` for a `YoutubePlayerEngine` that can never mount on Linux, **disposing the working native mpv player** — the runtime log shows this happened 4× per YouTube open attempt.
- After the swap, media_kit's native event pump was wedged process-wide. Verified live via the VM service on the wedged session: a **brand-new** engine's `player.open()` never completed and player state stayed `0ms / not playing / not buffering` forever (mpv threads alive, no events delivered).
- So every later `openMedia` awaited `engine.open` forever, never published a session, and `ExpandedPlayerScreen` stayed on its loading skeleton. For YouTube items that skeleton is the cover-preview stage, which explains step 4.

A standalone `Player() → open → dispose → Player() → open` cycle is clean, so the wedge requires the Flutter/texture context of the in-app engine swap — but either way, the app must never dispose its only working player for an open that cannot proceed.

## Fix

- `runPlayerOpen` throws the typed `YouTubePlaybackUnavailableException` **before any engine swap** on opted-out platforms — same "coming soon" UI as before, no engine churn.
- `ensureEngineForPlayableSource` refuses to install a YouTube engine when opted out (defense in depth).
- `engine.open` is bounded by `kEngineOpenTimeout` (30 s); a timeout invalidates the open generation and surfaces as an open failure instead of an infinite spinner for any future native wedge.
- Shared `YouTubePlaybackUnavailableException.linuxOptedOut()` keeps both guards in sync.

## Tests

- Controller regression: Linux YouTube open → typed throw, no engine installed, rev untouched, and a later audio open still publishes a session.
- Binding: opted-out Linux never swaps the live MediaKit engine for YouTube.
- Coordinator: a wedged `engine.open` fails with `TimeoutException`, invalidates the generation, and never publishes a session.

`flutter analyze` clean, full `flutter test` green (5747 passed), `validate_ci_gates.sh` passes. Docs updated (`docs/features/linux-platform.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)