### PR TITLE
perf(player): overlap echo-session read with engine.open; Completer-based WebView mount wait

### DIFF
--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -24,7 +24,10 @@ final _logYoutube = logNamed('YouTubePlayerEngine');
 
 /// See [YoutubeWebViewBridge.watchUri] — not iframe embed.
 class YoutubePlayerEngine implements PlayerEngine {
-  YoutubePlayerEngine() : _session = YoutubeSession() {
+  /// [session] is injectable so tests can drive the mount signal without a
+  /// WebView backend.
+  YoutubePlayerEngine({YoutubeSession? session})
+    : _session = session ?? YoutubeSession() {
     _webView = YoutubeWebViewController(
       session: _session,
       onStallRecovery: () => _webView.recoverStalledPlayback(),
@@ -104,17 +107,20 @@ class YoutubePlayerEngine implements PlayerEngine {
   }
 
   /// Completes when the WebView is mounted or [timeout] elapses.
+  ///
+  /// The mount is signalled by [YoutubeSession.noteWebViewMounted] (push from
+  /// `onWebViewCreated`), so waiting costs no periodic timer on the UI thread
+  /// — the 40 ms flag-poll used to sit on the `awaitSurfaceReady` critical
+  /// path of every open (issue #661). [timeout] only bounds a surface that
+  /// never mounts; the answer is still read off the session flag, exactly as
+  /// before.
   Future<bool> _awaitWebViewMounted({
     Duration timeout = const Duration(seconds: 8),
   }) async {
     if (youTubeEngineOptedOutHere) return false;
     _ensureWebViewAttached();
     if (_session.webViewMounted) return true;
-    final deadline = DateTime.now().add(timeout);
-    while (DateTime.now().isBefore(deadline)) {
-      if (_session.webViewMounted) return true;
-      await Future<void>.delayed(const Duration(milliseconds: 40));
-    }
+    await _session.awaitWebViewMounted().timeout(timeout, onTimeout: () {});
     return _session.webViewMounted;
   }
 

--- a/lib/features/player/application/engines/youtube/youtube_session.dart
+++ b/lib/features/player/application/engines/youtube/youtube_session.dart
@@ -44,6 +44,7 @@ class YoutubeSession {
   bool _mountRequested = false;
   bool _webViewMounted = false;
   Completer<void>? _surfaceDetached;
+  Completer<void>? _webViewMountedWaiter;
   bool _loggedFirstPlaying = false;
   bool _watchPageLoadStopReceived = false;
   bool _awaitingColdInitialNavigation = false;
@@ -433,7 +434,19 @@ class YoutubeSession {
   // WebView mount state.
   // ---------------------------------------------------------------------------
 
-  void noteWebViewMounted() => _webViewMounted = true;
+  void noteWebViewMounted() {
+    _webViewMounted = true;
+    // Push, don't poll: whoever is waiting on [awaitWebViewMounted] resolves
+    // here instead of re-reading the flag on a timer (issue #661). Idempotent
+    // — a second mount note with no waiter outstanding has nothing to
+    // complete, and the waiter is dropped once completed so a later
+    // unmount/remount cycle arms a fresh one.
+    final waiter = _webViewMountedWaiter;
+    _webViewMountedWaiter = null;
+    if (waiter != null && !waiter.isCompleted) {
+      waiter.complete();
+    }
+  }
 
   void noteWebViewUnmounted() {
     _webViewMounted = false;
@@ -442,6 +455,17 @@ class YoutubeSession {
     if (waiter != null && !waiter.isCompleted) {
       waiter.complete();
     }
+  }
+
+  /// Completes when the WebView next mounts, or immediately if it already is.
+  ///
+  /// The waiter is armed lazily so consecutive mount/unmount cycles each get
+  /// their own signal (same shape as [_surfaceDetached]). A waiter left
+  /// hanging by [closeStreams] is bounded by the caller's mount timeout, as
+  /// the flag-polling loop it replaces was.
+  Future<void> awaitWebViewMounted() {
+    if (_webViewMounted) return Future<void>.value();
+    return (_webViewMountedWaiter ??= Completer<void>()).future;
   }
 
   /// Completes when the WebView widget has unmounted, or immediately if it

--- a/lib/features/player/application/player_open_coordinator.dart
+++ b/lib/features/player/application/player_open_coordinator.dart
@@ -142,6 +142,17 @@ Future<void> runPlayerOpen(
   engine.setPosterUrl(openPosterUrl);
   engine.warmVideoSurface();
 
+  // The echo-session read does not depend on the engine: issue it beside
+  // `engine.open` instead of after the post-open commands, so the restore
+  // below is not serialized behind a cold engine start (issue #661). It is
+  // still *consumed* only after the same `isOpenStale` guards as before, so
+  // a superseded generation can no more apply this row than it could when
+  // the read started late. `ignore` keeps a read nobody ever awaits (stale
+  // return, or the open retry gave up) from surfacing as an unhandled async
+  // error — the await below still sees the result and rethrows failures.
+  final persistedFuture = db.echoSessionDao.getLatestForTarget(dexie, mediaId)
+    ..ignore();
+
   // After a YouTube → MediaKit swap the first `open` races WebView
   // teardown and can hang (2026-08-30: skeleton until back + reopen).
   // Use the short command ceiling for that first attempt, then retry
@@ -199,7 +210,7 @@ Future<void> runPlayerOpen(
   );
   if (host.isOpenStale(gen)) return;
 
-  final persisted = await db.echoSessionDao.getLatestForTarget(dexie, mediaId);
+  final persisted = await persistedFuture;
   if (host.isOpenStale(gen)) return;
 
   final posMs = options.restorePosition ? (persisted?.currentTimeMs ?? 0) : 0;

--- a/test/features/player/application/player_open_coordinator_test.dart
+++ b/test/features/player/application/player_open_coordinator_test.dart
@@ -19,6 +19,42 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import '../../../support/fake_player_engine.dart';
 import '../../../support/test_path_provider.dart';
 
+/// Echo-session DAO that records entries and can hold the read in flight —
+/// the barrier-controlled double from docs/perf-measurement.md (Pattern 3):
+/// count method entries instead of racing concurrent calls.
+class _CountingEchoSessionDao extends EchoSessionDao {
+  _CountingEchoSessionDao(super.db);
+
+  int getLatestCalls = 0;
+
+  /// When set, the read only resolves once the test releases it.
+  Completer<void>? entryGate;
+
+  @override
+  Future<EchoSessionRow?> getLatestForTarget(
+    String targetType,
+    String targetId,
+  ) {
+    getLatestCalls++;
+    final read = super.getLatestForTarget(targetType, targetId);
+    final gate = entryGate;
+    if (gate == null) return read;
+    return gate.future.then((_) => read);
+  }
+}
+
+/// [AppDatabase] exposing the counting echo-session DAO.
+class _CountingEchoDb extends AppDatabase {
+  _CountingEchoDb({required super.executor});
+
+  late final _CountingEchoSessionDao countingDao = _CountingEchoSessionDao(
+    this,
+  );
+
+  @override
+  EchoSessionDao get echoSessionDao => countingDao;
+}
+
 /// Minimal [PlayerOpenHost] driving [runPlayerOpen] without the controller.
 class _Host implements PlayerOpenHost {
   _Host(this.ref, this.engine);
@@ -268,6 +304,163 @@ void main() {
         throwsStateError,
       );
     });
+  });
+
+  group('runPlayerOpen echo-session read overlap (issue #661)', () {
+    late _CountingEchoDb db;
+    late AppDatabase bystanderDb;
+    late FakePlayerEngine fake;
+    late ProviderContainer container;
+    late PathProviderPlatform originalPathProvider;
+
+    setUp(() async {
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = TestPathProvider(
+        Directory.systemTemp.createTempSync('enjoy_player_open_overlap').path,
+      );
+      db = _CountingEchoDb(executor: NativeDatabase.memory());
+      // The open also schedules a fire-and-forget transcript resolve that
+      // reads the echo session through the same DAO. Point it at its own DB
+      // so the counter below can only ever be the coordinator's read.
+      bystanderDb = AppDatabase(executor: NativeDatabase.memory());
+      fake = FakePlayerEngine();
+      container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          playerEngineTestDoubleProvider.overrideWithValue(fake),
+          transcriptRepositoryProvider.overrideWithValue(
+            TranscriptRepository(bystanderDb),
+          ),
+        ],
+      );
+
+      final now = DateTime.now();
+      final file = File(
+        p.join(
+          Directory.systemTemp.path,
+          'enjoy_open_overlap_${DateTime.now().microsecondsSinceEpoch}.mp3',
+        ),
+      );
+      await file.writeAsBytes([1]);
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+      await db.audioDao.insertRow(
+        AudioRow(
+          id: 'hang-1',
+          aid: 'x',
+          provider: 'user',
+          title: 't',
+          description: null,
+          thumbnailUrl: null,
+          durationSeconds: 600,
+          language: 'en',
+          translationKey: null,
+          sourceText: null,
+          voice: null,
+          source: null,
+          localUri: Uri.file(file.path).toString(),
+          md5: null,
+          size: 1,
+          mediaUrl: null,
+          syncStatus: null,
+          serverUpdatedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      await pumpEventQueue();
+      container.dispose();
+      await db.close();
+      await bystanderDb.close();
+      await fake.dispose();
+    });
+
+    test(
+      'the echo-session read starts while engine.open is still in flight',
+      () async {
+        // Holding engine.open means the only way the read can already be
+        // pending is if the coordinator issued it first — the structural
+        // proxy for "the DB read no longer sits on the open's critical path"
+        // (docs/perf-measurement.md Pattern 3).
+        final openGate = Completer<void>();
+        fake.openDelay = () => openGate.future;
+        db.countingDao.entryGate = Completer<void>();
+        addTearDown(() {
+          if (!db.countingDao.entryGate!.isCompleted) {
+            db.countingDao.entryGate!.complete();
+          }
+          if (!openGate.isCompleted) openGate.complete();
+        });
+
+        final host = _Host(_refOf(container), fake);
+        final open = runPlayerOpen(host, _refOf(container), 'hang-1');
+
+        // Walk the coordinator up to `engine.open`'s entry (the resolver and
+        // the engine swap are immediate work on the in-memory DB).
+        for (var i = 0; i < 100 && fake.openUris.isEmpty; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        expect(fake.openUris, isNotEmpty, reason: 'engine.open was entered');
+        expect(
+          db.countingDao.getLatestCalls,
+          1,
+          reason:
+              'the echo-session read must start before engine.open resolves',
+        );
+
+        // Releasing both proves the open still consumes the overlapped read
+        // instead of dropping it.
+        db.countingDao.entryGate!.complete();
+        openGate.complete();
+        await expectLater(open, completes);
+        expect(host.session, isNotNull);
+      },
+    );
+
+    test(
+      'the overlapped read still drives the position + echo restore',
+      () async {
+        final now = DateTime.now();
+        await db.echoSessionDao.upsert(
+          EchoSessionRow(
+            id: 'es-overlap-1',
+            targetType: 'Audio',
+            targetId: 'hang-1',
+            language: 'en',
+            currentTimeMs: 9000,
+            playbackRate: 1,
+            volume: 1,
+            recordingsCount: 0,
+            recordingsDurationMs: 0,
+            currentSegmentIndex: 5,
+            echoActive: true,
+            echoStartLine: 1,
+            echoEndLine: 3,
+            echoStartMs: 1000,
+            echoEndMs: 2000,
+            blurActive: false,
+            createdAt: now,
+            updatedAt: now,
+            startedAt: now,
+            lastActiveAt: now,
+          ),
+        );
+
+        final host = _Host(_refOf(container), fake);
+        await runPlayerOpen(host, _refOf(container), 'hang-1');
+
+        expect(db.countingDao.getLatestCalls, 1);
+        expect(fake.seekCalls, [const Duration(milliseconds: 9000)]);
+        expect(host.session, isNotNull);
+        expect(host.session!.currentTimeSeconds, 9);
+        expect(host.session!.currentSegmentIndex, 5);
+      },
+    );
   });
 }
 

--- a/test/features/player/youtube_player_engine_test.dart
+++ b/test/features/player/youtube_player_engine_test.dart
@@ -5,6 +5,8 @@ import 'package:enjoy_player/features/player/application/engines/youtube/youtube
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_session.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_webview_events.dart';
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -86,6 +88,103 @@ void main() {
       session.resetForClear(keepMounted: true);
       expect(session.shouldMountWebView, isTrue);
       expect(session.videoId, isEmpty);
+    });
+
+    // The mount waiter is a push from noteWebViewMounted, not a flag poll —
+    // the 40 ms loop used to sit on the awaitSurfaceReady critical path of
+    // every open (issue #661).
+    test('awaitWebViewMounted resolves immediately when already mounted', () {
+      final session = YoutubeSession()..noteWebViewMounted();
+      expect(session.awaitWebViewMounted(), completes);
+    });
+
+    test('awaitWebViewMounted resolves on the mount signal', () async {
+      final session = YoutubeSession();
+      final waiter = session.awaitWebViewMounted();
+      var completed = false;
+      unawaited(waiter.then((_) => completed = true));
+      await pumpEventQueue();
+      expect(completed, isFalse, reason: 'still waiting for the mount');
+
+      session.noteWebViewMounted();
+      await pumpEventQueue();
+      expect(completed, isTrue);
+      expect(session.webViewMounted, isTrue);
+    });
+
+    test(
+      'a second mount note is a no-op, and a remount arms a new waiter',
+      () async {
+        final session = YoutubeSession();
+        final first = session.awaitWebViewMounted();
+
+        session.noteWebViewMounted();
+        session.noteWebViewMounted(); // idempotent — must not throw
+        await expectLater(first, completes);
+
+        session.noteWebViewUnmounted();
+        expect(session.webViewMounted, isFalse);
+
+        final second = session.awaitWebViewMounted();
+        var secondCompleted = false;
+        unawaited(second.then((_) => secondCompleted = true));
+        await pumpEventQueue();
+        // A stale (already completed) waiter would have resolved this one too.
+        expect(secondCompleted, isFalse);
+
+        session.noteWebViewMounted();
+        await expectLater(second, completes);
+      },
+    );
+  });
+
+  group('YoutubePlayerEngine mount wait (issue #661)', () {
+    testWidgets('a mount resolves awaitSurfaceReady with no poll tick', (
+      tester,
+    ) async {
+      // Not Linux, so the ADR-0048 opt-out does not short-circuit the wait.
+      // try/finally so the override is cleared *before* the testWidgets
+      // verification check runs (same pattern as the Linux availability
+      // test).
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final session = YoutubeSession();
+      final engine = YoutubePlayerEngine(session: session);
+      try {
+        var resolved = false;
+        unawaited(engine.awaitSurfaceReady().then((_) => resolved = true));
+        session.noteWebViewMounted();
+
+        // One millisecond is less than the old 40 ms poll period: under the
+        // flag-poll this stayed false until a timer tick was pumped.
+        await tester.pump(const Duration(milliseconds: 1));
+        expect(resolved, isTrue);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+      await engine.dispose();
+    });
+
+    testWidgets('a surface that never mounts still resolves via the timeout', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final session = YoutubeSession();
+      final engine = YoutubePlayerEngine(session: session);
+      try {
+        var resolved = false;
+        unawaited(engine.awaitSurfaceReady().then((_) => resolved = true));
+        await tester.pump();
+
+        // Advance past the 8 s mount ceiling: the wait must give up on its
+        // own instead of hanging the open.
+        await tester.pump(const Duration(seconds: 8, milliseconds: 100));
+        await tester.pump(const Duration(milliseconds: 1));
+        expect(resolved, isTrue);
+        expect(session.webViewMounted, isFalse);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+      await engine.dispose();
     });
   });
 


### PR DESCRIPTION
Fixes #661

## What

Two independent cuts at the open path's serialized critical section.

**A. Echo-session read moved off the open critical path**
`runPlayerOpen` issued `db.echoSessionDao.getLatestForTarget` only after `engine.open` AND the two post-open engine commands, even though the read does not depend on the engine. It is now issued beside `engine.open` and awaited exactly where it used to be issued, so position/echo restore is no longer serialized behind a cold engine start.

Nothing else moved:
- every `host.isOpenStale(gen)` guard stays where it was, and the row is still consumed only after them — a superseded generation can no more apply this row than before;
- the session-publish ordering is untouched (explicitly out of scope);
- `Future.ignore()` keeps a read nobody ever awaits (stale-generation return, or the open retry giving up) from surfacing as an unhandled async error, while the later `await` still sees the result and still rethrows failures.

**B. WebView mount wait is a push, not a poll**
`YoutubePlayerEngine._awaitWebViewMounted` polled `_session.webViewMounted` every 40 ms for up to 8 s on the `awaitSurfaceReady` critical path of every open. `YoutubeSession.noteWebViewMounted` now completes a `Completer` (idempotent — the waiter is dropped once completed and re-armed per mount cycle, the same shape as the existing `_surfaceDetached`), and the engine awaits it. The 8 s ceiling is unchanged and still only bounds a surface that never mounts; the returned answer is still read off the session flag. The ADR-0048 opted-out early-return is unchanged.

## Deliberately skipped

The optional `disableRenderedSubtitles` + `applyCurrentToEngine` `Future.wait` was **not** done. Command-wise it is safe (verified: `applyCurrentToEngine` only sets volume + rate, and `disableRenderedSubtitles` is `setSubtitleTrack(no())` on MediaKit), but the `isOpenStale` guard that sits between the two steps would have to be dropped, and that guard is what keeps a superseded generation from writing prefs into an engine a newer open may own. One saved IPC is not worth weakening the most regression-prone seam in this file (see the engine-swap/`engine.open` hang history of 2026-08-30).

## Test plan

Structural tests per docs/perf-measurement.md (Pattern 3 — barrier-controlled double, no wall-clock racing):

- [x] `player_open_coordinator_test.dart` / `echo-session read overlap (issue #661)`:
  - a barrier-controlled `_CountingEchoSessionDao` + `engine.open` held open proves the read is **entered while `engine.open` is still in flight** — verified to fail against the pre-fix ordering;
  - the overlapped read still drives the restore (seek target, session position and segment index come from the concurrently-issued row);
  - a second in-memory DB isolates the fire-and-forget transcript resolve, which reads the same DAO, so the counter can only be the coordinator's read.
- [x] `youtube_player_engine_test.dart` / `mount wait (issue #661)`:
  - a mount resolves `awaitSurfaceReady` after a **1 ms pump — less than one 40 ms poll tick** — verified to fail against the polling implementation, i.e. no periodic timer is on the wait path;
  - a surface that never mounts still resolves by advancing past the 8 s ceiling;
  - session-level: waiter completes on the signal, second `noteWebViewMounted` is a no-op, and a remount after unmount arms a fresh waiter.
- [x] `flutter analyze` — clean (4 pre-existing infos in `test/core/`, untouched by this PR).
- [x] `flutter test test/features/player` — 650 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)