### PR TITLE
fix(player): echo robustness — bounds, stale lines cache, poster-capture interference, tiny windows

### DIFF
--- a/lib/features/player/application/echo_mode_provider.dart
+++ b/lib/features/player/application/echo_mode_provider.dart
@@ -105,9 +105,21 @@ class EchoMode extends _$EchoMode {
     );
   }
 
+  /// Whether the persisted line indices still fit [lines].
+  ///
+  /// [restoreFromSession] persists indices without validation, so a transcript
+  /// re-import that re-segmented the cues shorter leaves them past the end.
+  /// Mirror [EchoEnforcer]'s line-index bounds check and no-op instead of
+  /// throwing RangeError (issue #659).
+  bool _indicesFitLines(List<TranscriptLine> lines) {
+    final start = state.startLineIndex;
+    final end = state.endLineIndex;
+    return start >= 0 && end >= start && end < lines.length;
+  }
+
   /// Add one line before the echo segment (web expand backward).
   void expandEchoBackward(List<TranscriptLine> lines) {
-    if (!state.active || lines.isEmpty) return;
+    if (!state.active || !_indicesFitLines(lines)) return;
     final start = state.startLineIndex;
     if (start <= 0) return;
     final nextStart = start - 1;
@@ -119,7 +131,7 @@ class EchoMode extends _$EchoMode {
 
   /// Remove one line from the start of the echo segment (web shrink backward).
   void shrinkEchoBackward(List<TranscriptLine> lines) {
-    if (!state.active || lines.isEmpty) return;
+    if (!state.active || !_indicesFitLines(lines)) return;
     final start = state.startLineIndex;
     final end = state.endLineIndex;
     if (start >= end) return;
@@ -132,7 +144,7 @@ class EchoMode extends _$EchoMode {
 
   /// Add one line after the echo segment (web expand forward).
   void expandEchoForward(List<TranscriptLine> lines) {
-    if (!state.active || lines.isEmpty) return;
+    if (!state.active || !_indicesFitLines(lines)) return;
     final end = state.endLineIndex;
     if (end >= lines.length - 1) return;
     final nextEnd = end + 1;
@@ -144,7 +156,7 @@ class EchoMode extends _$EchoMode {
 
   /// Remove one line from the end of the echo segment (web shrink forward).
   void shrinkEchoForward(List<TranscriptLine> lines) {
-    if (!state.active || lines.isEmpty) return;
+    if (!state.active || !_indicesFitLines(lines)) return;
     final start = state.startLineIndex;
     final end = state.endLineIndex;
     if (end <= start) return;

--- a/lib/features/player/application/player_interactions.dart
+++ b/lib/features/player/application/player_interactions.dart
@@ -65,28 +65,39 @@ class PlayerInteractions extends _$PlayerInteractions {
   @override
   int build() => 0;
 
-  String? _cachedLinesMediaId;
+  /// Identity of the transcript row the line cache was decoded from.
+  ///
+  /// Keyed on the row (not just the mediaId): a re-import re-segments cues, so
+  /// a keepAlive cache keyed on mediaId alone would feed echo stale line
+  /// indices (issue #659). `linesForRow` memoizes the decode on the same key,
+  /// so an unchanged transcript still hits the cached lines.
+  ({String id, String timelineJson})? _cachedRow;
   List<TranscriptLine> _cachedLines = const [];
+
+  void _resetLinesCache() {
+    _cachedRow = null;
+    _cachedLines = const [];
+  }
 
   Future<List<TranscriptLine>> _lines() async {
     final session = ref.read(playerControllerProvider);
     final mediaId = session?.mediaId;
     if (mediaId == null) {
-      _cachedLines = const [];
-      _cachedLinesMediaId = null;
+      _resetLinesCache();
       return _cachedLines;
     }
-    if (mediaId == _cachedLinesMediaId) return _cachedLines;
 
     final repo = ref.read(transcriptRepositoryProvider);
     final row = await repo.primaryTranscriptRowForMedia(mediaId);
     if (row == null) {
-      _cachedLines = const [];
-      _cachedLinesMediaId = null;
+      _resetLinesCache();
       return _cachedLines;
     }
+    final key = (id: row.id, timelineJson: row.timelineJson);
+    if (_cachedRow == key) return _cachedLines;
+
     _cachedLines = repo.linesForRow(row);
-    _cachedLinesMediaId = mediaId;
+    _cachedRow = key;
     return _cachedLines;
   }
 

--- a/lib/features/player/application/video_poster_capture_service.dart
+++ b/lib/features/player/application/video_poster_capture_service.dart
@@ -12,6 +12,7 @@ import 'package:enjoy_player/core/utils/remote_thumbnail_url.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
 import 'package:enjoy_player/data/files/video_poster_extract.dart';
+import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
 
 final _log = logNamed('VideoPosterCapture');
@@ -63,6 +64,13 @@ class VideoPosterCaptureService {
   }) async {
     var soughtForPoster = false;
     try {
+      // Opening at position 0 while echo is active makes the capture seek (and
+      // the seek-back-to-zero below) fight the live enforcer: the seek is
+      // corrected back into the echo window, so the wrong frame is captured and
+      // playback is paused / churned right after open (issue #659). Skip — a
+      // later open without echo still captures the poster.
+      if (restoredPositionMs == 0 && _ref.read(echoModeProvider).active) return;
+
       await Future<void>.delayed(const Duration(milliseconds: 450));
       if (gen != currentOpenGeneration()) return;
       if (currentSessionMediaId() != mediaId) return;

--- a/lib/features/player/domain/echo_window.dart
+++ b/lib/features/player/domain/echo_window.dart
@@ -83,6 +83,16 @@ EchoWindow? normalizeEchoWindow(NormalizeEchoWindowInput input) {
   if (!start.isFinite || !end.isFinite) return null;
   if (end <= start) return null;
 
+  // A window narrower than `endGuard + seekEpsilon` has no playable position:
+  // the end guard fires pause-and-rewind the instant the rewind-to-start seek
+  // lands, looping seek → pause → seek (issue #659 — arbitrary start/end query
+  // params or a sub-40 ms cue). Widen to the minimum; when the media is too
+  // short to allow even that, drop the window — enforcing it can only churn.
+  final minEnd =
+      start + defaultEchoEndGuardSeconds + defaultEchoSeekEpsilonSeconds;
+  if (minEnd > maxTime) return null;
+  if (end < minEnd) return (start: start, end: minEnd);
+
   return (start: start, end: end);
 }
 

--- a/test/features/player/application/video_poster_capture_service_test.dart
+++ b/test/features/player/application/video_poster_capture_service_test.dart
@@ -1,0 +1,145 @@
+// ignore_for_file: avoid_redundant_argument_values
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:enjoy_player/data/db/app_database.dart';
+import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
+import 'package:enjoy_player/features/player/application/video_poster_capture_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../../../support/fake_player_engine.dart';
+import '../../../support/test_path_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('VideoPosterCaptureService', () {
+    const mediaId = 'v-cap-echo';
+
+    late AppDatabase db;
+    late FakePlayerEngine fake;
+    late ProviderContainer container;
+    late PathProviderPlatform originalPathProvider;
+    late Directory pathProviderRoot;
+    late VideoRow video;
+
+    setUp(() async {
+      originalPathProvider = PathProviderPlatform.instance;
+      pathProviderRoot = Directory.systemTemp.createTempSync(
+        'enjoy_poster_cap',
+      );
+      PathProviderPlatform.instance = TestPathProvider(pathProviderRoot.path);
+
+      db = AppDatabase(executor: NativeDatabase.memory());
+      fake = FakePlayerEngine()
+        ..screenshotReturnValue = Uint8List.fromList(const [1, 2, 3]);
+      container = ProviderContainer(
+        overrides: [appDatabaseProvider.overrideWithValue(db)],
+      );
+
+      final now = DateTime.now();
+      await db.videoDao.insertRow(
+        VideoRow(
+          id: mediaId,
+          vid: 'x',
+          provider: 'user',
+          title: 't',
+          description: null,
+          thumbnailUrl: null,
+          durationSeconds: 600,
+          language: 'en',
+          source: null,
+          localUri: null,
+          md5: 'a' * 64,
+          size: 1,
+          mediaUrl: null,
+          syncStatus: null,
+          serverUpdatedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+      video = (await db.videoDao.getById(mediaId))!;
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      if (pathProviderRoot.existsSync()) {
+        pathProviderRoot.deleteSync(recursive: true);
+      }
+      container.dispose();
+      await db.close();
+      await fake.dispose();
+    });
+
+    Future<void> capture({required int restoredPositionMs}) {
+      return container
+          .read(videoPosterCaptureServiceProvider)
+          .captureAndPersist(
+            mediaId: mediaId,
+            video: video,
+            restoredPositionMs: restoredPositionMs,
+            gen: 1,
+            currentOpenGeneration: () => 1,
+            currentSessionMediaId: () => mediaId,
+            sessionDurationSeconds: () => 600,
+            activeEngine: fake,
+            onSessionThumbnail: (_) {},
+          );
+    }
+
+    void activateEcho() {
+      container
+          .read(echoModeProvider.notifier)
+          .activate(
+            startLineIndex: 0,
+            endLineIndex: 0,
+            startTimeSeconds: 4,
+            endTimeSeconds: 6,
+          );
+    }
+
+    test(
+      'skips capture when echo is active and the open starts at 0',
+      () async {
+        activateEcho();
+
+        await capture(restoredPositionMs: 0);
+
+        // No poster seek, no seek-back-to-zero, no screenshot: enforcement must
+        // not be fighting the capture right after open (issue #659).
+        expect(fake.seekCalls, isEmpty);
+        expect(fake.screenshotCalls, 0);
+        expect((await db.videoDao.getById(mediaId))!.thumbnailUrl, isNull);
+      },
+    );
+
+    test('still captures without echo when the open starts at 0', () async {
+      await capture(restoredPositionMs: 0);
+
+      expect(fake.screenshotCalls, 1);
+      // Poster seek, then the restore back to position zero.
+      expect(fake.seekCalls, hasLength(2));
+      expect(fake.seekCalls.first, const Duration(seconds: 72));
+      expect(fake.seekCalls.last, Duration.zero);
+
+      final row = await db.videoDao.getById(mediaId);
+      expect(row!.thumbnailUrl, isNotNull);
+      expect(File(row.thumbnailUrl!).existsSync(), isTrue);
+    });
+
+    test('captures mid-media even with echo active (no poster seek)', () async {
+      activateEcho();
+
+      await capture(restoredPositionMs: 12000);
+
+      expect(fake.seekCalls, isEmpty);
+      expect(fake.screenshotCalls, 1);
+      expect((await db.videoDao.getById(mediaId))!.thumbnailUrl, isNotNull);
+    });
+  });
+}

--- a/test/features/player/echo_mode_provider_test.dart
+++ b/test/features/player/echo_mode_provider_test.dart
@@ -224,6 +224,103 @@ void main() {
         expect(lastState.active, isFalse);
       });
     });
+    group('re-segmented transcript (issue #659)', () {
+      // `restoreFromSession` persists line indices without validation; a
+      // re-import that shortened the transcript leaves them past the end.
+      final shortLines = <TranscriptLine>[
+        const TranscriptLine(text: 'only', startMs: 0, durationMs: 2000),
+      ];
+
+      test('restoreFromSession with out-of-range indices', () {
+        notifier.restoreFromSession(
+          startLine: 4,
+          endLine: 4,
+          echoStartMs: 8000,
+          echoEndMs: 10000,
+        );
+        expect(lastState.active, isTrue);
+        expect(lastState.startLineIndex, 4);
+      });
+
+      test('expandEchoBackward does not throw past the end', () {
+        notifier.restoreFromSession(
+          startLine: 4,
+          endLine: 4,
+          echoStartMs: 8000,
+          echoEndMs: 10000,
+        );
+
+        notifier.expandEchoBackward(shortLines);
+
+        expect(lastState.startLineIndex, 4);
+        expect(lastState.endLineIndex, 4);
+      });
+
+      test('shrinkEchoBackward does not throw past the end', () {
+        notifier.restoreFromSession(
+          startLine: 0,
+          endLine: 6,
+          echoStartMs: 0,
+          echoEndMs: 14000,
+        );
+
+        notifier.shrinkEchoBackward(shortLines);
+
+        expect(lastState.startLineIndex, 0);
+        expect(lastState.endLineIndex, 6);
+      });
+
+      test('shrinkEchoForward does not throw past the end', () {
+        notifier.restoreFromSession(
+          startLine: 0,
+          endLine: 6,
+          echoStartMs: 0,
+          echoEndMs: 14000,
+        );
+
+        notifier.shrinkEchoForward(shortLines);
+
+        expect(lastState.startLineIndex, 0);
+        expect(lastState.endLineIndex, 6);
+      });
+
+      test('expandEchoForward does not throw with a negative start', () {
+        notifier.restoreFromSession(
+          startLine: -1,
+          endLine: 3,
+          echoStartMs: 0,
+          echoEndMs: 6000,
+        );
+
+        notifier.expandEchoForward(shortLines);
+
+        expect(lastState.startLineIndex, -1);
+        expect(lastState.endLineIndex, 3);
+      });
+
+      test(
+        'echo keeps working once indices fit the re-imported transcript',
+        () {
+          notifier.restoreFromSession(
+            startLine: 0,
+            endLine: 6,
+            echoStartMs: 0,
+            echoEndMs: 14000,
+          );
+          notifier.shrinkEchoForward(shortLines);
+          expect(lastState.endLineIndex, 6);
+
+          notifier.activate(
+            startLineIndex: 0,
+            endLineIndex: 0,
+            startTimeSeconds: 0,
+            endTimeSeconds: 2,
+          );
+          notifier.expandEchoForward(shortLines);
+          expect(lastState.endLineIndex, 0);
+        },
+      );
+    });
   });
 
   group('EchoState', () {

--- a/test/features/player/echo_window_test.dart
+++ b/test/features/player/echo_window_test.dart
@@ -25,6 +25,61 @@ void main() {
       expect(w!.start, 0);
       expect(w.end, 10.0);
     });
+
+    test('widens a sub-guard window to the minimum playable width', () {
+      // 20 ms < endGuard (40 ms): every position would fire pause-and-rewind.
+      final w = normalizeEchoWindow((
+        active: true,
+        startTimeSeconds: 1.0,
+        endTimeSeconds: 1.02,
+        durationSeconds: 10.0,
+      ));
+      expect(
+        w!.end - w.start,
+        closeTo(
+          defaultEchoEndGuardSeconds + defaultEchoSeekEpsilonSeconds,
+          1e-9,
+        ),
+      );
+      expect(w.start, 1.0);
+    });
+
+    test('drops a minimum-width window that cannot fit the media', () {
+      // Remaining tail is shorter than endGuard + seekEpsilon — no way to
+      // build a window the enforcer can hold without looping.
+      final w = normalizeEchoWindow((
+        active: true,
+        startTimeSeconds: 9.99,
+        endTimeSeconds: 10.0,
+        durationSeconds: 10.0,
+      ));
+      expect(w, isNull);
+    });
+
+    test('does not widen windows already past the minimum', () {
+      final w = normalizeEchoWindow((
+        active: true,
+        startTimeSeconds: 1.0,
+        endTimeSeconds: 1.2,
+        durationSeconds: 10.0,
+      ));
+      expect(w!.start, 1.0);
+      expect(w.end, 1.2);
+    });
+  });
+
+  test('rewinding to a normalized sub-guard window start stays playable', () {
+    // The busy-loop: pause-and-rewind seeks to `start`, and if `start` is
+    // already past `end - endGuard` the next tick fires pause-and-rewind
+    // again. After widening, the rewind target must be playable.
+    final w = normalizeEchoWindow((
+      active: true,
+      startTimeSeconds: 4.0,
+      endTimeSeconds: 4.03,
+      durationSeconds: 30.0,
+    ))!;
+    expect(decideEchoPlaybackTime(w.start, w), isA<EchoOk>());
+    expect(clampSeekTimeToEchoWindow(w.start, w), w.start);
   });
 
   test('clampSeekTimeToEchoWindow stays before end', () {

--- a/test/features/player/player_interactions_class_test.dart
+++ b/test/features/player/player_interactions_class_test.dart
@@ -150,6 +150,42 @@ void main() {
     );
   }
 
+  /// Simulates a re-import: replaces the primary transcript with [importLines].
+  Future<void> reimportTranscript(List<TranscriptLine> importLines) async {
+    await db.transcriptDao.upsert(
+      TranscriptRow(
+        id: '$transcriptId-reimport',
+        targetType: 'Audio',
+        targetId: mediaId,
+        language: 'en',
+        source: 'official',
+        timelineJson: jsonEncode(
+          importLines
+              .map(
+                (l) => {
+                  'text': l.text,
+                  'start': l.startMs,
+                  'duration': l.durationMs,
+                },
+              )
+              .toList(),
+        ),
+        referenceId: null,
+        label: '',
+        trackIndex: null,
+        syncStatus: null,
+        serverUpdatedAt: null,
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+    await db.echoSessionDao.updatePrimaryTranscriptForTarget(
+      'Audio',
+      mediaId,
+      '$transcriptId-reimport',
+    );
+  }
+
   test('prevLine bails out when there is no session', () async {
     final n = container.read(playerInteractionsProvider.notifier);
     await n.prevLine();
@@ -578,6 +614,30 @@ void main() {
       final n = container.read(playerInteractionsProvider.notifier);
       await n.replayLine();
       expect(fake.seekCalls, isEmpty);
+    },
+  );
+
+  test(
+    'line cache drops stale lines when the transcript is re-imported',
+    () async {
+      await insertAudioRow(mediaId);
+      await seedTranscript();
+      setUpSession(currentTime: 0.5);
+
+      final n = container.read(playerInteractionsProvider.notifier);
+      await n.nextLine(); // populates the keepAlive cache with the old import
+      expect(fake.seekCalls, [const Duration(seconds: 2)]);
+
+      // Re-import re-segments to a shorter, differently timed transcript.
+      await reimportTranscript(const [
+        TranscriptLine(text: 'new 1', startMs: 0, durationMs: 2000),
+        TranscriptLine(text: 'new 2', startMs: 9000, durationMs: 2000),
+      ]);
+      await pumpEventQueue();
+
+      await n.nextLine();
+      // Stale lines would seek to 2s again; the fresh import lands on 9s.
+      expect(fake.seekCalls.last, const Duration(seconds: 9));
     },
   );
 


### PR DESCRIPTION
Four small echo fixes from the issue #659 field report (transcript re-import + open-time interference):

- **RangeError on re-segmented transcripts** — `restoreFromSession` persists line indices without validation; after a re-import that shortened the transcript, `expandEchoBackward`, `shrinkEchoBackward` and `shrinkEchoForward` indexed past `lines.length` (only `expandEchoForward` bounded-checked). All four now validate the persisted segment against the current lines (mirroring the check `EchoEnforcer` already applies) and no-op when it no longer fits.
- **Stale lines cache** — `PlayerInteractions._lines` cached lines per mediaId forever in a keepAlive notifier, so a re-import kept feeding echo the previous transcript's cues. The cache is now keyed on the primary transcript row (id + timelineJson); `linesForRow` memoizes the decode on the same key, so an unchanged transcript still hits the cache.
- **Poster capture vs. the live enforcer** — with `restoredPositionMs == 0` and echo restored, the capture seek to the poster frame (and the finally seek back to zero) were corrected back into the echo window: wrong frame captured, playback paused/churned right after open. Capture is skipped in that case; opens without echo still capture.
- **Ultra-short window busy-loop** — `normalizeEchoWindow` accepted any `end > start`, but `decideEchoPlaybackTime` fires `pauseAndRewind` at `position >= end - 0.04`, so a window narrower than the guard (arbitrary start/end query params, a sub-40 ms cue) looped seek → pause → seek. Windows are now widened to `endGuard + seekEpsilon` minimum, and dropped when the media cannot fit even that.

## Test plan
- [x] `flutter analyze` clean (only pre-existing infos in untouched `test/core` files)
- [x] New bounds tests: shortened transcript + all four expand/shrink methods no-op without throwing, echo still works once indices fit
- [x] New cache test: re-import to a differently timed transcript, next `nextLine` seeks to the new cue, not the stale one
- [x] New capture tests: skipped with echo active at position 0; still captures (poster seek + seek-to-zero + thumbnail written) without echo; captures mid-media with echo active
- [x] New window tests: a 20 ms window normalizes to the minimum width, the rewind target stays playable (no loop), windows already past the minimum are untouched, and one that cannot fit the media is dropped
- [x] `flutter test test/features/player` green (657) and full `flutter test` green (5823 passed, 2 skipped)

Fixes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)