### PR TITLE
fix(player): EchoEnforcer — stale seek after reset, bounded wait, cached window

### DIFF
--- a/lib/features/player/application/echo_enforcer.dart
+++ b/lib/features/player/application/echo_enforcer.dart
@@ -8,13 +8,19 @@
 /// gate (issue #280, P1/P6/M3).
 library;
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/data/subtitle/transcript_line.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/player_engine_constants.dart';
 import 'package:enjoy_player/features/player/domain/echo_window.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
+
+final _echoLog = logNamed('EchoEnforcer');
 
 /// Serializes echo enforcement for one open generation.
 ///
@@ -52,6 +58,15 @@ class EchoEnforcer {
   /// two synchronous position events.
   Future<void>? _inFlight;
 
+  /// Inputs behind the memoized window in [_windowCache]: the fields the hot
+  /// path can compare for free (echo state by value, session duration). The
+  /// transcript is re-read on a miss only (see [_resolveWindow]). `null` until
+  /// the first derivation and after [reset].
+  (EchoState, double?)? _windowCacheKey;
+
+  /// Last derived non-override window for [_windowCacheKey].
+  EchoWindow? _windowCache;
+
   /// Reactive per-tick enforcement. Called on every position event — the
   /// decision is cheap (pure reads), so the segment-end pause fires promptly.
   /// If enforcement is already in flight, this tick is dropped (single-flight):
@@ -75,19 +90,26 @@ class EchoEnforcer {
 
   /// Proactive seek clamp (user tapped a cue / scrubbed). Clamps the requested
   /// target into the echo window and seeks, serialized against reactive ticks.
-  /// Returns the (possibly clamped) target actually sought.
+  /// Returns the (possibly clamped) target actually sought, or the unclamped
+  /// [requestedSeconds] when nothing was sought — a [reset] landed while
+  /// waiting, or the in-flight enforcement never settled within [waitTimeout].
   Future<double> clampAndSeek(
     double requestedSeconds, {
     EchoWindow? override,
+    Duration waitTimeout = kEngineCommandTimeout,
   }) async {
-    while (true) {
+    // Captured before the first await: if [reset] lands while we wait on an
+    // in-flight enforcement, the requested target belongs to media that is
+    // gone, and re-entering the loop with a fresh epoch would seek the old
+    // target onto the new engine (unclamped, its echo being inactive).
+    final epoch = _epoch;
+    while (_epoch == epoch) {
       final pending = _inFlight;
       if (pending == null) {
         final window = _resolveWindow(override: override);
         final target = window == null
             ? requestedSeconds
             : clampSeekTimeToEchoWindow(requestedSeconds, window);
-        final epoch = _epoch;
         final future = _seek(target, epoch);
         _inFlight = future;
         try {
@@ -97,9 +119,23 @@ class EchoEnforcer {
         }
         return target;
       }
-      // An enforcement is running; wait for it, then re-check.
-      await pending;
+      // An enforcement is running; wait for it (bounded — a wedged engine seek
+      // must not hold the slot forever), then re-check.
+      try {
+        await pending.timeout(waitTimeout);
+      } on TimeoutException {
+        _echoLog.warning(
+          'echo enforcement still in flight after $waitTimeout '
+          '(engine seek wedged?); releasing the slot and skipping the clamp '
+          'seek',
+        );
+        // The wedged op's own finally is guarded by identity, so clearing here
+        // cannot race it out of a slot it still owns.
+        if (_inFlight == pending) _inFlight = null;
+        return requestedSeconds;
+      }
     }
+    return requestedSeconds;
   }
 
   /// Neutralizes any in-flight enforcement and releases the slot. Called on
@@ -108,6 +144,10 @@ class EchoEnforcer {
   void reset() {
     _epoch++;
     _inFlight = null;
+    // The window is derived from the previous media's session; re-derive for
+    // the next one rather than serving a cached duration / transcript.
+    _windowCacheKey = null;
+    _windowCache = null;
   }
 
   Future<void> _applyDecision(EchoPlaybackDecision decision, int epoch) async {
@@ -132,15 +172,42 @@ class EchoEnforcer {
   }
 
   /// Resolves the effective echo window. When [override] is given (a freshly
-  /// tapped cue) it wins; otherwise seconds are re-derived from the line
-  /// indices + current transcript (single source of truth), falling back to the
-  /// cached seconds captured at activation / expand / shrink time when no
-  /// transcript is available.
+  /// tapped cue) it wins; otherwise the derivation is memoized on its inputs
+  /// (see [_deriveWindow]) so the per-position-event hot path only recomputes
+  /// when the echo state or the session duration actually changed.
   EchoWindow? _resolveWindow({EchoWindow? override}) {
     final echo = ref.read(echoModeProvider);
     if (!echo.active) return null;
     final durationSeconds = getSession()?.durationSeconds;
 
+    if (override != null) {
+      return _deriveWindow(
+        echo,
+        durationSeconds: durationSeconds,
+        override: override,
+      );
+    }
+
+    // EchoState compares by value, so this is a cheap no-allocation key. A
+    // transcript-only change (re-segmentation) is picked up on the next echo /
+    // duration change, or on [reset] at the next media switch.
+    final key = (echo, durationSeconds);
+    if (_windowCacheKey == key) return _windowCache;
+    final window = _deriveWindow(echo, durationSeconds: durationSeconds);
+    _windowCacheKey = key;
+    _windowCache = window;
+    return window;
+  }
+
+  /// Derives the effective window: [override] wins; otherwise seconds come
+  /// from [echo]'s line indices + current transcript (single source of truth),
+  /// falling back to the seconds cached at activation / expand / shrink time
+  /// when no transcript is available.
+  EchoWindow? _deriveWindow(
+    EchoState echo, {
+    double? durationSeconds,
+    EchoWindow? override,
+  }) {
     final double startSeconds;
     final double endSeconds;
     if (override != null) {

--- a/test/features/player/application/echo_enforcer_test.dart
+++ b/test/features/player/application/echo_enforcer_test.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+
+import 'package:enjoy_player/data/subtitle/transcript_line.dart';
+import 'package:enjoy_player/features/player/application/echo_enforcer.dart';
+import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../support/fake_player_engine.dart';
+
+void main() {
+  // Echo segment 0–5 s over two cues at 0–2 s and 2–5 s.
+  List<TranscriptLine> lines() => const [
+    TranscriptLine(text: 'a', startMs: 0, durationMs: 2000),
+    TranscriptLine(text: 'b', startMs: 2000, durationMs: 3000),
+  ];
+
+  test(
+    'reset during an in-flight enforcement drops the queued clamp seek',
+    () async {
+      final h = _Harness(lines: lines());
+      addTearDown(h.dispose);
+      h.activateEcho(startSeconds: 0, endSeconds: 5);
+
+      // Reactive pause-and-rewind, with its rewind seek held in flight.
+      final gate = Completer<void>();
+      h.engine.seekGate = gate;
+      final tick = h.enforcer.enforceTick(4.97);
+      await Future<void>.delayed(Duration.zero);
+      expect(h.engine.pauseCallCount, 1);
+      expect(h.engine.seekCalls, [Duration.zero]);
+
+      // A user seek queues behind it, then the media is switched (reset) before
+      // the rewind settles.
+      final clamp = h.enforcer.clampAndSeek(9.0);
+      h.enforcer.reset();
+      gate.complete();
+
+      // Nothing may be sought on the (new) engine: the stale request would land
+      // unclamped there, its echo being inactive.
+      expect(
+        await clamp,
+        9.0,
+        reason: 'the abandoned request is reported back unclamped',
+      );
+      expect(h.engine.seekCalls, hasLength(1));
+      await tick;
+    },
+  );
+
+  test(
+    'a never-settling enforcement is released by the wait timeout',
+    () async {
+      final h = _Harness(lines: lines());
+      addTearDown(h.dispose);
+      h.activateEcho(startSeconds: 0, endSeconds: 5);
+
+      // The rewind seek never completes (wedged engine).
+      h.engine.seekGate = Completer<void>();
+      unawaited(h.enforcer.enforceTick(4.97));
+      await Future<void>.delayed(Duration.zero);
+      expect(h.engine.pauseCallCount, 1);
+
+      final clamped = await h.enforcer.clampAndSeek(
+        9.0,
+        waitTimeout: const Duration(milliseconds: 20),
+      );
+
+      expect(
+        clamped,
+        9.0,
+        reason: 'returns instead of hanging on the wedged op',
+      );
+      expect(h.engine.seekCalls, hasLength(1));
+
+      // The slot is released, so enforcement keeps working for the session.
+      expect(
+        await h.enforcer.clampAndSeek(
+          3.0,
+          waitTimeout: const Duration(milliseconds: 20),
+        ),
+        3.0,
+      );
+      expect(h.engine.seekCalls, hasLength(2));
+    },
+  );
+
+  test('window derivation is memoized across position events', () async {
+    final h = _Harness(lines: lines());
+    addTearDown(h.dispose);
+    h.activateEcho(startSeconds: 0, endSeconds: 5);
+
+    for (var i = 0; i < 20; i++) {
+      await h.enforcer.enforceTick(1.0 + i * 0.01);
+    }
+    expect(
+      h.lineProbeCalls,
+      1,
+      reason: 'the derivation must not run on every position event',
+    );
+
+    // ...but an input that actually changed must re-derive, not serve stale
+    // boundaries.
+    h.durationSeconds = 60;
+    await h.enforcer.enforceTick(1.0);
+    expect(h.lineProbeCalls, 2);
+  });
+
+  test('an override window is never served from the cache', () async {
+    final h = _Harness(lines: lines());
+    addTearDown(h.dispose);
+    h.activateEcho(startSeconds: 0, endSeconds: 5);
+
+    await h.enforcer.enforceTick(3.0);
+    expect(h.lineProbeCalls, 1);
+
+    // A freshly tapped cue wins over the cached window...
+    await h.enforcer.clampAndSeek(9.0, override: (start: 1, end: 2));
+    expect(h.engine.seekCalls, [const Duration(milliseconds: 1980)]);
+
+    // ...without clobbering the cache for the reactive ticks.
+    await h.enforcer.enforceTick(3.0);
+    expect(h.lineProbeCalls, 1);
+  });
+}
+
+/// Wires an [EchoEnforcer] to a [FakePlayerEngine] through a real container so
+/// the echo mode notifier and the provider reads behave as in production.
+class _Harness {
+  _Harness({required this.lines}) {
+    final container = ProviderContainer();
+    this.container = container;
+    final harness = this;
+    enforcer = container.read(
+      Provider<EchoEnforcer>(
+        (ref) => EchoEnforcer(
+          ref: ref,
+          getEngine: () => engine,
+          getSession: () => session,
+          getLines: () {
+            harness.lineProbeCalls++;
+            return harness.lines;
+          },
+        ),
+      ),
+    );
+  }
+
+  final FakePlayerEngine engine = FakePlayerEngine();
+  final List<TranscriptLine> lines;
+  late final ProviderContainer container;
+  late final EchoEnforcer enforcer;
+
+  int lineProbeCalls = 0;
+
+  double durationSeconds = 120;
+
+  PlaybackSession get session => _sessionAt(durationSeconds);
+
+  void activateEcho({
+    required double startSeconds,
+    required double endSeconds,
+  }) {
+    container
+        .read(echoModeProvider.notifier)
+        .activate(
+          startLineIndex: 0,
+          endLineIndex: lines.length - 1,
+          startTimeSeconds: startSeconds,
+          endTimeSeconds: endSeconds,
+        );
+  }
+
+  void dispose() => container.dispose();
+}
+
+PlaybackSession _sessionAt(double durationSeconds) {
+  final now = DateTime.now();
+  return PlaybackSession(
+    mediaId: 'media-1',
+    dexieTargetType: 'Audio',
+    mediaType: 'audio',
+    mediaTitle: 't',
+    durationSeconds: durationSeconds,
+    currentTimeSeconds: 0,
+    currentSegmentIndex: 0,
+    language: 'en',
+    startedAt: now,
+    lastActiveAt: now,
+  );
+}


### PR DESCRIPTION
## What

Single file (`lib/features/player/application/echo_enforcer.dart`) + new tests. Three fixes, all in the echo enforcement coordinator:

- **Stale un-clamped seek after reset.** `clampAndSeek` captured the epoch inside its wait loop, *after* `await pending`. A `reset()` (media switch / clear) landing while the clamp waited on an in-flight enforcement let the loop re-capture the fresh epoch and seek the **old** `requestedSeconds` on the **new** engine — unclamped, since the new media's echo is inactive. The epoch is now captured at method entry and the loop bails (returning the request untouched) if it changed while waiting.
- **Unbounded wait.** `await pending` had no limit: one wedged engine seek (the `kEngineCommandTimeout` wedge class) hung `PlayerController.seekTo` forever and left `_inFlight` set, silently disabling echo enforcement for the rest of the session. The wait is now bounded by `kEngineCommandTimeout` (overridable, mirroring `runBoundedEngineStep`'s `limit`), logs a warning, releases the slot, and returns the caller's request without seeking — so later enforcement still works.
- **Per-tick re-derivation.** `_resolveWindow` re-derived the echo window on every position event: two provider reads plus a `normalizeEchoWindow` record allocation and line-index lookups per tick. The non-override derivation is now memoized on the inputs the hot path can compare for free — echo state (compares by value) + session duration — re-reading the transcript only on a cache miss, and `reset()` drops the cache with the epoch.

## Why

`clampAndSeek` is the one path where a media switch can turn a queued echo clamp into a stray seek on unrelated media; and a single wedged seek previously took echo enforcement down for the whole session without any signal. The per-tick derivation ran ~30×/s for no reason while the window only moves when echo state or duration does.

Note on the cache key: a transcript-only change (re-segmentation) is picked up on the next echo/duration change or on the next media switch rather than immediately — the per-tick hot path no longer consults the transcript provider. The `override` (freshly tapped cue) path is never served from the cache and never clobbers it.

## Test plan

- [x] New `test/features/player/application/echo_enforcer_test.dart` (4 tests):
  - `reset()` during an in-flight enforcement issues no seek and reports the request back unclamped — **fails on `main`** (returned the clamped stale target 4.98 and issued the stray seek).
  - a never-resolving enforcement future is released by the wait timeout and the slot keeps working afterwards.
  - window-derivation count over 20 position events is **1**, not 20 — **fails on `main`** (20) — and still re-derives when the duration actually changes.
  - an `override` window bypasses the cache and does not clobber it.
- [x] `flutter analyze` — clean (only the 4 pre-existing `prefer_const_constructors` infos in unrelated test files).
- [x] `flutter test test/features/player` — 647 passing.

Fixes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)