### PR TITLE
fix(player): guard CompletionLoop replay, duration-listener writes; make mpv guard honest

### DIFF
--- a/lib/features/player/application/completion_loop.dart
+++ b/lib/features/player/application/completion_loop.dart
@@ -91,17 +91,29 @@ class CompletionLoop {
 
         final decision = decideOnMediaEnd(repeatMode: _repeatMode());
         _log.fine('completion fired for $mediaId; decision=$decision');
-        switch (decision) {
-          case StopAtEnd():
-            return;
-          case LoopMedia():
-            await _replayFrom(Duration.zero, gen);
-            if (gen != _playbackGen || _isDisposed()) return;
-          case LoopSegment():
-            final echo = _echoSnapshot();
-            if (!echo.active) return;
-            await _replayFrom(durationFromSeconds(echo.startTimeSeconds), gen);
-            if (gen != _playbackGen || _isDisposed()) return;
+        // A replay that throws (engine seek/play failing at end-of-media) must
+        // not escape [unawaited] — it would surface as an unhandled async
+        // error and the `finally` would drop the loop either way, killing
+        // repeat/segment-loop for the rest of the stint. Log and stop instead.
+        try {
+          switch (decision) {
+            case StopAtEnd():
+              return;
+            case LoopMedia():
+              await _replayFrom(Duration.zero, gen);
+              if (gen != _playbackGen || _isDisposed()) return;
+            case LoopSegment():
+              final echo = _echoSnapshot();
+              if (!echo.active) return;
+              await _replayFrom(
+                durationFromSeconds(echo.startTimeSeconds),
+                gen,
+              );
+              if (gen != _playbackGen || _isDisposed()) return;
+          }
+        } catch (e, st) {
+          _log.warning('replay for $mediaId failed; loop stopped', e, st);
+          return;
         }
       }
     } finally {

--- a/lib/features/player/application/player_engine.dart
+++ b/lib/features/player/application/player_engine.dart
@@ -152,17 +152,14 @@ class MediaKitPlayerEngine implements PlayerEngine {
   mk.Player? __player;
 
   /// Set by [prepareNativeBackend] after the previous platform view has
-  /// detached. Stream / snapshot getters must not construct [mk.Player]
-  /// before this — a YouTube → local open otherwise allocates mpv in the
-  /// same frame the WebView starts destroying (2026-08-30 field report).
+  /// detached. Only [buildVideoStage] consults it: the stream/snapshot getters
+  /// read `__player` without ever constructing, and the command path
+  /// ([_player]) allocates mpv unconditionally — the WebView-detach wait lives
+  /// in the swap (player_engine_binding), not in a getter (2026-08-30 field
+  /// report, issue #658).
   var _nativeBackendAllowed = false;
 
-  mk.Player get _player {
-    if (!_nativeBackendAllowed) {
-      _nativeBackendAllowed = true;
-    }
-    return __player ??= mk.Player();
-  }
+  mk.Player get _player => __player ??= mk.Player();
 
   mk.Player get player => _player;
 

--- a/lib/features/player/application/player_position_tracker.dart
+++ b/lib/features/player/application/player_position_tracker.dart
@@ -171,18 +171,25 @@ class PlayerPositionTracker {
         final sec = d.inMilliseconds ~/ 1000;
         setSession(getSession()?.copyWith(durationSeconds: newSec));
         final db = ref.read(appDatabaseProvider);
-        if (kind == MediaKind.video &&
-            video != null &&
-            video.durationSeconds == 0) {
-          await db.videoDao.insertRow(
-            video.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
-          );
-        } else if (kind == MediaKind.audio &&
-            audio != null &&
-            audio.durationSeconds == 0) {
-          await db.audioDao.insertRow(
-            audio.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
-          );
+        // One-off duration backfill. Guarded like the position tick above: a
+        // Drift throw must not surface as an uncaught async exception from a
+        // stream listener and take playback down with it.
+        try {
+          if (kind == MediaKind.video &&
+              video != null &&
+              video.durationSeconds == 0) {
+            await db.videoDao.insertRow(
+              video.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
+            );
+          } else if (kind == MediaKind.audio &&
+              audio != null &&
+              audio.durationSeconds == 0) {
+            await db.audioDao.insertRow(
+              audio.copyWith(durationSeconds: sec, updatedAt: DateTime.now()),
+            );
+          }
+        } catch (e, st) {
+          _positionLog.warning('duration backfill write failed', e, st);
         }
       },
       onError: (Object e, StackTrace st) {

--- a/test/features/player/application/completion_loop_test.dart
+++ b/test/features/player/application/completion_loop_test.dart
@@ -1,8 +1,34 @@
 import 'package:enjoy_player/features/player/application/completion_loop.dart';
 import 'package:enjoy_player/features/player/domain/player_settings.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
 
 import '../../../support/fake_player_engine.dart';
+
+/// Engine double whose replay path throws, simulating an end-of-media engine
+/// error: [seekFailuresLeft] seek failures first, then an optional persistent
+/// [failPlay].
+class _FailingReplayEngine extends FakePlayerEngine {
+  _FailingReplayEngine({this.seekFailuresLeft = 1, this.failPlay = false});
+
+  int seekFailuresLeft;
+  bool failPlay;
+
+  @override
+  Future<void> seek(Duration target) async {
+    seekCalls.add(target);
+    if (seekFailuresLeft > 0) {
+      seekFailuresLeft--;
+      throw StateError('engine seek failed at end of media');
+    }
+  }
+
+  @override
+  Future<void> play() async {
+    playCallCount++;
+    if (failPlay) throw StateError('engine play failed at end of media');
+  }
+}
 
 void main() {
   group('CompletionLoop', () {
@@ -37,6 +63,23 @@ void main() {
 
     Future<void> settle() =>
         Future<void>.delayed(const Duration(milliseconds: 20));
+
+    CompletionLoop loopOn(FakePlayerEngine engine) => CompletionLoop(
+      engine: () => engine,
+      activeMediaId: () => mediaId,
+      isDisposed: () => disposed,
+      repeatMode: () => repeat,
+      echoSnapshot: () => (active: echoActive, startTimeSeconds: echoStart),
+    );
+
+    /// Captures the loop's log channel; the returned subscription is torn down
+    /// with the test.
+    List<LogRecord> captureLoopLogs() {
+      final records = <LogRecord>[];
+      final sub = Logger('CompletionLoop').onRecord.listen(records.add);
+      addTearDown(sub.cancel);
+      return records;
+    }
 
     test('single loops: seeks to zero and plays on completion', () async {
       loop.arm();
@@ -182,5 +225,68 @@ void main() {
 
       expect(fake.seekCalls, isEmpty);
     });
+
+    test(
+      'a throwing seek at replay logs instead of escaping the loop',
+      () async {
+        // An escaping error would surface as an unhandled async exception in
+        // this zone and fail the test — passing is part of the assertion.
+        fake = _FailingReplayEngine();
+        loop = loopOn(fake);
+        final records = captureLoopLogs();
+
+        loop.arm();
+        await settle();
+        fake.emitCompleted();
+        await settle();
+
+        expect(fake.seekCalls, [Duration.zero]);
+        expect(fake.playCallCount, 0);
+        expect(records.where((r) => r.level >= Level.WARNING), isNotEmpty);
+      },
+    );
+
+    test(
+      'a throwing play() after a successful seek is contained too',
+      () async {
+        fake = _FailingReplayEngine(seekFailuresLeft: 0, failPlay: true);
+        loop = loopOn(fake);
+        final records = captureLoopLogs();
+
+        loop.arm();
+        await settle();
+        fake.emitCompleted();
+        await settle();
+
+        expect(fake.seekCalls, [Duration.zero]);
+        expect(fake.playCallCount, 1);
+        expect(records.where((r) => r.level >= Level.WARNING), isNotEmpty);
+      },
+    );
+
+    test(
+      'a failed replay leaves the loop re-armable for the same media',
+      () async {
+        final failing = _FailingReplayEngine();
+        loop = loopOn(failing);
+        loop.arm();
+        await settle();
+        failing.emitCompleted();
+        await settle();
+        expect(failing.playCallCount, 0);
+
+        // Engine recovered: a fresh [arm] must start a new loop, not stay wedged
+        // on the one that just failed.
+        fake = _FailingReplayEngine(seekFailuresLeft: 0);
+        loop = loopOn(fake);
+        loop.arm();
+        await settle();
+        fake.emitCompleted();
+        await settle();
+
+        expect(fake.seekCalls, [Duration.zero]);
+        expect(fake.playCallCount, 1);
+      },
+    );
   });
 }

--- a/test/features/player/application/media_kit_player_engine_linux_test.dart
+++ b/test/features/player/application/media_kit_player_engine_linux_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io' show Platform;
 
 import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -24,6 +25,40 @@ void main() {
           true,
           reason: 'media_kit screenshot works on Linux (libmpv frame capture).',
         );
+      },
+    );
+
+    testWidgets(
+      'native backend gate lives in buildVideoStage only (issue #658)',
+      (tester) async {
+        final engine = MediaKitPlayerEngine();
+
+        late BuildContext context;
+        await tester.pumpWidget(
+          Builder(
+            builder: (ctx) {
+              context = ctx;
+              return const SizedBox.shrink();
+            },
+          ),
+        );
+
+        Widget stage() => engine.buildVideoStage(
+          context: context,
+          maxWidth: 320,
+          maxHeight: 180,
+        );
+
+        // Not allowed yet: a bare placeholder — no Video, hence no
+        // [videoController] and no mpv allocation.
+        expect((stage() as ColoredBox).child, isNull);
+
+        // Engine entry points other than [prepareNativeBackend] must not
+        // approve the gate. The old `_player` getter did exactly that (it set
+        // `_nativeBackendAllowed = true` while claiming to check it), so the
+        // gate is now stage-only and nothing else can flip it.
+        engine.warmVideoSurface();
+        expect((stage() as ColoredBox).child, isNull);
       },
     );
   });

--- a/test/features/player/application/player_position_tracker_test.dart
+++ b/test/features/player/application/player_position_tracker_test.dart
@@ -1,0 +1,142 @@
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/library/domain/media.dart';
+import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+
+import '../../../support/fake_player_engine.dart';
+
+/// Video DAO that always fails to insert — a Drift write blowing up mid-play.
+class _ThrowingVideoDao extends VideoDao {
+  _ThrowingVideoDao(super.db);
+
+  int insertCalls = 0;
+
+  @override
+  Future<void> insertRow(VideoRow row) async {
+    insertCalls++;
+    throw StateError('disk I/O error');
+  }
+}
+
+/// Database whose [videoDao] throws, so the tracker hits a real failing write
+/// instead of a mock seam.
+class _ThrowingVideoDatabase extends AppDatabase {
+  _ThrowingVideoDatabase() : super(executor: NativeDatabase.memory());
+
+  late final _ThrowingVideoDao throwingVideoDao = _ThrowingVideoDao(
+    this as AppDatabase,
+  );
+
+  @override
+  VideoDao get videoDao => throwingVideoDao;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PlayerPositionTracker duration listener', () {
+    late _ThrowingVideoDatabase db;
+    late FakePlayerEngine fake;
+    late ProviderContainer container;
+    late PlaybackSession? session;
+
+    setUp(() {
+      db = _ThrowingVideoDatabase();
+      fake = FakePlayerEngine();
+      session = PlaybackSession(
+        mediaId: 'v1',
+        dexieTargetType: 'Video',
+        mediaType: 'video',
+        mediaTitle: 't',
+        durationSeconds: 0,
+        currentTimeSeconds: 0,
+        currentSegmentIndex: -1,
+        language: 'en',
+        startedAt: DateTime.utc(2026, 8, 30),
+        lastActiveAt: DateTime.utc(2026, 8, 30),
+      );
+      container = ProviderContainer(
+        overrides: [appDatabaseProvider.overrideWithValue(db)],
+      );
+      addTearDown(container.dispose);
+    });
+
+    Ref refOf() {
+      late Ref captured;
+      container.read(
+        Provider<int>((ref) {
+          captured = ref;
+          return 0;
+        }),
+      );
+      return captured;
+    }
+
+    PlayerPositionTracker tracker() => PlayerPositionTracker(
+      ref: refOf(),
+      getEngine: () => fake,
+      getSession: () => session,
+      setSession: (next) => session = next,
+      currentOpenGeneration: () => 0,
+    );
+
+    VideoRow videoRow() {
+      final now = DateTime.utc(2026, 8, 30);
+      return VideoRow(
+        id: 'v1',
+        vid: 'v1',
+        provider: 'user',
+        title: 't',
+        description: null,
+        thumbnailUrl: null,
+        durationSeconds: 0,
+        language: 'en',
+        source: null,
+        localUri: null,
+        md5: null,
+        size: null,
+        mediaUrl: null,
+        createdAt: now,
+        updatedAt: now,
+      );
+    }
+
+    test('a failing duration backfill logs and playback continues', () async {
+      final records = <LogRecord>[];
+      final sub = Logger('PlayerPositionTracker').onRecord.listen(records.add);
+      addTearDown(sub.cancel);
+
+      final t = tracker();
+      t.subscribe(
+        openGeneration: 0,
+        mediaId: 'v1',
+        dexieTargetType: 'Video',
+        kind: MediaKind.video,
+        video: videoRow(),
+        audio: null,
+      );
+
+      // An escaping Drift throw would surface as an unhandled async exception
+      // and fail the test — passing is part of the assertion.
+      fake.emitDuration(const Duration(seconds: 91));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(db.throwingVideoDao.insertCalls, 1);
+      // The session was already updated before the write threw.
+      expect(session?.durationSeconds, 91);
+
+      // Later events still flow (and still try the write).
+      fake.emitDuration(const Duration(seconds: 92));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(db.throwingVideoDao.insertCalls, 2);
+      expect(session?.durationSeconds, 92);
+      expect(records.where((r) => r.level >= Level.WARNING), isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## What / why

- **CompletionLoop replay is now guarded.** `arm()` runs `_run` with `unawaited`, and `_run` had try/finally but no catch — a single end-of-media throw from `engine.seek` / `engine.play` became an unhandled async exception while the `finally` still cleared the loop marker, so repeat and segment-loop silently stopped working for the rest of the stint. The replay switch is now wrapped in try/catch that logs through the file's `_log` channel and returns.
- **Duration-listener DB writes are guarded.** The async duration listener in `PlayerPositionTracker` only guarded stream errors, so a Drift throw from the one-off duration backfill (`videoDao` / `audioDao` `insertRow`) escaped as an uncaught async exception. It now gets the same try/catch + `_positionLog.warning` the position tick has had since M7.
- **The `MediaKitPlayerEngine._player` mpv guard is honest.** `if (!_nativeBackendAllowed) { _nativeBackendAllowed = true; }` set the very flag it claimed to check and gated nothing — `open()` allocated mpv regardless. The dance is deleted and the field doc now states what actually enforces the window: the stage-level check in `buildVideoStage` plus the surface-detach wait in `player_engine_binding`. Enforcing the getter instead (option 1) would have required `prepareNativeBackend()` on the default-engine path (`PlayerController._ensureDefaultMediaKitEngine`), which reaches `activeEngine` from transports/launch providers and would let mpv be allocated while a previous WebView is still detaching — the exact 2026-08-30 field report this flag exists for.

## Test plan

- [x] `completion_loop_test.dart`: new engine double whose `seek`/`play` throws at replay — 3 tests assert a warning is logged (no escaping async error), `play` is not reached on a failed seek, and a fresh `arm()` re-arms after the failure. All 4 new/updated assertions fail on the pre-fix code.
- [x] New `player_position_tracker_test.dart`: real `AppDatabase` subclass whose `VideoDao.insertRow` throws — the write is attempted, the session still updates, the failure is logged, and later duration events still flow.
- [x] `media_kit_player_engine_linux_test.dart`: pins the chosen semantics — `buildVideoStage` stays a bare placeholder until `prepareNativeBackend()` and no other engine entry point approves the gate.
- [x] Target files first, then `flutter test test/features/player` (648 passing), then the full `flutter test` (5814 passing, 2 skipped).
- [x] `flutter analyze` clean (4 pre-existing `prefer_const_constructors` infos in `test/core/**`, untouched here).

Fixes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)