### PR TITLE
fix(player): guard launch pipeline against stale open generation

### DIFF
--- a/lib/features/player/application/open_media_provider.dart
+++ b/lib/features/player/application/open_media_provider.dart
@@ -39,11 +39,19 @@ final openMediaLaunchProvider = FutureProvider.autoDispose
         await player.openMedia(request.mediaId);
       }
 
+      // Leaving the player mid-launch runs clearLivePlaybackSessionIfNeeded,
+      // whose clear() bumps the open generation. YouTube readiness can block
+      // for seconds, so every step after openMedia re-checks and bails instead
+      // of driving seek/play into the cleared engine (#654).
+      final gen = player.openGeneration;
+
       await player.activeEngine.awaitSurfaceReady();
+      if (player.isOpenStale(gen)) return;
 
       final start = request.startSec;
       if (start != null) {
         await player.seekToSeconds(start);
+        if (player.isOpenStale(gen)) return;
       }
 
       final end = request.endSec;
@@ -57,6 +65,7 @@ final openMediaLaunchProvider = FutureProvider.autoDispose
       }
 
       if (request.autoplay) {
+        if (player.isOpenStale(gen)) return;
         await player.play();
       }
     }, retry: null);

--- a/test/features/player/open_media_launch_provider_test.dart
+++ b/test/features/player/open_media_launch_provider_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/native.dart';
@@ -50,6 +51,20 @@ EchoSessionRow _session({
     createdAt: now,
     updatedAt: now,
   );
+}
+
+/// [FakePlayerEngine] whose [awaitSurfaceReady] blocks until released, so a
+/// test can hold the launch pipeline mid-flight (the YouTube readiness wait).
+class GatedSurfaceEngine extends FakePlayerEngine {
+  Completer<void>? surfaceReadyGate;
+  int awaitSurfaceReadyCalls = 0;
+
+  @override
+  Future<void> awaitSurfaceReady() async {
+    awaitSurfaceReadyCalls++;
+    final gate = surfaceReadyGate;
+    if (gate != null) await gate.future;
+  }
 }
 
 void main() {
@@ -163,5 +178,59 @@ void main() {
 
     expect(fake.seekCalls, contains(const Duration(milliseconds: 45000)));
     expect(fake.playCallCount, 0);
+  });
+
+  test('clear() mid-launch leaves the engine untouched after resume', () async {
+    final file = File('${pathProviderRoot.path}/c.mp3')..writeAsStringSync('x');
+    final id = await insertAudio(id: 'm3', localUri: file.uri.toString());
+    await db.echoSessionDao.upsert(
+      _session(targetId: id, currentTimeMs: 712000, echoActive: true),
+    );
+
+    final gated = GatedSurfaceEngine();
+    final gate = Completer<void>();
+    gated.surfaceReadyGate = gate;
+    final gatedContainer = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        playerEngineTestDoubleProvider.overrideWithValue(gated),
+        transcriptRepositoryProvider.overrideWithValue(
+          TranscriptRepository(db),
+        ),
+      ],
+    );
+    addTearDown(gatedContainer.dispose);
+
+    final request = PlayerLaunchRequest.vocabularyOpenSource(
+      mediaId: id,
+      startSec: 3.0,
+      endSec: 5.0,
+    );
+    final launch = gatedContainer.read(openMediaLaunchProvider(request).future);
+
+    // Hold the pipeline inside the readiness wait, then leave the player —
+    // clearLivePlaybackSessionIfNeeded clears the controller mid-launch.
+    final deadline = DateTime.now().add(const Duration(seconds: 2));
+    while (gated.awaitSurfaceReadyCalls == 0 &&
+        DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    expect(
+      gated.awaitSurfaceReadyCalls,
+      1,
+      reason: 'pipeline reached readiness',
+    );
+    await gatedContainer.read(playerControllerProvider.notifier).clear();
+
+    gate.complete();
+    await launch;
+
+    expect(
+      gated.seekCalls,
+      isEmpty,
+      reason: 'cleared engine must not be seeked',
+    );
+    expect(gated.playCallCount, 0, reason: 'cleared engine must not be played');
+    expect(gatedContainer.read(echoModeProvider).active, isFalse);
   });
 }


### PR DESCRIPTION
`openMediaLaunchProvider` ran its post-open steps (readiness wait, seek, clip window, autoplay) with no generation guard. Leaving the player route mid-launch runs `PlayerController.clear()`, which bumps the open generation — but a launch blocked in `awaitSurfaceReady` (up to 8 s on YouTube) then resumed and drove `seekToSeconds` + `play()` into the cleared engine. That is zombie playback after the learner already left the player, and it armed the D8 retry latch on a session that no longer existed.

This captures `openGeneration` right after `openMedia` and bails before the clip window and `play()`, re-checking after `awaitSurfaceReady` and after the seek — the same capture-then-check pattern `runPlayerOpen` already applies internally.

**Test plan**
- [x] New test `clear() mid-launch leaves the engine untouched after resume` in `test/features/player/open_media_launch_provider_test.dart`: a `FakePlayerEngine` subclass blocks inside `awaitSurfaceReady`, the test calls `clear()` while the pipeline is parked there, then releases the gate and asserts zero seeks, zero plays, and no re-activated echo window.
- [x] Confirmed the new test fails without the fix (cleared engine got seeked to 3 s), and passes with it.
- [x] `flutter analyze` — no new findings.
- [x] `flutter test test/features/player` — 644 passing.

Fixes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)