### PR TITLE
feat(craft): remember style/voice/mode preferences; seed languages from profile

### DIFF
--- a/docs/features/craft.md
+++ b/docs/features/craft.md
@@ -25,6 +25,21 @@ Flows as a full-screen route; back returns to wherever the user came from.
 
 **Branding**: "Craft" is kept as an untranslated brand term in the Chinese locale (`craftScreenTitle` / `homeCraftAction` both render `"Craft"` in `app_zh.arb`), matching the existing `importCraftFromText` → `"Craft…"` convention — it is not translated to a Chinese word.
 
+### Remembered preferences
+
+Craft choices persist across sessions so learners don't re-pick them every time. `CraftPreferencesCtrl` (keepAlive, per-user) stores a JSON blob under the Drift settings key `craft.preferences_v1` (`SettingsKeys.craftPreferencesV1`):
+
+| Persisted | Notes |
+|-----------|-------|
+| Last screen mode | Express / Advanced — reopening Craft restores it |
+| Translation style **per mode** | `expressStyle` (first-run default `auto`) and `advancedStyle` (first-run default `natural`) |
+| Custom prompt | Remembered alongside the style it belongs to |
+| Voice **per base language** | Map like `{'en': 'en-US-GuyNeural'}`; entries validate against `kAzureVoices` on load and are dropped if the catalog changed |
+
+Deliberately **not** persisted: the language pair. It always re-seeds from the learner's profile settings on entry — `CraftController.build()` reads `AppPreferencesCtrl.effectiveNativeLanguage` / `effectiveLearningLanguage` synchronously (so the Express idle pill never renders the `—` placeholder), and the lazy per-widget seeding that used to live in `CaptureStage._startRecording` / `TranslateTool.initState` is gone.
+
+Sign-in semantics mirror `AppPreferencesCtrl`: the blob lives in the per-user DB, so reads/writes are skipped while signed out (translate still works; choices are session-only). `CraftController` setters write through to the prefs controller but never persist on programmatic restores — `loadForEdit` prefills an item's own values via `copyWith` and does not touch the blob. A late hydration never clobbers user input: every user-intent setter latches `_prefsHydrationMutated`, and hydration is skipped while an edit-from-history restore is in flight.
+
 ### Craft history (`/craft/history`)
 
 An in-app-bar history `IconButton` (tooltip `craftHistoryTooltip`) on the Craft screen opens `CraftHistoryScreen`, which lists every media item where `Audios.provider == 'craft'`, newest-updated first (`craftHistoryProvider` — a thin `StreamProvider` over the existing `mediaLibraryRepositoryProvider.watchAll()`, no new query or schema). Empty state uses `craftHistoryEmptyTitle` / `craftHistoryEmptyHint` / `craftHistoryEmptyAction`.
@@ -56,7 +71,7 @@ A linear three-stage pipeline (`CraftStage` enum: `capture` → `rewrite` → `a
 
 - **Editable native transcript card** (labelled "Your words") — STT / typed source is a `TextField` so learners can correct recognition errors; edits write to `rawTranscript` (+ synced `sourceText`). When the native text differs from the last successful rewrite input (`isRawTranscriptDirty`), a **Re-translate** action appears on the card (`craftReTranslateButton`)
 - **Editable target text card** (labelled "In [target]…") — `TextEditingController` synced to `state.translatedText` only when the field is not focused, so user edits are preserved across regenerations; field is height-capped (`maxLines: 10`) to avoid layout overflow
-- **Options panel** — always-visible `StylePicker` + Azure Neural `VoicePicker` before Generate; style defaults to **Auto**; voice defaults via `defaultVoiceForLanguage` when unset
+- **Options panel** — always-visible `StylePicker` + Azure Neural `VoicePicker` before Generate; style starts from the remembered Express style (**Auto** on first run); voice from the remembered per-language pick, falling back via `defaultVoiceForLanguage` when unset
 - Re-translate / Regenerate keep the form visible with inline progress when a target already exists (full-screen "Crafting…" spinner only for the first rewrite)
 - Three action buttons:
   - **Regenerate** → `controller.regenerate()` — re-runs the LLM rewrite on the current native transcript with the current style (same path as Re-translate; no-op if below `craftMinTextLength`)
@@ -77,7 +92,7 @@ A new `TranslationStyle.auto` is the **default** for Express mode. Instead of a 
 - **Unsaved hint** — when `hasUnsavedPreview` is true, an inline callout (`craftAudioUnsavedHint`) reminds the learner that TTS bytes are in memory only until a save CTA runs
 - Two save CTAs (labels make persistence explicit):
   - **Save & practice** (`saveAndPractice`) — primary `EnjoyButton`; saves and navigates to the player route with the new media ID
-  - **Save & say another** (`saveAndCaptureNext`) — outlined secondary; saves to library, shows a snackbar confirmation ("Saved to library"), then resets to the capture stage while preserving session preferences (language pair, style, voice). This is the **rapid-capture loop** for building a personal library in quick succession.
+  - **Save & say another** (`saveAndCaptureNext`) — outlined secondary; saves to library, shows a snackbar confirmation ("Saved to library"), then resets to the capture stage while preserving the language pair, style, and voice (remembered across sessions — see [Remembered preferences](#remembered-preferences)). This is the **rapid-capture loop** for building a personal library in quick succession.
 - **Leave / mode-switch guard** — `CraftScreen` blocks system back and the mode segmented control while `hasUnsavedPreview` (or while capturing). Confirming discard (`confirmDiscardUnsavedCraftPreview`) drops the in-memory preview; cancel keeps the learner on the audio stage. Preview is never written to SQLite until `saveToLibrary` succeeds.
 
 ### Failure handling in Express stages
@@ -239,8 +254,8 @@ No `isWide` width calculations or ad-hoc max widths live in Craft widgets — al
 
 | Layer | Key files |
 |-------|----------|
-| **Domain** | `craft_mode.dart`, `craft_screen_mode.dart`, `craft_stage.dart`, `craft_transcriber.dart`, `craft_failure.dart`, `craft_request.dart`, `craft_job_state.dart`, `craft_job_status.dart`, `craft_translator.dart`, `craft_synthesizer.dart`, `azure_voice.dart`, `translation_style.dart`, `word_boundary_segmenter.dart`, `transcript_timestamp_estimator.dart`, `wav_duration.dart` |
-| **Application** | `craft_controller.dart`, `craft_history_provider.dart` |
+| **Domain** | `craft_mode.dart`, `craft_screen_mode.dart`, `craft_stage.dart`, `craft_transcriber.dart`, `craft_failure.dart`, `craft_request.dart`, `craft_job_state.dart`, `craft_job_status.dart`, `craft_preferences.dart`, `craft_translator.dart`, `craft_synthesizer.dart`, `azure_voice.dart`, `translation_style.dart`, `word_boundary_segmenter.dart`, `transcript_timestamp_estimator.dart`, `wav_duration.dart` |
+| **Application** | `craft_controller.dart`, `craft_preferences_provider.dart`, `craft_history_provider.dart` |
 | **Data** | `craft_translation_service_translator.dart`, `craft_tts_service_synthesizer.dart`, `craft_asr_service_transcriber.dart` |
 | **Presentation** | `craft_screen.dart`, `craft_history_screen.dart`, `express_flow.dart`, `capture_stage.dart`, `rewrite_stage.dart`, `audio_stage.dart`, `advanced_tools.dart`, `translate_tool.dart`, `synthesize_tool.dart`, `voice_picker.dart`, `style_picker.dart` |
 | **Integration** | `LibraryRepository.importCraftedFromText()`, `getCraftEditSource()`, `updateCraftedFromText()` (library data layer); `CraftEditSource` (library domain layer) |

--- a/lib/data/db/settings_keys.dart
+++ b/lib/data/db/settings_keys.dart
@@ -68,6 +68,10 @@ abstract final class SettingsKeys {
   /// JSON blob: volume, rate, repeat, split width ([PlayerPreferencesCtrl]).
   static const String playerPreferencesV1 = 'player_preferences_v1';
 
+  /// JSON blob: remembered Craft options — screen mode, per-mode translation
+  /// style, custom prompt, per-language voice map ([CraftPreferencesCtrl]).
+  static const String craftPreferencesV1 = 'craft.preferences_v1';
+
   /// JSON map of custom hotkey action id → binding string.
   static const String hotkeysCustomBindings = 'hotkeys_custom_bindings';
 
@@ -114,6 +118,7 @@ abstract final class SettingsKeys {
     transcriptKaraokeHighlight,
     transcriptIpaOverlay,
     playerPreferencesV1,
+    craftPreferencesV1,
     hotkeysCustomBindings,
     aiModalityConfigsV1,
     youtubeClientProfilesV1,

--- a/lib/features/craft/application/craft_controller.dart
+++ b/lib/features/craft/application/craft_controller.dart
@@ -6,6 +6,8 @@ import 'dart:typed_data';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:enjoy_player/core/application/app_language_catalog.dart';
+import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/errors/app_failure.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/core/riverpod/async_value_x.dart';
@@ -18,6 +20,7 @@ import 'package:enjoy_player/features/craft/data/craft_asr_service_transcriber.d
 import 'package:enjoy_player/features/craft/data/craft_translation_service_translator.dart';
 import 'package:enjoy_player/features/craft/data/craft_tts_service_synthesizer.dart';
 import 'package:enjoy_player/features/craft/application/craft_library_repository_provider.dart';
+import 'package:enjoy_player/features/craft/application/craft_preferences_provider.dart';
 import 'package:enjoy_player/features/craft/application/craft_timeline_enricher.dart';
 import 'package:enjoy_player/features/craft/domain/azure_voice.dart';
 import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
@@ -50,8 +53,55 @@ final craftTranscriberProvider = Provider<CraftTranscriber>((ref) {
 
 /// Two-tool Craft controller for the full-screen Craft route.
 class CraftController extends Notifier<CraftJobState> {
+  /// Set by every user-intent setter so a late preference hydration never
+  /// clobbers choices the user already made this session.
+  bool _prefsHydrationMutated = false;
+
   @override
-  CraftJobState build() => const CraftJobState();
+  CraftJobState build() {
+    _prefsHydrationMutated = false;
+    // Seed the language pair synchronously from the learner's profile
+    // settings so the Express idle screen never renders '—'. The router
+    // gates on prefs having data, so valueOrNull is resolved in practice;
+    // 'en' is the cold-start fallback.
+    final prefs = ref.read(appPreferencesCtrlProvider).valueOrNull;
+    final native = canonicalMediaLanguageTag(
+      prefs?.effectiveNativeLanguage ?? 'en',
+    );
+    final learn = canonicalMediaLanguageTag(
+      prefs?.effectiveLearningLanguage ?? 'en',
+    );
+    unawaited(Future<void>.microtask(_hydrateFromPreferences));
+    return const CraftJobState().copyWith(
+      sourceLanguage: native,
+      targetLanguage: learn,
+    );
+  }
+
+  /// Overlay persisted craft preferences (mode / per-mode style / prompt /
+  /// remembered voice). Skipped when the user already interacted (their
+  /// setters write through) or when an edit-from-history restore is in
+  /// flight ([loadForEdit] sets fields directly and must not be clobbered).
+  Future<void> _hydrateFromPreferences() async {
+    if (!ref.mounted) return;
+    final prefs = await ref.read(craftPreferencesCtrlProvider.notifier).load();
+    if (!ref.mounted) return;
+    if (_prefsHydrationMutated || state.editingMediaId != null) return;
+
+    final base = _baseLang(state.targetLanguage);
+    final remembered = prefs.voices[base];
+    final rememberedValid =
+        remembered != null &&
+        voicesForLanguage(base).any((v) => v.id == remembered);
+
+    state = state.copyWith(
+      screenMode: prefs.screenMode,
+      style: prefs.styleFor(prefs.screenMode),
+      customPrompt: prefs.customPrompt,
+      // null (invalid / absent) keeps the current voice in copyWith.
+      selectedVoice: rememberedValid ? remembered : null,
+    );
+  }
 
   // === Translate tool actions ===
 
@@ -60,10 +110,12 @@ class CraftController extends Notifier<CraftJobState> {
   }
 
   void setSourceLanguage(String? lang) {
+    _prefsHydrationMutated = true;
     state = state.copyWith(sourceLanguage: lang, clearFailure: true);
   }
 
   void setTargetLanguage(String lang) {
+    _prefsHydrationMutated = true;
     state = state.copyWith(
       targetLanguage: lang,
       selectedVoice: _voiceMatchingLanguage(lang, state.selectedVoice),
@@ -72,11 +124,21 @@ class CraftController extends Notifier<CraftJobState> {
   }
 
   void setStyle(TranslationStyle style) {
+    _prefsHydrationMutated = true;
     state = state.copyWith(style: style, clearFailure: true);
+    unawaited(
+      ref
+          .read(craftPreferencesCtrlProvider.notifier)
+          .setStyleFor(state.screenMode, style),
+    );
   }
 
   void setCustomPrompt(String? prompt) {
+    _prefsHydrationMutated = true;
     state = state.copyWith(customPrompt: prompt, clearFailure: true);
+    unawaited(
+      ref.read(craftPreferencesCtrlProvider.notifier).setCustomPrompt(prompt),
+    );
   }
 
   /// Inline edit of the translated result.
@@ -97,6 +159,7 @@ class CraftController extends Notifier<CraftJobState> {
   }
 
   void swapLanguages() {
+    _prefsHydrationMutated = true;
     final src = state.sourceLanguage;
     state = state.copyWith(
       sourceLanguage: state.targetLanguage,
@@ -165,6 +228,7 @@ class CraftController extends Notifier<CraftJobState> {
 
   void setSynthLanguage(String lang) {
     // Auto-pick default voice for the new language if current voice doesn't match.
+    _prefsHydrationMutated = true;
     state = state.copyWith(
       synthLanguage: lang,
       selectedVoice: _voiceMatchingLanguage(lang, state.selectedVoice),
@@ -173,8 +237,23 @@ class CraftController extends Notifier<CraftJobState> {
     );
   }
 
-  void setSelectedVoice(String? voice) {
-    state = state.copyWith(selectedVoice: voice, clearPreview: true);
+  /// Selects a voice, remembering it under [forLanguage]'s base code so the
+  /// pick survives sessions. Defaults to [CraftJobState.synthLanguage]; the
+  /// RewriteStage picker passes [CraftJobState.targetLanguage] explicitly
+  /// because synthLanguage may still be stale there.
+  void setSelectedVoice(String? voice, {String? forLanguage}) {
+    _prefsHydrationMutated = true;
+    final language = forLanguage ?? state.synthLanguage;
+    state = state.copyWith(
+      selectedVoice: voice,
+      clearSelectedVoice: voice == null,
+      clearPreview: true,
+    );
+    unawaited(
+      ref
+          .read(craftPreferencesCtrlProvider.notifier)
+          .setVoice(_baseLang(language), voice),
+    );
   }
 
   Future<void> synthesize() async {
@@ -406,16 +485,19 @@ class CraftController extends Notifier<CraftJobState> {
   // === Express mode actions ===
 
   /// Switch between Express and Advanced screen layouts.
-  /// Resets all working state so each mode starts fresh, and sets the
-  /// default translation style for the target mode.
+  /// Resets all working state so each mode starts fresh, restores the
+  /// remembered translation style for the target mode, and persists the
+  /// choice for the next session.
   void setScreenMode(CraftScreenMode mode) {
     if (mode == state.screenMode) return;
+    _prefsHydrationMutated = true;
+    final rememberedStyle = ref
+        .read(craftPreferencesCtrlProvider)
+        .styleFor(mode);
     state = state.copyWith(
       screenMode: mode,
       stage: CraftStage.capture,
-      style: mode == CraftScreenMode.express
-          ? TranslationStyle.auto
-          : TranslationStyle.natural,
+      style: rememberedStyle,
       isCapturing: false,
       isTranscribing: false,
       clearCapturedAudio: true,
@@ -430,15 +512,16 @@ class CraftController extends Notifier<CraftJobState> {
       sourceText: '',
       synthText: '',
     );
+    unawaited(
+      ref.read(craftPreferencesCtrlProvider.notifier).setScreenMode(mode),
+    );
   }
 
-  /// Begin voice capture — sets [isCapturing] flag and defaults the style
-  /// to [TranslationStyle.auto] for the Express flow.
+  /// Begin voice capture — sets [isCapturing] flag.
   /// The [CaptureStage] widget owns the actual AudioRecorder.
   void startCapture() {
     state = state.copyWith(
       isCapturing: true,
-      style: TranslationStyle.auto,
       clearFailure: true,
       clearCapturedAudio: true,
       clearRawTranscript: true,
@@ -468,13 +551,11 @@ class CraftController extends Notifier<CraftJobState> {
   }
 
   /// Text fallback: skip ASR, advance directly to rewrite.
-  /// Uses [TranslationStyle.auto] as the Express default.
   Future<void> useTextInput(String text) async {
     final normalized = normalizeCraftText(text);
     state = state.copyWith(
       rawTranscript: normalized.isEmpty ? null : normalized,
       sourceText: text,
-      style: TranslationStyle.auto,
       isTranscribing: false,
       clearFailure: true,
     );
@@ -643,15 +724,22 @@ class CraftController extends Notifier<CraftJobState> {
 
   // === Helpers ===
 
-  /// Keep [current] when it belongs to [language]; otherwise pick the default.
+  /// Keep [current] when it belongs to [language]; otherwise fall back to
+  /// the remembered voice for that language, then the catalog default.
   String? _voiceMatchingLanguage(String language, String? current) {
-    final base = language.split('-').first.toLowerCase();
+    final base = _baseLang(language);
     final voices = voicesForLanguage(base);
     if (current != null && voices.any((v) => v.id == current)) {
       return current;
     }
+    final remembered = ref.read(craftPreferencesCtrlProvider).voices[base];
+    if (remembered != null && voices.any((v) => v.id == remembered)) {
+      return remembered;
+    }
     return defaultVoiceForLanguage(base)?.id;
   }
+
+  String _baseLang(String tag) => tag.split('-').first.toLowerCase();
 
   bool _sameBaseLanguage(String a, String b) {
     final aBase = a.split('-').first.toLowerCase();

--- a/lib/features/craft/application/craft_preferences_provider.dart
+++ b/lib/features/craft/application/craft_preferences_provider.dart
@@ -77,8 +77,14 @@ class CraftPreferencesCtrl extends _$CraftPreferencesCtrl {
   Future<void> _persist() {
     final auth = ref.read(authCtrlProvider).valueOrNull;
     if (auth is! AuthSignedIn) return Future<void>.value();
+
+    final userId = auth.profile.id;
     final task = _persistQueue.then((_) async {
       if (!ref.mounted) return;
+
+      final cur = ref.read(authCtrlProvider).valueOrNull;
+      if (cur is! AuthSignedIn || cur.profile.id != userId) return;
+
       await ref
           .read(appDatabaseProvider)
           .settingsDao
@@ -87,6 +93,7 @@ class CraftPreferencesCtrl extends _$CraftPreferencesCtrl {
             jsonEncode(state.toJson()),
           );
     });
+
     // Keep the chain alive even if a write fails.
     _persistQueue = task.then((_) {}, onError: (_) {});
     return task;

--- a/lib/features/craft/application/craft_preferences_provider.dart
+++ b/lib/features/craft/application/craft_preferences_provider.dart
@@ -1,0 +1,131 @@
+/// Persisted Craft preferences (Drift settings KV, JSON blob).
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/core/riverpod/async_value_x.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/db/settings_keys.dart';
+import 'package:enjoy_player/features/auth/application/auth_controller.dart';
+import 'package:enjoy_player/features/auth/domain/auth_state.dart';
+import 'package:enjoy_player/features/craft/domain/craft_preferences.dart';
+import 'package:enjoy_player/features/craft/domain/craft_screen_mode.dart';
+import 'package:enjoy_player/features/craft/domain/translation_style.dart';
+
+part 'craft_preferences_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class CraftPreferencesCtrl extends _$CraftPreferencesCtrl {
+  Future<CraftPreferences>? _loadFuture;
+
+  /// Bumped by every setter so an in-flight [load] never clobbers values the
+  /// user just chose.
+  int _mutation = 0;
+
+  /// Serializes writes; [load] awaits it so it never reads a row older than
+  /// a setter that already ran. Each task encodes the latest state.
+  Future<void> _persistQueue = Future<void>.value();
+
+  @override
+  CraftPreferences build() {
+    _loadFuture = null;
+    // Watching auth (not selecting) matches AppPreferencesCtrl: a sign-in
+    // transition re-hydrates from that user's DB, sign-out drops to defaults.
+    final auth = ref.watch(authCtrlProvider).valueOrNull;
+    if (auth is AuthSignedIn) {
+      unawaited(Future<void>.microtask(load));
+    }
+    return CraftPreferences.defaults;
+  }
+
+  /// Single-flight hydrate. Awaitable so callers never apply a pre-hydration
+  /// snapshot; safe to call repeatedly.
+  Future<CraftPreferences> load() => _loadFuture ??= _loadFromDb();
+
+  Future<CraftPreferences> _loadFromDb() async {
+    // Flush setters that already ran so the row we read includes them.
+    await _persistQueue;
+    final readGeneration = _mutation;
+    CraftPreferences? loaded;
+    try {
+      final auth = ref.read(authCtrlProvider).valueOrNull;
+      if (auth is AuthSignedIn) {
+        final raw = await ref
+            .read(appDatabaseProvider)
+            .settingsDao
+            .getValue(SettingsKeys.craftPreferencesV1);
+        final decoded = raw == null ? null : jsonDecode(raw);
+        if (decoded is Map<String, dynamic>) {
+          loaded = CraftPreferences.fromJson(decoded);
+        }
+      }
+    } catch (e, st) {
+      logNamed('craft.prefs').warning('Hydrate failed; using defaults', e, st);
+    }
+    // The provider went away mid-flight (screen left / container disposed).
+    if (!ref.mounted) return loaded ?? CraftPreferences.defaults;
+    // A setter ran while we awaited the DB — keep the user's values.
+    if (_mutation != readGeneration) return state;
+    if (loaded != null) state = loaded;
+    return state;
+  }
+
+  Future<void> _persist() {
+    final auth = ref.read(authCtrlProvider).valueOrNull;
+    if (auth is! AuthSignedIn) return Future<void>.value();
+    final task = _persistQueue.then((_) async {
+      if (!ref.mounted) return;
+      await ref
+          .read(appDatabaseProvider)
+          .settingsDao
+          .setValue(
+            SettingsKeys.craftPreferencesV1,
+            jsonEncode(state.toJson()),
+          );
+    });
+    // Keep the chain alive even if a write fails.
+    _persistQueue = task.then((_) {}, onError: (_) {});
+    return task;
+  }
+
+  Future<void> setScreenMode(CraftScreenMode mode) async {
+    _mutation++;
+    state = state.copyWith(screenMode: mode);
+    await _persist();
+  }
+
+  Future<void> setStyleFor(CraftScreenMode mode, TranslationStyle style) async {
+    _mutation++;
+    state = mode == CraftScreenMode.express
+        ? state.copyWith(expressStyle: style)
+        : state.copyWith(advancedStyle: style);
+    await _persist();
+  }
+
+  Future<void> setCustomPrompt(String? prompt) async {
+    _mutation++;
+    state = prompt == null || prompt.isEmpty
+        ? state.copyWith(clearCustomPrompt: true)
+        : state.copyWith(customPrompt: prompt);
+    await _persist();
+  }
+
+  /// Remembers the voice the user picked for [baseLang] (e.g. `'en'`).
+  /// A null [voiceId] removes the remembered voice for that language.
+  Future<void> setVoice(String baseLang, String? voiceId) async {
+    _mutation++;
+    final base = baseLang.toLowerCase();
+    final voices = Map<String, String>.of(state.voices);
+    if (voiceId == null) {
+      voices.remove(base);
+    } else {
+      voices[base] = voiceId;
+    }
+    state = state.copyWith(voices: voices);
+    await _persist();
+  }
+}

--- a/lib/features/craft/application/craft_preferences_provider.g.dart
+++ b/lib/features/craft/application/craft_preferences_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'craft_preferences_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(CraftPreferencesCtrl)
+final craftPreferencesCtrlProvider = CraftPreferencesCtrlProvider._();
+
+final class CraftPreferencesCtrlProvider
+    extends $NotifierProvider<CraftPreferencesCtrl, CraftPreferences> {
+  CraftPreferencesCtrlProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'craftPreferencesCtrlProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$craftPreferencesCtrlHash();
+
+  @$internal
+  @override
+  CraftPreferencesCtrl create() => CraftPreferencesCtrl();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(CraftPreferences value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<CraftPreferences>(value),
+    );
+  }
+}
+
+String _$craftPreferencesCtrlHash() =>
+    r'dc6882f7fb7ebfcccdcd00096342ebeee237adae';
+
+abstract class _$CraftPreferencesCtrl extends $Notifier<CraftPreferences> {
+  CraftPreferences build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<CraftPreferences, CraftPreferences>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<CraftPreferences, CraftPreferences>,
+              CraftPreferences,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/craft/domain/craft_job_state.dart
+++ b/lib/features/craft/domain/craft_job_state.dart
@@ -155,6 +155,7 @@ class CraftJobState {
     int? generation,
     String? editingMediaId,
     bool clearPreview = false,
+    bool clearSelectedVoice = false,
     bool clearFailure = false,
     bool clearCapturedAudio = false,
     bool clearRawTranscript = false,
@@ -190,7 +191,9 @@ class CraftJobState {
       captureCancelTick: captureCancelTick ?? this.captureCancelTick,
       synthText: synthText ?? this.synthText,
       synthLanguage: synthLanguage ?? this.synthLanguage,
-      selectedVoice: selectedVoice ?? this.selectedVoice,
+      selectedVoice: clearSelectedVoice
+          ? null
+          : (selectedVoice ?? this.selectedVoice),
       previewAudioBytes: clearPreview
           ? null
           : (previewAudioBytes ?? this.previewAudioBytes),

--- a/lib/features/craft/domain/craft_preferences.dart
+++ b/lib/features/craft/domain/craft_preferences.dart
@@ -1,0 +1,147 @@
+/// Remembered Craft options (mode, per-mode style, custom prompt, voices).
+library;
+
+import 'package:flutter/foundation.dart';
+
+import 'azure_voice.dart';
+import 'craft_screen_mode.dart';
+import 'translation_style.dart';
+
+/// User's last-used Craft choices, persisted across sessions.
+///
+/// The language pair is deliberately absent — it always re-seeds from the
+/// learner's profile settings on entry (`AppPreferencesCtrl`).
+@immutable
+class CraftPreferences {
+  const CraftPreferences({
+    this.screenMode = CraftScreenMode.express,
+    this.expressStyle = TranslationStyle.auto,
+    this.advancedStyle = TranslationStyle.natural,
+    this.customPrompt,
+    this.voices = const {},
+  });
+
+  static const CraftPreferences defaults = CraftPreferences();
+
+  /// Last screen layout the user chose.
+  final CraftScreenMode screenMode;
+
+  /// Remembered translation style, kept separately per screen mode.
+  final TranslationStyle expressStyle;
+  final TranslationStyle advancedStyle;
+
+  /// Last custom prompt typed for the custom style (or Translate tool).
+  final String? customPrompt;
+
+  /// Base language code (e.g. `'en'`) → Azure voice id the user picked.
+  final Map<String, String> voices;
+
+  TranslationStyle styleFor(CraftScreenMode mode) =>
+      mode == CraftScreenMode.express ? expressStyle : advancedStyle;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CraftPreferences &&
+        other.screenMode == screenMode &&
+        other.expressStyle == expressStyle &&
+        other.advancedStyle == advancedStyle &&
+        other.customPrompt == customPrompt &&
+        mapEquals(other.voices, voices);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    screenMode,
+    expressStyle,
+    advancedStyle,
+    customPrompt,
+    Object.hashAllUnordered(voices.entries),
+  );
+
+  CraftPreferences copyWith({
+    CraftScreenMode? screenMode,
+    TranslationStyle? expressStyle,
+    TranslationStyle? advancedStyle,
+    String? customPrompt,
+    bool clearCustomPrompt = false,
+    Map<String, String>? voices,
+  }) {
+    return CraftPreferences(
+      screenMode: screenMode ?? this.screenMode,
+      expressStyle: expressStyle ?? this.expressStyle,
+      advancedStyle: advancedStyle ?? this.advancedStyle,
+      customPrompt: clearCustomPrompt
+          ? null
+          : (customPrompt ?? this.customPrompt),
+      voices: voices ?? this.voices,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'v': 1,
+      'screenMode': screenMode.name,
+      'expressStyle': expressStyle.name,
+      'advancedStyle': advancedStyle.name,
+      if (customPrompt != null && customPrompt!.isNotEmpty)
+        'customPrompt': customPrompt,
+      if (voices.isNotEmpty) 'voices': voices,
+    };
+  }
+
+  /// Total decode: unknown / ill-typed fields fall back per field instead of
+  /// throwing; a foreign schema version ignores the whole blob.
+  static CraftPreferences fromJson(Map<String, dynamic> json) {
+    if (json['v'] != 1) return defaults;
+
+    final screenMode = CraftScreenMode.values.firstWhere(
+      (m) => m.name == json['screenMode'],
+      orElse: () => defaults.screenMode,
+    );
+    final expressStyle = _styleFromJson(
+      json['expressStyle'],
+      fallback: defaults.expressStyle,
+    );
+    final advancedStyle = _styleFromJson(
+      json['advancedStyle'],
+      fallback: defaults.advancedStyle,
+    );
+    final prompt = json['customPrompt'];
+    final customPrompt = prompt is String && prompt.isNotEmpty ? prompt : null;
+    final voices = _voicesFromJson(json['voices']);
+
+    return CraftPreferences(
+      screenMode: screenMode,
+      expressStyle: expressStyle,
+      advancedStyle: advancedStyle,
+      customPrompt: customPrompt,
+      voices: voices,
+    );
+  }
+
+  static TranslationStyle _styleFromJson(
+    Object? raw, {
+    required TranslationStyle fallback,
+  }) {
+    return TranslationStyle.values.firstWhere(
+      (s) => s.name == raw,
+      orElse: () => fallback,
+    );
+  }
+
+  /// Keeps only entries whose id exists in the catalog and whose voice's
+  /// base language matches the (lowercased) key.
+  static Map<String, String> _voicesFromJson(Object? raw) {
+    if (raw is! Map) return const {};
+    final out = <String, String>{};
+    raw.forEach((key, value) {
+      if (key is! String || value is! String) return;
+      final base = key.toLowerCase();
+      final voice = kAzureVoices.where((v) => v.id == value).firstOrNull;
+      if (voice == null || voice.baseLang != base) return;
+      out[base] = value;
+    });
+    return out;
+  }
+}

--- a/lib/features/craft/presentation/audio_stage.dart
+++ b/lib/features/craft/presentation/audio_stage.dart
@@ -258,7 +258,10 @@ class _AudioStageState extends ConsumerState<AudioStage> {
                 onVoiceChanged: (voice) {
                   ref
                       .read(craftControllerProvider.notifier)
-                      .setSelectedVoice(voice);
+                      .setSelectedVoice(
+                        voice,
+                        forLanguage: state.synthLanguage,
+                      );
                   unawaited(
                     ref.read(craftControllerProvider.notifier).generateAudio(),
                   );

--- a/lib/features/craft/presentation/capture_stage.dart
+++ b/lib/features/craft/presentation/capture_stage.dart
@@ -14,8 +14,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 
-import 'package:enjoy_player/core/application/app_language_catalog.dart';
-import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
@@ -41,7 +39,6 @@ class _CaptureStageState extends ConsumerState<CaptureStage> {
   AudioRecorder _recorder = AudioRecorder();
   bool _recordingPending = false;
   bool _textMode = false;
-  bool _prefsSeeded = false;
 
   /// True while this widget owns an in-flight capture on [CraftController].
   /// Tracked locally so [dispose] can clear the session flag without [ref].
@@ -108,23 +105,6 @@ class _CaptureStageState extends ConsumerState<CaptureStage> {
 
     if (state.isBusy) return;
     _recordingPending = true;
-
-    // Seed source/target language from prefs on first entry (mirrors
-    // TranslateTool's initState so the Express flow has a valid source lang).
-    if (!_prefsSeeded) {
-      _prefsSeeded = true;
-      final prefs = ref.read(appPreferencesCtrlProvider);
-      final prefsState = prefs.whenOrNull(data: (s) => s);
-      final nativeLang = canonicalMediaLanguageTag(
-        prefsState?.effectiveNativeLanguage ?? 'en',
-      );
-      final learnLang = canonicalMediaLanguageTag(
-        prefsState?.effectiveLearningLanguage ?? 'en',
-      );
-      ref.read(craftControllerProvider.notifier)
-        ..setSourceLanguage(nativeLang)
-        ..setTargetLanguage(learnLang);
-    }
 
     // Permission check.
     bool granted;

--- a/lib/features/craft/presentation/rewrite_stage.dart
+++ b/lib/features/craft/presentation/rewrite_stage.dart
@@ -72,7 +72,10 @@ class _RewriteStageState extends ConsumerState<RewriteStage> {
       if (current.selectedVoice == null) {
         ref
             .read(craftControllerProvider.notifier)
-            .setSelectedVoice(defaultVoice.id);
+            .setSelectedVoice(
+              defaultVoice.id,
+              forLanguage: current.targetLanguage,
+            );
       }
     });
   }
@@ -203,7 +206,10 @@ class _RewriteStageState extends ConsumerState<RewriteStage> {
                     if (state.isBusy) return;
                     ref
                         .read(craftControllerProvider.notifier)
-                        .setSelectedVoice(voice);
+                        .setSelectedVoice(
+                          voice,
+                          forLanguage: state.targetLanguage,
+                        );
                   },
                 ),
               ],

--- a/lib/features/craft/presentation/translate_tool.dart
+++ b/lib/features/craft/presentation/translate_tool.dart
@@ -8,8 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import 'package:enjoy_player/core/application/app_language_catalog.dart';
-import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/presentation/loading_icon.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
@@ -40,20 +38,6 @@ class _TranslateToolState extends ConsumerState<TranslateTool> {
     super.initState();
     _sourceCtrl = TextEditingController();
     _resultCtrl = TextEditingController();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      final prefs = ref.read(appPreferencesCtrlProvider);
-      final prefsState = prefs.whenOrNull(data: (s) => s);
-      final nativeLang = canonicalMediaLanguageTag(
-        prefsState?.effectiveNativeLanguage ?? 'en',
-      );
-      final learnLang = canonicalMediaLanguageTag(
-        prefsState?.effectiveLearningLanguage ?? 'en',
-      );
-      ref.read(craftControllerProvider.notifier)
-        ..setSourceLanguage(nativeLang)
-        ..setTargetLanguage(learnLang);
-    });
   }
 
   @override

--- a/test/data/db/settings_keys_test.dart
+++ b/test/data/db/settings_keys_test.dart
@@ -68,6 +68,10 @@ void main() {
     test('player preferences v1', () {
       expect(SettingsKeys.playerPreferencesV1, 'player_preferences_v1');
     });
+
+    test('craft preferences v1', () {
+      expect(SettingsKeys.craftPreferencesV1, 'craft.preferences_v1');
+    });
   });
 
   group('SettingsKeys dynamic helpers', () {
@@ -119,6 +123,7 @@ void main() {
         SettingsKeys.transcriptKaraokeHighlight,
         SettingsKeys.transcriptIpaOverlay,
         SettingsKeys.playerPreferencesV1,
+        SettingsKeys.craftPreferencesV1,
         SettingsKeys.hotkeysCustomBindings,
         SettingsKeys.aiModalityConfigsV1,
         SettingsKeys.youtubeClientProfilesV1,

--- a/test/features/craft/application/craft_controller_test.dart
+++ b/test/features/craft/application/craft_controller_test.dart
@@ -5,9 +5,12 @@ import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:enjoy_player/core/application/app_preferences_provider.dart';
 import 'package:enjoy_player/core/errors/app_failure.dart';
 import 'package:enjoy_player/data/api/api_exception.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/db/settings_keys.dart';
 import 'package:enjoy_player/data/files/file_storage.dart';
 import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
 import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
@@ -15,9 +18,11 @@ import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
+import 'package:enjoy_player/features/craft/application/craft_preferences_provider.dart';
 import 'package:enjoy_player/features/craft/application/craft_timeline_enricher.dart';
 import 'package:enjoy_player/features/craft/domain/craft_failure.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
+import 'package:enjoy_player/features/craft/domain/craft_preferences.dart';
 import 'package:enjoy_player/features/craft/domain/craft_synthesizer.dart';
 import 'package:enjoy_player/features/craft/domain/craft_transcriber.dart';
 import 'package:enjoy_player/features/craft/domain/craft_translator.dart';
@@ -41,6 +46,16 @@ class _SignedInAuthCtrl extends AuthCtrl {
 class _SignedOutAuthCtrl extends AuthCtrl {
   @override
   Future<AuthState> build() async => const AuthSignedOut();
+}
+
+/// Resolved app prefs without the real controller's server-sync pipeline.
+class _FixedPrefsCtrl extends AppPreferencesCtrl {
+  @override
+  Future<AppPreferencesState> build() async => const AppPreferencesState(
+    locale: kAppDefaultDisplayLocale,
+    learningLanguage: 'en-US',
+    nativeLanguage: 'zh-CN',
+  );
 }
 
 class _TogglableAuthCtrl extends AuthCtrl {
@@ -295,6 +310,8 @@ void main() {
         craftTimelineEnricherProvider.overrideWithValue(
           CraftTimelineEnricher(enabled: false),
         ),
+        appDatabaseProvider.overrideWithValue(db),
+        appPreferencesCtrlProvider.overrideWith(_FixedPrefsCtrl.new),
         if (profile == null)
           authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new)
         else
@@ -303,8 +320,13 @@ void main() {
     );
   }
 
-  CraftController notifierOf(ProviderContainer c) =>
-      c.read(craftControllerProvider.notifier);
+  /// Mirrors the CraftScreen subscriber: keeps the autoDispose controller
+  /// alive across awaits so preference hydration applies as in production.
+  /// Call after auth has resolved — Craft is only reachable when signed in.
+  CraftController notifierOf(ProviderContainer c) {
+    c.listen(craftControllerProvider, (_, _) {});
+    return c.read(craftControllerProvider.notifier);
+  }
 
   CraftJobState stateOf(ProviderContainer c) => c.read(craftControllerProvider);
 
@@ -314,8 +336,10 @@ void main() {
       addTearDown(c.dispose);
       final s = stateOf(c);
       expect(s.sourceText, '');
-      expect(s.sourceLanguage, isNull);
-      expect(s.targetLanguage, 'en');
+      // Languages are seeded synchronously from app prefs. Prefs are still
+      // resolving at this instant in tests → the 'en-US' cold-start fallback.
+      expect(s.sourceLanguage, 'en-US');
+      expect(s.targetLanguage, 'en-US');
       expect(s.style, TranslationStyle.natural);
       expect(s.customPrompt, isNull);
       expect(s.translatedText, isNull);
@@ -447,14 +471,15 @@ void main() {
       expect(stateOf(c).targetLanguage, 'zh');
     });
 
-    test('keeps target when source is null', () {
+    test('swaps the seeded pair when only target was changed', () {
       final c = container();
       addTearDown(c.dispose);
       final n = notifierOf(c);
+      // Build seeds sourceLanguage, so swapping exchanges both sides.
       n.setTargetLanguage('fr');
       n.swapLanguages();
       expect(stateOf(c).sourceLanguage, 'fr');
-      expect(stateOf(c).targetLanguage, 'fr');
+      expect(stateOf(c).targetLanguage, 'en-US');
     });
   });
 
@@ -504,14 +529,15 @@ void main() {
       expect(stateOf(c).translatedText, isNull);
     });
 
-    test('returns early when source language is null', () async {
+    test('build-seeded languages make a bare translate hit the same-language '
+        'guard instead of calling the translator', () async {
       final c = container();
       addTearDown(c.dispose);
       final n = notifierOf(c);
-      n.setTargetLanguage('en');
       n.setSourceText('long enough text');
       await n.translate();
       expect(translator.callCount, 0);
+      expect(stateOf(c).failure, isA<CraftSameLanguageFailure>());
       expect(stateOf(c).translatedText, isNull);
     });
 
@@ -812,6 +838,7 @@ void main() {
           craftTimelineEnricherProvider.overrideWithValue(
             CraftTimelineEnricher(enabled: false),
           ),
+          appDatabaseProvider.overrideWithValue(db),
           authCtrlProvider.overrideWith(() => auth),
         ],
       );
@@ -976,6 +1003,7 @@ void main() {
             craftTranscriberProvider.overrideWithValue(transcriber),
             craftLibraryRepositoryProvider.overrideWithValue(repo),
             craftTimelineEnricherProvider.overrideWithValue(enricher),
+            appDatabaseProvider.overrideWithValue(db),
             authCtrlProvider.overrideWith(() => _SignedInAuthCtrl(_profile)),
           ],
         );
@@ -1025,6 +1053,7 @@ void main() {
             craftTranscriberProvider.overrideWithValue(transcriber),
             craftLibraryRepositoryProvider.overrideWithValue(repo),
             craftTimelineEnricherProvider.overrideWithValue(enricher),
+            appDatabaseProvider.overrideWithValue(db),
             authCtrlProvider.overrideWith(() => _SignedInAuthCtrl(_profile)),
           ],
         );
@@ -1685,6 +1714,274 @@ void main() {
       expect(result, isNull);
       expect(stateOf(c).failure, isA<CraftSaveFailure>());
       expect(repo.importCalls, 0);
+    });
+  });
+
+  // === Remembered preferences ===
+
+  Future<String?> storedRaw() =>
+      db.settingsDao.getValue(SettingsKeys.craftPreferencesV1);
+
+  group('preference hydration', () {
+    test(
+      'seeds languages from app prefs when they are already resolved',
+      () async {
+        final c = container();
+        addTearDown(c.dispose);
+        // Resolve prefs before the first read so build() sees real values.
+        await c.read(appPreferencesCtrlProvider.future);
+        c.invalidate(craftControllerProvider);
+
+        final s = stateOf(c);
+        expect(s.targetLanguage, 'en-US');
+        expect(s.sourceLanguage, 'zh-CN');
+      },
+    );
+
+    test(
+      'applies persisted mode, style, prompt, and voice after settle',
+      () async {
+        const persisted = CraftPreferences(
+          screenMode: CraftScreenMode.advanced,
+          advancedStyle: TranslationStyle.formal,
+          customPrompt: 'keep it short',
+          voices: {'en': 'en-US-GuyNeural'},
+        );
+        await db.settingsDao.setValue(
+          SettingsKeys.craftPreferencesV1,
+          jsonEncode(persisted.toJson()),
+        );
+
+        final c = container();
+        addTearDown(c.dispose);
+        await c.read(authCtrlProvider.future);
+        notifierOf(c); // attach + build, mirroring entry to the Craft screen
+        await pumpEventQueue(); // hydration lands
+
+        final s = stateOf(c);
+        expect(s.screenMode, CraftScreenMode.advanced);
+        expect(s.style, TranslationStyle.formal);
+        expect(s.customPrompt, 'keep it short');
+        expect(s.selectedVoice, 'en-US-GuyNeural');
+      },
+    );
+
+    test('signed-out build does not touch the DB and uses fallbacks', () async {
+      final c = container(profile: null);
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      notifierOf(c);
+      await pumpEventQueue();
+
+      final s = stateOf(c);
+      expect(s.sourceLanguage, 'en-US');
+      expect(s.targetLanguage, 'en-US');
+      expect(s.style, TranslationStyle.auto); // express default after hydrate
+      expect(s.screenMode, CraftScreenMode.express);
+      expect(await storedRaw(), isNull);
+    });
+
+    test('rebuild re-applies hydration', () async {
+      const persisted = CraftPreferences(
+        screenMode: CraftScreenMode.advanced,
+        advancedStyle: TranslationStyle.formal,
+      );
+      await db.settingsDao.setValue(
+        SettingsKeys.craftPreferencesV1,
+        jsonEncode(persisted.toJson()),
+      );
+
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      notifierOf(c);
+      await pumpEventQueue();
+      expect(stateOf(c).screenMode, CraftScreenMode.advanced);
+
+      c.invalidate(craftControllerProvider);
+      await pumpEventQueue();
+      expect(stateOf(c).screenMode, CraftScreenMode.advanced);
+      expect(stateOf(c).style, TranslationStyle.formal);
+    });
+
+    test('user input before hydration wins', () async {
+      const persisted = CraftPreferences(expressStyle: TranslationStyle.formal);
+      await db.settingsDao.setValue(
+        SettingsKeys.craftPreferencesV1,
+        jsonEncode(persisted.toJson()),
+      );
+
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final n = notifierOf(c); // build() scheduled the hydration microtask
+      n.setStyle(TranslationStyle.casual); // synchronous, before H1 can run
+      await pumpEventQueue();
+
+      expect(stateOf(c).style, TranslationStyle.casual);
+      // The user's choice is what got persisted.
+      expect(
+        CraftPreferences.fromJson(
+          jsonDecode((await storedRaw())!) as Map<String, dynamic>,
+        ).expressStyle,
+        TranslationStyle.casual,
+      );
+    });
+
+    test(
+      'loadForEdit after hydration replaces prefs and persists nothing',
+      () async {
+        const persisted = CraftPreferences(
+          advancedStyle: TranslationStyle.formal,
+          voices: {'en': 'en-US-GuyNeural'},
+        );
+        final seededJson = jsonEncode(persisted.toJson());
+        await db.settingsDao.setValue(
+          SettingsKeys.craftPreferencesV1,
+          seededJson,
+        );
+        repo.editSource = const CraftEditSource(
+          mediaId: 'media-direct',
+          practiceText: 'Speak this text directly.',
+          language: 'en-US',
+          voice: 'en-US-JennyNeural',
+          sourceFlag: 'craft-direct',
+        );
+
+        final c = container();
+        addTearDown(c.dispose);
+        await c.read(authCtrlProvider.future);
+        await pumpEventQueue(); // hydration lands first
+
+        final ok = await notifierOf(c).loadForEdit('media-direct');
+        await pumpEventQueue();
+
+        expect(ok, isTrue);
+        final s = stateOf(c);
+        expect(s.editingMediaId, 'media-direct');
+        expect(s.selectedVoice, 'en-US-JennyNeural'); // the item's own voice
+        expect(await storedRaw(), seededJson); // no write happened
+      },
+    );
+  });
+
+  group('preference persistence', () {
+    test('setStyle persists under the current screen mode', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      await pumpEventQueue();
+      final n = notifierOf(c);
+      CraftPreferences prefsOf() => c.read(craftPreferencesCtrlProvider);
+
+      n.setScreenMode(CraftScreenMode.advanced);
+      n.setStyle(TranslationStyle.formal);
+      await pumpEventQueue();
+      expect(prefsOf().advancedStyle, TranslationStyle.formal);
+
+      n.setScreenMode(CraftScreenMode.express);
+      n.setStyle(TranslationStyle.casual);
+      await pumpEventQueue();
+      expect(prefsOf().expressStyle, TranslationStyle.casual);
+      expect(prefsOf().advancedStyle, TranslationStyle.formal);
+    });
+
+    test('setScreenMode restores the remembered per-mode style', () async {
+      const persisted = CraftPreferences(
+        expressStyle: TranslationStyle.casual,
+        advancedStyle: TranslationStyle.formal,
+      );
+      await db.settingsDao.setValue(
+        SettingsKeys.craftPreferencesV1,
+        jsonEncode(persisted.toJson()),
+      );
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final n = notifierOf(c);
+      await pumpEventQueue(); // hydration lands before the user acts
+
+      n.setScreenMode(CraftScreenMode.advanced);
+      expect(stateOf(c).style, TranslationStyle.formal);
+      n.setScreenMode(CraftScreenMode.express);
+      expect(stateOf(c).style, TranslationStyle.casual);
+    });
+
+    test('startCapture and useTextInput keep the chosen style', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final n = notifierOf(c);
+
+      n.setStyle(TranslationStyle.casual);
+      n.startCapture();
+      expect(stateOf(c).style, TranslationStyle.casual);
+
+      await n.useTextInput('This is a test of text input mode.');
+      expect(stateOf(c).style, TranslationStyle.casual);
+    });
+
+    test(
+      'voice is filed under the picked language, not a stale synthLanguage',
+      () async {
+        final c = container();
+        addTearDown(c.dispose);
+        await c.read(authCtrlProvider.future);
+        await pumpEventQueue();
+        final n = notifierOf(c);
+
+        n.setSynthLanguage('zh-CN'); // makes synthLanguage the wrong key
+        n.setSelectedVoice('en-US-GuyNeural', forLanguage: 'en-US');
+        await pumpEventQueue();
+
+        final voices = c.read(craftPreferencesCtrlProvider).voices;
+        expect(voices['en'], 'en-US-GuyNeural');
+        expect(voices.containsKey('zh'), isFalse);
+      },
+    );
+
+    test('remembered voice survives a target-language round trip', () async {
+      const persisted = CraftPreferences(voices: {'en': 'en-US-GuyNeural'});
+      await db.settingsDao.setValue(
+        SettingsKeys.craftPreferencesV1,
+        jsonEncode(persisted.toJson()),
+      );
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      await pumpEventQueue();
+      final n = notifierOf(c);
+
+      n.setTargetLanguage('ja-JP');
+      expect(stateOf(c).selectedVoice, 'ja-JP-NanamiNeural');
+      // Let the first prefs load land so the remembered tier can consult it.
+      await pumpEventQueue();
+      n.setTargetLanguage('en-US');
+      expect(stateOf(c).selectedVoice, 'en-US-GuyNeural');
+    });
+
+    test('resetForNextCapture keeps hydrated preferences', () async {
+      const persisted = CraftPreferences(
+        expressStyle: TranslationStyle.casual,
+        voices: {'en': 'en-US-GuyNeural'},
+      );
+      await db.settingsDao.setValue(
+        SettingsKeys.craftPreferencesV1,
+        jsonEncode(persisted.toJson()),
+      );
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final n = notifierOf(c);
+      await pumpEventQueue(); // hydration lands before the user acts
+
+      await n.useTextInput('This is a test of text input mode.');
+      n.resetForNextCapture();
+
+      final s = stateOf(c);
+      expect(s.style, TranslationStyle.casual);
+      expect(s.selectedVoice, 'en-US-GuyNeural');
+      expect(s.screenMode, CraftScreenMode.express);
     });
   });
 }

--- a/test/features/craft/application/craft_preferences_provider_test.dart
+++ b/test/features/craft/application/craft_preferences_provider_test.dart
@@ -1,0 +1,224 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/db/settings_keys.dart';
+import 'package:enjoy_player/features/auth/application/auth_controller.dart';
+import 'package:enjoy_player/features/auth/domain/auth_state.dart';
+import 'package:enjoy_player/features/auth/domain/user_profile.dart';
+import 'package:enjoy_player/features/craft/application/craft_preferences_provider.dart';
+import 'package:enjoy_player/features/craft/domain/craft_preferences.dart';
+import 'package:enjoy_player/features/craft/domain/craft_screen_mode.dart';
+import 'package:enjoy_player/features/craft/domain/translation_style.dart';
+
+class _SignedInAuthCtrl extends AuthCtrl {
+  _SignedInAuthCtrl(this.profile);
+  final UserProfile profile;
+  @override
+  Future<AuthState> build() async => AuthSignedIn(profile: profile);
+}
+
+class _SignedOutAuthCtrl extends AuthCtrl {
+  @override
+  Future<AuthState> build() async => const AuthSignedOut();
+}
+
+const _profile = UserProfile(id: 'user-1', email: 'a@b.com', name: 'Tester');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(executor: NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<String?> storedRaw() =>
+      db.settingsDao.getValue(SettingsKeys.craftPreferencesV1);
+
+  ProviderContainer container({UserProfile? profile = _profile}) {
+    return ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        if (profile == null)
+          authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new)
+        else
+          authCtrlProvider.overrideWith(() => _SignedInAuthCtrl(profile)),
+      ],
+    );
+  }
+
+  group('load', () {
+    test('hydrates a persisted blob', () async {
+      const persisted = CraftPreferences(
+        screenMode: CraftScreenMode.advanced,
+        advancedStyle: TranslationStyle.formal,
+        customPrompt: 'keep it short',
+        voices: {'en': 'en-US-GuyNeural'},
+      );
+      await db.settingsDao.setValue(
+        SettingsKeys.craftPreferencesV1,
+        jsonEncode(persisted.toJson()),
+      );
+
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final prefs = await c.read(craftPreferencesCtrlProvider.notifier).load();
+
+      expect(prefs, persisted);
+      expect(c.read(craftPreferencesCtrlProvider), persisted);
+    });
+
+    test('returns defaults when nothing is stored', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final prefs = await c.read(craftPreferencesCtrlProvider.notifier).load();
+      expect(prefs, CraftPreferences.defaults);
+    });
+
+    test('falls back to defaults on a corrupt blob', () async {
+      await db.settingsDao.setValue(
+        SettingsKeys.craftPreferencesV1,
+        'not json at all',
+      );
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final prefs = await c.read(craftPreferencesCtrlProvider.notifier).load();
+      expect(prefs, CraftPreferences.defaults);
+    });
+
+    test('is single-flight', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final notifier = c.read(craftPreferencesCtrlProvider.notifier);
+      expect(identical(notifier.load(), notifier.load()), isTrue);
+      await notifier.load();
+    });
+
+    test('returns defaults without touching the DB when signed out', () async {
+      final c = container(profile: null);
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final prefs = await c.read(craftPreferencesCtrlProvider.notifier).load();
+      expect(prefs, CraftPreferences.defaults);
+      expect(await storedRaw(), isNull);
+    });
+  });
+
+  group('setters', () {
+    test('setScreenMode persists', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final notifier = c.read(craftPreferencesCtrlProvider.notifier);
+      await notifier.setScreenMode(CraftScreenMode.advanced);
+      final prefs = c.read(craftPreferencesCtrlProvider);
+      expect(prefs.screenMode, CraftScreenMode.advanced);
+      expect(
+        CraftPreferences.fromJson(
+          jsonDecode((await storedRaw())!) as Map<String, dynamic>,
+        ),
+        prefs,
+      );
+    });
+
+    test('setStyleFor persists per mode', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final notifier = c.read(craftPreferencesCtrlProvider.notifier);
+      await notifier.setStyleFor(
+        CraftScreenMode.express,
+        TranslationStyle.casual,
+      );
+      await notifier.setStyleFor(
+        CraftScreenMode.advanced,
+        TranslationStyle.formal,
+      );
+      final prefs = c.read(craftPreferencesCtrlProvider);
+      expect(prefs.expressStyle, TranslationStyle.casual);
+      expect(prefs.advancedStyle, TranslationStyle.formal);
+      expect(
+        CraftPreferences.fromJson(
+          jsonDecode((await storedRaw())!) as Map<String, dynamic>,
+        ),
+        prefs,
+      );
+    });
+
+    test('setCustomPrompt persists; empty clears', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final notifier = c.read(craftPreferencesCtrlProvider.notifier);
+      await notifier.setCustomPrompt('be poetic');
+      expect(c.read(craftPreferencesCtrlProvider).customPrompt, 'be poetic');
+
+      await notifier.setCustomPrompt('');
+      expect(c.read(craftPreferencesCtrlProvider).customPrompt, isNull);
+      expect(
+        CraftPreferences.fromJson(
+          jsonDecode((await storedRaw())!) as Map<String, dynamic>,
+        ).customPrompt,
+        isNull,
+      );
+    });
+
+    test('setVoice persists per base language; null removes', () async {
+      final c = container();
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final notifier = c.read(craftPreferencesCtrlProvider.notifier);
+      await notifier.setVoice('en', 'en-US-GuyNeural');
+      await notifier.setVoice('JA', 'ja-JP-NanamiNeural');
+      expect(c.read(craftPreferencesCtrlProvider).voices, {
+        'en': 'en-US-GuyNeural',
+        'ja': 'ja-JP-NanamiNeural',
+      });
+
+      await notifier.setVoice('en', null);
+      final prefs = c.read(craftPreferencesCtrlProvider);
+      expect(prefs.voices, {'ja': 'ja-JP-NanamiNeural'});
+      expect(
+        CraftPreferences.fromJson(
+          jsonDecode((await storedRaw())!) as Map<String, dynamic>,
+        ).voices,
+        {'ja': 'ja-JP-NanamiNeural'},
+      );
+    });
+
+    test('setters update state but write nothing when signed out', () async {
+      final c = container(profile: null);
+      addTearDown(c.dispose);
+      await c.read(authCtrlProvider.future);
+      final notifier = c.read(craftPreferencesCtrlProvider.notifier);
+      await notifier.setScreenMode(CraftScreenMode.advanced);
+      await notifier.setStyleFor(
+        CraftScreenMode.advanced,
+        TranslationStyle.formal,
+      );
+      expect(
+        c.read(craftPreferencesCtrlProvider).screenMode,
+        CraftScreenMode.advanced,
+      );
+      expect(
+        c.read(craftPreferencesCtrlProvider).advancedStyle,
+        TranslationStyle.formal,
+      );
+      expect(await storedRaw(), isNull);
+    });
+  });
+}

--- a/test/features/craft/domain/craft_preferences_test.dart
+++ b/test/features/craft/domain/craft_preferences_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:enjoy_player/features/craft/domain/craft_preferences.dart';
+import 'package:enjoy_player/features/craft/domain/craft_screen_mode.dart';
+import 'package:enjoy_player/features/craft/domain/translation_style.dart';
+
+void main() {
+  group('CraftPreferences defaults', () {
+    test('toJson emits v1 with defaults and omits empty fields', () {
+      final json = CraftPreferences.defaults.toJson();
+      expect(json['v'], 1);
+      expect(json['screenMode'], 'express');
+      expect(json['expressStyle'], 'auto');
+      expect(json['advancedStyle'], 'natural');
+      expect(json.containsKey('customPrompt'), isFalse);
+      expect(json.containsKey('voices'), isFalse);
+    });
+
+    test('fromJson of an empty map yields defaults', () {
+      expect(CraftPreferences.fromJson(const {}), CraftPreferences.defaults);
+    });
+  });
+
+  group('CraftPreferences round-trip', () {
+    test('preserves every field', () {
+      const prefs = CraftPreferences(
+        screenMode: CraftScreenMode.advanced,
+        expressStyle: TranslationStyle.casual,
+        advancedStyle: TranslationStyle.formal,
+        customPrompt: 'keep it short',
+        voices: {'en': 'en-US-GuyNeural', 'ja': 'ja-JP-NanamiNeural'},
+      );
+      final decoded = CraftPreferences.fromJson(prefs.toJson());
+      expect(decoded, prefs);
+    });
+
+    test('drops an empty customPrompt on encode', () {
+      final json = const CraftPreferences(customPrompt: '').toJson();
+      expect(json.containsKey('customPrompt'), isFalse);
+      expect(CraftPreferences.fromJson(json).customPrompt, isNull);
+    });
+
+    test('drops an empty voices map on encode', () {
+      final json = const CraftPreferences(voices: {}).toJson();
+      expect(json.containsKey('voices'), isFalse);
+    });
+  });
+
+  group('CraftPreferences.fromJson fallbacks', () {
+    test('foreign schema version ignores the whole blob', () {
+      expect(
+        CraftPreferences.fromJson(const {
+          'v': 2,
+          'screenMode': 'advanced',
+          'expressStyle': 'casual',
+          'advancedStyle': 'formal',
+          'customPrompt': 'x',
+          'voices': {'en': 'en-US-GuyNeural'},
+        }),
+        CraftPreferences.defaults,
+      );
+      expect(
+        CraftPreferences.fromJson(const {'screenMode': 'advanced'}),
+        CraftPreferences.defaults,
+      );
+    });
+
+    test('unknown style names fall back per field', () {
+      final prefs = CraftPreferences.fromJson(const {
+        'v': 1,
+        'expressStyle': 'nope',
+        'advancedStyle': 'formal',
+      });
+      expect(prefs.expressStyle, TranslationStyle.auto);
+      expect(prefs.advancedStyle, TranslationStyle.formal);
+    });
+
+    test('unknown screenMode falls back to express', () {
+      expect(
+        CraftPreferences.fromJson(const {
+          'v': 1,
+          'screenMode': 'wizard',
+        }).screenMode,
+        CraftScreenMode.express,
+      );
+    });
+
+    test('ill-typed fields fall back instead of throwing', () {
+      final prefs = CraftPreferences.fromJson(const {
+        'v': 1,
+        'screenMode': 42,
+        'expressStyle': true,
+        'customPrompt': 7,
+        'voices': 'nope',
+      });
+      expect(prefs, CraftPreferences.defaults);
+    });
+
+    test('empty customPrompt decodes to null', () {
+      expect(
+        CraftPreferences.fromJson(const {
+          'v': 1,
+          'customPrompt': '',
+        }).customPrompt,
+        isNull,
+      );
+    });
+  });
+
+  group('CraftPreferences voice validation', () {
+    test('keeps entries whose voice exists and matches the key', () {
+      final prefs = CraftPreferences.fromJson(const {
+        'v': 1,
+        'voices': {'en': 'en-US-GuyNeural', 'ja': 'ja-JP-NanamiNeural'},
+      });
+      expect(prefs.voices, {
+        'en': 'en-US-GuyNeural',
+        'ja': 'ja-JP-NanamiNeural',
+      });
+    });
+
+    test('drops unknown voice ids and base-lang mismatches', () {
+      final prefs = CraftPreferences.fromJson(const {
+        'v': 1,
+        'voices': {
+          'en': 'xx-UnknownNeural', // not in the catalog
+          'ja': 'en-US-GuyNeural', // wrong language for the key
+        },
+      });
+      expect(prefs.voices, isEmpty);
+    });
+
+    test('normalizes uppercase keys to lowercase', () {
+      final prefs = CraftPreferences.fromJson(const {
+        'v': 1,
+        'voices': {'EN': 'en-US-GuyNeural'},
+      });
+      expect(prefs.voices, {'en': 'en-US-GuyNeural'});
+    });
+
+    test('ignores non-string entries', () {
+      final prefs = CraftPreferences.fromJson(const {
+        'v': 1,
+        'voices': {'en': 42, 7: 'en-US-GuyNeural'},
+      });
+      expect(prefs.voices, isEmpty);
+    });
+  });
+}

--- a/test/features/craft/presentation/capture_stage_test.dart
+++ b/test/features/craft/presentation/capture_stage_test.dart
@@ -123,9 +123,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Language pair shows target language (default 'en' → 'EN').
-    // Source language is null initially → shows '—'.
+    // Language pair seeds from app prefs at build time (native 'zh-CN',
+    // learning 'en-US') — the '—' placeholder never renders.
     expect(find.textContaining('EN'), findsWidgets);
+    expect(find.text('—'), findsNothing);
   });
 
   testWidgets('CaptureStage type instead toggles to text input', (

--- a/test/features/craft/presentation/craft_screen_test.dart
+++ b/test/features/craft/presentation/craft_screen_test.dart
@@ -11,6 +11,9 @@ import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/auth/domain/user_profile.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
+import 'package:enjoy_player/features/craft/application/craft_preferences_provider.dart';
+import 'package:enjoy_player/features/craft/domain/craft_preferences.dart';
+import 'package:enjoy_player/features/craft/domain/craft_screen_mode.dart';
 import 'package:enjoy_player/features/craft/domain/craft_synthesizer.dart';
 import 'package:enjoy_player/features/craft/domain/craft_transcriber.dart';
 import 'package:enjoy_player/features/craft/domain/craft_translator.dart';
@@ -38,6 +41,34 @@ class _FakePrefsCtrl extends AppPreferencesCtrl {
     learningLanguage: 'en-US',
     nativeLanguage: 'zh-CN',
   );
+}
+
+/// Fixed, DB-free craft preferences ([CraftPreferences] to inject, if any).
+class _StubCraftPrefsCtrl extends CraftPreferencesCtrl {
+  _StubCraftPrefsCtrl([this.initial]);
+
+  final CraftPreferences? initial;
+
+  @override
+  CraftPreferences build() => initial ?? CraftPreferences.defaults;
+
+  @override
+  Future<CraftPreferences> load() async => state;
+
+  @override
+  Future<void> setScreenMode(CraftScreenMode mode) async {}
+
+  @override
+  Future<void> setStyleFor(
+    CraftScreenMode mode,
+    TranslationStyle style,
+  ) async {}
+
+  @override
+  Future<void> setCustomPrompt(String? prompt) async {}
+
+  @override
+  Future<void> setVoice(String baseLang, String? voiceId) async {}
 }
 
 class _FakeTranslator implements CraftTranslator {
@@ -91,9 +122,12 @@ Widget _harness({required List<Override> overrides}) {
   );
 }
 
-List<Override> _baseOverrides() => [
+List<Override> _baseOverrides({CraftPreferences? craftPrefs}) => [
   authCtrlProvider.overrideWith(_AuthSignedInCtrl.new),
   appPreferencesCtrlProvider.overrideWith(_FakePrefsCtrl.new),
+  craftPreferencesCtrlProvider.overrideWith(
+    () => _StubCraftPrefsCtrl(craftPrefs),
+  ),
   craftTranslatorProvider.overrideWithValue(_FakeTranslator()),
   craftSynthesizerProvider.overrideWithValue(_FakeSynthesizer()),
   craftTranscriberProvider.overrideWithValue(_FakeTranscriber()),
@@ -110,6 +144,22 @@ void main() {
     expect(find.byType(ExpressFlow), findsOneWidget);
     expect(find.byType(AdvancedTools), findsNothing);
     expect(find.text('Express'), findsWidgets);
+  });
+
+  testWidgets('CraftScreen reopens in the last used mode', (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        overrides: _baseOverrides(
+          craftPrefs: const CraftPreferences(
+            screenMode: CraftScreenMode.advanced,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AdvancedTools), findsOneWidget);
+    expect(find.byType(ExpressFlow), findsNothing);
   });
 
   testWidgets('CraftScreen switches to Advanced mode on tap', (tester) async {


### PR DESCRIPTION
## What

Fixes two Craft-flow annoyances:

1. **Choices reset on every entry.** `craftControllerProvider` is autoDispose, so each visit to `/craft` snapped the translation style back to a hardcoded per-mode default, dropped the voice, and required re-picking everything. Craft choices were never persisted anywhere.
2. **Native language showed `—` on the Express idle pill.** Languages were only seeded lazily — inside `_startRecording` (mic tap) or a post-frame callback in `TranslateTool` — so the idle screen rendered `— → EN` until first interaction.

## Changes

- **New `CraftPreferences` + `CraftPreferencesCtrl`** (keepAlive, codegen) persisting a versioned JSON blob under the new Drift settings key `craft.preferences_v1` (`SettingsKeys.craftPreferencesV1`, registered in `_staticKeys`):
  - last screen mode (Express / Advanced)
  - translation style **per mode** (first-run defaults `auto` / `natural`)
  - custom prompt
  - voice **per base language** (`{'en': 'en-US-GuyNeural'}`), validated against `kAzureVoices` on load so catalog drift drops stale entries
  - follows the `PlayerPreferencesCtrl` blob pattern + `AppPreferencesCtrl` auth guard (per-user DB ⇒ reads/writes skipped while signed out; watching auth re-hydrates on sign-in)
- **`CraftController.build()`** now seeds the language pair **synchronously** from `effectiveNativeLanguage` / `effectiveLearningLanguage` (via `canonicalMediaLanguageTag`) so `—` never renders; a guarded microtask then overlays persisted prefs. The duplicated lazy seeding in `CaptureStage._startRecording` and `TranslateTool.initState` is deleted.
- **Setters write through** (`setStyle`, `setCustomPrompt`, `setScreenMode`, `setSelectedVoice` persist; language setters don't — languages always follow profile settings). `setScreenMode` restores the remembered per-mode style instead of hardcoding `auto`/`natural`; `startCapture`/`useTextInput` no longer force style back to `auto`.
- **Voice correctness:** `setSelectedVoice(voice, {forLanguage})` — the RewriteStage picker passes `targetLanguage` explicitly because `synthLanguage` can be stale there (previously would have mis-filed the pick); `_voiceMatchingLanguage` gains a remembered-voice tier so a persisted pick survives in-session language switches.
- **Race hardening:** late hydration never clobbers user input (`_prefsHydrationMutated` latch) or an edit-from-history restore (`editingMediaId` guard); `load()` awaits the persist queue so it never reads a row older than a setter that already ran; all post-await state writes are `ref.mounted`-guarded.
- `loadForEdit` is untouched — programmatic `copyWith` bypasses setters, so editing a history item restores the item's own values and persists nothing.
- Docs: "Remembered preferences" section + stale statements fixed in `docs/features/craft.md`.

## Tests

- New: `craft_preferences_test.dart` (codec round-trip, per-field fallbacks, voice validation, `v:2` → defaults), `craft_preferences_provider_test.dart` (hydration, corrupt blob, persistence, signed-out no-write, single-flight).
- Extended `craft_controller_test.dart`: hydration (persisted overlay, language seeding, signed-out no-throw, rebuild re-hydration, user-input-wins, `loadForEdit` not clobbered + no persist) and persistence (per-mode style, mode-switch style restore, style survives capture/text-input, voice filed under the picked language, remembered voice survives a language round trip).
- Widget tests: hermetic `_StubCraftPrefsCtrl` in `craft_screen_test.dart` + new "reopens in the last used mode"; idle-pill test now asserts `—` never renders.

## Verification

- `flutter test` full suite: all green (377 in craft + settings; full suite exit 0)
- `check_dart_format` / `flutter analyze` (0 new issues) / `check_codegen_drift` / `validate_ci_gates`: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)