### PR TITLE
fix(youtube): prevent poll-loop re-entrancy from applying stale DOM state

### DIFF
--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -72,6 +72,20 @@ class YoutubeWebViewPollLoop {
   Timer? _pollTimer;
   Timer? _pollKickTimer;
 
+  /// A poll is awaited but not finished yet. [Timer.periodic] does not wait
+  /// for the previous callback, so a read that outlives one
+  /// [YoutubeAudiblePlaybackPolicy.pollTick] — a heavy page, the inject
+  /// interval, a GC pause — used to let the next tick issue a second read
+  /// while the first was still outstanding. Two overlapping reads resolve in
+  /// completion order, not issue order, so the OLDER DOM snapshot could apply
+  /// last: a stale `s=1` landing after end-of-media runs
+  /// [YoutubeSession.notePlayingConfirmed], which clears `_playbackCompleted`
+  /// and re-emits `playing=true` on a video that is already over (issue #655).
+  /// Dropping the tick rather than queuing it keeps the cadence self-correcting
+  /// — the next period samples the DOM again, so a slow page loses nothing but
+  /// the ordering hazard.
+  bool _pollInFlight = false;
+
   bool get isRunning => _pollTimer != null;
 
   void scheduleKick() {
@@ -99,118 +113,128 @@ class YoutubeWebViewPollLoop {
   }
 
   Future<void> _tick() async {
-    await pollFn(
-      disposed: session.disposed,
-      web: webController(),
-      onResult:
-          ({
-            required Duration position,
-            Duration? newDuration,
-            required bool jsPaused,
-            required bool jsEnded,
-          }) {
-            if (session.disposed) return;
-            session.emitPosition(position);
-            if (newDuration != null &&
-                newDuration > Duration.zero &&
-                newDuration != session.lastDuration) {
-              session.emitDuration(newDuration);
-            }
-            if (!jsPaused && !jsEnded) {
-              onPlaybackProgress?.call(position);
-            }
-            final transition = decidePollTransition(
-              jsEnded: jsEnded,
-              jsPaused: jsPaused,
-              playing: session.playing,
-              pausedPollStreak: session.pausedPollStreak,
-              pauseConfirmThreshold: YoutubeSession.pauseConfirmPollTicks,
-              playbackCompleted: session.playbackCompleted,
-            );
-            switch (transition) {
-              case MediaJustEnded():
-                // Surface the transition only — the transport's CompletionLoop
-                // is the single consumer of `completed` for repeat policy
-                // (ADR-0044). Stop polling; the loop's replay re-arms it via
-                // the explicit-play path.
-                session.noteEnded();
-                stop();
-              case PauseStreaking(:final confirmed, :final newStreak):
-                session.notePauseStreak(newStreak);
-                if (confirmed) {
-                  final immediate = session.isImmediatePause(DateTime.now());
-                  final retry = decideImmediatePauseRetry(
-                    immediate: immediate,
-                    userPlayInFlight: session.userPlayInFlight,
-                    disposed: session.disposed,
-                    playbackCompleted: session.playbackCompleted,
-                    lastPlayingFromAutoRetry: session.lastPlayingFromAutoRetry,
-                    autoRetriesIssued: session.autoRetriesIssued,
-                    maxAutoRetries: YoutubeSession.maxAutoRetries,
-                  );
-                  _logPoll.fine(
-                    'youtube pause confirmed vid=${session.videoId} '
-                    'positionMs=${position.inMilliseconds} '
-                    'immediate=$immediate '
-                    'explicitPlay=${session.explicitPlayAttempted}',
-                  );
-                  if (immediate) {
-                    _logPoll.info(
-                      'youtube immediate pause vid=${session.videoId} '
-                      'positionMs=${position.inMilliseconds}',
+    // See [_pollInFlight]: one read at a time, never two overlapping ones.
+    if (_pollInFlight) return;
+    _pollInFlight = true;
+    // `finally`, not the happy path: a pollFn that throws must not leave the
+    // guard latched and silently starve the loop while `isRunning` stays true.
+    try {
+      await pollFn(
+        disposed: session.disposed,
+        web: webController(),
+        onResult:
+            ({
+              required Duration position,
+              Duration? newDuration,
+              required bool jsPaused,
+              required bool jsEnded,
+            }) {
+              if (session.disposed) return;
+              session.emitPosition(position);
+              if (newDuration != null &&
+                  newDuration > Duration.zero &&
+                  newDuration != session.lastDuration) {
+                session.emitDuration(newDuration);
+              }
+              if (!jsPaused && !jsEnded) {
+                onPlaybackProgress?.call(position);
+              }
+              final transition = decidePollTransition(
+                jsEnded: jsEnded,
+                jsPaused: jsPaused,
+                playing: session.playing,
+                pausedPollStreak: session.pausedPollStreak,
+                pauseConfirmThreshold: YoutubeSession.pauseConfirmPollTicks,
+                playbackCompleted: session.playbackCompleted,
+              );
+              switch (transition) {
+                case MediaJustEnded():
+                  // Surface the transition only — the transport's CompletionLoop
+                  // is the single consumer of `completed` for repeat policy
+                  // (ADR-0044). Stop polling; the loop's replay re-arms it via
+                  // the explicit-play path.
+                  session.noteEnded();
+                  stop();
+                case PauseStreaking(:final confirmed, :final newStreak):
+                  session.notePauseStreak(newStreak);
+                  if (confirmed) {
+                    final immediate = session.isImmediatePause(DateTime.now());
+                    final retry = decideImmediatePauseRetry(
+                      immediate: immediate,
+                      userPlayInFlight: session.userPlayInFlight,
+                      disposed: session.disposed,
+                      playbackCompleted: session.playbackCompleted,
+                      lastPlayingFromAutoRetry:
+                          session.lastPlayingFromAutoRetry,
+                      autoRetriesIssued: session.autoRetriesIssued,
+                      maxAutoRetries: YoutubeSession.maxAutoRetries,
                     );
-                  }
-                  session.notePauseConfirmed();
-                  switch (retry) {
-                    case RetryPlayOnce():
-                      // Consume the command budget before re-playing; further
-                      // retries for this pause chain come from the capped
-                      // escalation arm (auto-retry attribution), so a
-                      // deliberate pause is never fought indefinitely.
-                      session.clearUserPlayInFlight();
-                      // Timestamp the issue: the audible policy's
-                      // post-restore heal suppresses itself while a retry
-                      // is this recent (same pause, one play).
-                      session.noteAutoPlayRetry();
+                    _logPoll.fine(
+                      'youtube pause confirmed vid=${session.videoId} '
+                      'positionMs=${position.inMilliseconds} '
+                      'immediate=$immediate '
+                      'explicitPlay=${session.explicitPlayAttempted}',
+                    );
+                    if (immediate) {
                       _logPoll.info(
-                        'youtube immediate pause retry vid='
-                        '${session.videoId}',
+                        'youtube immediate pause vid=${session.videoId} '
+                        'positionMs=${position.inMilliseconds}',
                       );
-                      unawaited(
-                        retryPlay(webController()).catchError((
-                          Object error,
-                          StackTrace stackTrace,
-                        ) {
-                          // The budget is already spent; surface the failed
-                          // retry instead of an unhandled zone error that
-                          // reads as a crash with no context.
-                          _logPoll.warning(
-                            'youtube immediate pause retry failed '
-                            'vid=${session.videoId}',
-                            error,
-                            stackTrace,
-                          );
-                        }),
-                      );
-                    case SurfacePause():
-                      if (immediate || session.explicitPlayAttempted) {
-                        session.scheduleRecoveryHint();
-                      }
+                    }
+                    session.notePauseConfirmed();
+                    switch (retry) {
+                      case RetryPlayOnce():
+                        // Consume the command budget before re-playing; further
+                        // retries for this pause chain come from the capped
+                        // escalation arm (auto-retry attribution), so a
+                        // deliberate pause is never fought indefinitely.
+                        session.clearUserPlayInFlight();
+                        // Timestamp the issue: the audible policy's
+                        // post-restore heal suppresses itself while a retry
+                        // is this recent (same pause, one play).
+                        session.noteAutoPlayRetry();
+                        _logPoll.info(
+                          'youtube immediate pause retry vid='
+                          '${session.videoId}',
+                        );
+                        unawaited(
+                          retryPlay(webController()).catchError((
+                            Object error,
+                            StackTrace stackTrace,
+                          ) {
+                            // The budget is already spent; surface the failed
+                            // retry instead of an unhandled zone error that
+                            // reads as a crash with no context.
+                            _logPoll.warning(
+                              'youtube immediate pause retry failed '
+                              'vid=${session.videoId}',
+                              error,
+                              stackTrace,
+                            );
+                          }),
+                        );
+                      case SurfacePause():
+                        if (immediate || session.explicitPlayAttempted) {
+                          session.scheduleRecoveryHint();
+                        }
+                    }
+                    // Keep polling after pause so a subsequent play attempt can
+                    // detect DOM state even if `playing`/`playRejected` is missed.
+                    // Position updates while paused are cheap; stop only on ended.
                   }
-                  // Keep polling after pause so a subsequent play attempt can
-                  // detect DOM state even if `playing`/`playRejected` is missed.
-                  // Position updates while paused are cheap; stop only on ended.
-                }
-              case PollPlaying():
-                session.notePlayingConfirmed();
-                onFirstPlaying();
-                if (session.buffering) {
-                  session.emitBuffering(false);
-                }
-              case PollIdleTick():
-                session.resetPauseStreak();
-            }
-          },
-    );
+                case PollPlaying():
+                  session.notePlayingConfirmed();
+                  onFirstPlaying();
+                  if (session.buffering) {
+                    session.emitBuffering(false);
+                  }
+                case PollIdleTick():
+                  session.resetPauseStreak();
+              }
+            },
+      );
+    } finally {
+      _pollInFlight = false;
+    }
   }
 }

--- a/test/features/player/application/engines/youtube/youtube_webview_poll_loop_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_webview_poll_loop_test.dart
@@ -47,6 +47,44 @@ class _FakePollDriver {
   }
 }
 
+/// Poll double whose reads never resolve on their own: the test settles them
+/// one at a time and chooses the ORDER. That order is exactly what the real
+/// loop cannot control — a read that outlives a tick resolves after a later
+/// one (issue #655).
+class _GatedPollDriver {
+  final List<_ResultFn> reads = [];
+  final List<Completer<void>> _gates = [];
+
+  Future<void> poll({
+    required bool disposed,
+    required InAppWebViewController? web,
+    required _ResultFn onResult,
+  }) async {
+    reads.add(onResult);
+    final gate = Completer<void>();
+    _gates.add(gate);
+    await gate.future;
+  }
+
+  /// Applies DOM [state] through the read issued at index [call] (issue
+  /// order) and lets that poll future settle.
+  void settle(
+    int call, {
+    Duration position = Duration.zero,
+    Duration? newDuration,
+    bool jsPaused = false,
+    bool jsEnded = false,
+  }) {
+    reads[call](
+      position: position,
+      newDuration: newDuration,
+      jsPaused: jsPaused,
+      jsEnded: jsEnded,
+    );
+    _gates[call].complete();
+  }
+}
+
 void main() {
   group('YoutubeWebViewPollLoop', () {
     late YoutubeSession session;
@@ -150,6 +188,101 @@ void main() {
         loop.stop();
       },
     );
+
+    test('skips the tick while a poll is still in flight', () async {
+      // Timer.periodic does not wait for the previous callback: a read that
+      // outlives one pollTick (heavy page, the 300 ms inject interval, GC)
+      // used to let the next tick start a second read, and the two resolved
+      // in completion order rather than issue order. One read at a time is
+      // the whole invariant (issue #655).
+      final driver = _GatedPollDriver();
+      var firstPlayingCalls = 0;
+      final loop = YoutubeWebViewPollLoop(
+        session: session,
+        webController: () => null,
+        onFirstPlaying: () => firstPlayingCalls++,
+        pollFn: driver.poll,
+      );
+
+      loop.start();
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      // One full extra period elapses while read #0 is still awaited.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(
+        driver.reads,
+        hasLength(1),
+        reason: 'the overlapping tick must not issue a second read',
+      );
+      expect(firstPlayingCalls, 0);
+
+      // Skipping the tick costs nothing: settling the one read still drives
+      // the transport.
+      driver.settle(0, position: const Duration(milliseconds: 250));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(session.playing, isTrue);
+      expect(firstPlayingCalls, 1);
+
+      loop.stop();
+    });
+
+    test('a late read cannot resurrect playing after end-of-media', () async {
+      // Issue #655's worst case: the read issued first resolved LAST with a
+      // stale s=1 and landed after the fresher read had reported ended —
+      // notePlayingConfirmed() then cleared _playbackCompleted and re-emitted
+      // playing=true on a video that was already over.
+      final driver = _GatedPollDriver();
+      var completedFired = false;
+      var playingTrueAfterCompleted = 0;
+      final completedSub = session.completed.listen((_) {
+        completedFired = true;
+      });
+      final playingSub = session.playingStream.listen((v) {
+        // The `playing=false` of the ended transition itself is delivered
+        // after `completed` (both controllers deliver asynchronously); only a
+        // later `true` is a resurrection.
+        if (completedFired && v) playingTrueAfterCompleted++;
+      });
+      session.emitPlaying(true);
+
+      final loop = YoutubeWebViewPollLoop(
+        session: session,
+        webController: () => null,
+        onFirstPlaying: () {},
+        pollFn: driver.poll,
+      );
+
+      loop.start();
+      // Two full periods: read #0 is still awaited and the overlapping tick
+      // has been skipped.
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+      expect(
+        driver.reads,
+        hasLength(1),
+        reason:
+            'no second read may be issued — a second read is what let a '
+            'stale snapshot apply after the end-of-media one',
+      );
+
+      // The DOM truth arrives through the only in-flight read: ended.
+      driver.settle(
+        0,
+        position: const Duration(seconds: 60),
+        jsPaused: true,
+        jsEnded: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(session.playbackCompleted, isTrue);
+      expect(session.playing, isFalse);
+      // Nothing may follow the completion — above all no stale `playing`.
+      expect(playingTrueAfterCompleted, 0);
+      expect(loop.isRunning, isFalse);
+
+      await completedSub.cancel();
+      await playingSub.cancel();
+      loop.stop();
+    });
 
     test('does not start the poll timer when session is disposed', () async {
       var firstPlayingCalls = 0;


### PR DESCRIPTION
## What / why

`YoutubeWebViewPollLoop` drove its DOM poll with `Timer.periodic(pollTick, (_) => _tick())`, where `_tick` is async and had no in-flight guard. `Timer.periodic` does not wait for the previous callback, so any read that outlived one 250 ms tick — a heavy watch page, the 300 ms inject interval, a GC pause — let the next tick issue a second `evaluateJavascript` while the first was still outstanding. Two overlapping reads resolve in completion order rather than issue order, so the OLDER DOM snapshot could apply last. The worst case was a stale `s=1` landing after end-of-media: it decided `PollPlaying`, ran `session.notePlayingConfirmed()`, which clears `_playbackCompleted` and re-emits `playing=true` on a video that is already over, leaving the transport showing playing while the video has ended (#655).

The fix is a single in-flight guard: a tick that arrives while a read is still awaited is dropped, not queued. Skipping is enough because the next period samples the DOM again — a slow page loses nothing but the ordering hazard, and the cadence stays self-correcting. The guard resets in a `finally` so a throwing `pollFn` cannot latch it and silently starve the loop while `isRunning` still reads true. `start`/`stop`/`scheduleKick` semantics, the inject script, and the poll cadence are unchanged.

Everything after the guard line is the mechanical re-indent of the existing `onResult` body inside the new `try`; `git diff -w` shows the only semantic change is the guard itself.

## Test plan

- [x] New `skips the tick while a poll is still in flight`: a gated `pollFn` double holds its first read open across a full extra period and asserts only one read was issued, then that settling it still drives the transport (`playing`, `onFirstPlaying`).
- [x] New `a late read cannot resurrect playing after end-of-media`: the only in-flight read settles with `jsEnded`, and asserts `playbackCompleted`, `playing=false`, `isRunning=false`, and zero `playing=true` events after `completed`.
- [x] Both new tests fail without the fix (the old loop issues a second read) and pass with it.
- [x] `flutter analyze` — no new findings (same 4 pre-existing infos in unrelated files).
- [x] `flutter test test/features/player` — 645 passing.

Fixes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)