### PR TITLE
fix(player): scrubber holds the pending seek fraction until the stream catches up

### DIFF
--- a/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
@@ -11,6 +11,7 @@ import 'package:enjoy_player/core/interaction/mouse_tracker_safe.dart';
 import 'package:enjoy_player/core/platform/mobile_platform.dart';
 import 'package:enjoy_player/core/utils/time_format.dart';
 import 'package:enjoy_player/features/player/application/player_interactions.dart';
+import 'package:enjoy_player/features/player/application/position_buckets.dart';
 import 'package:enjoy_player/features/player/application/transport_slider_position_provider.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 
@@ -74,6 +75,23 @@ class _TransportProgressStripState
   /// (issue #470).
   double? _dragFraction;
 
+  /// Non-null for a short window after the drag ends: the engine position
+  /// stream keeps reporting the PRE-seek position until the seek lands, so
+  /// dropping [_dragFraction] immediately makes the thumb rubber-band back to
+  /// where the user came from and then jump forward once the seek arrives
+  /// (issue #660 — worst on YouTube, whose 250 ms poll cadence + JS seek keep
+  /// the stale position on screen for 300-800 ms). While held, the thumb and
+  /// the elapsed label render the requested target instead.
+  double? _pendingSeekFraction;
+
+  /// How long [_pendingSeekFraction] may pin the thumb when the stream never
+  /// reports the target (swallowed / failed seek). Comfortably above
+  /// YouTube's 250 ms poll cadence so a healthy seek always releases through
+  /// the catch-up check below rather than through this bound.
+  static const Duration _pendingSeekHold = Duration(milliseconds: 1500);
+
+  Timer? _pendingSeekTimer;
+
   /// Hover state is managed locally so the parent transport bar does not
   /// rebuild when the cursor enters/exits the slider thumb area (issue #471).
   bool _hovered = false;
@@ -81,6 +99,40 @@ class _TransportProgressStripState
   int? _scrubSecond;
 
   bool get _hapticScrub => isMobilePlatform;
+
+  @override
+  void dispose() {
+    _pendingSeekTimer?.cancel();
+    super.dispose();
+  }
+
+  /// True once the engine position stream reports a position within one
+  /// scrubber bucket ([kPositionBucketScrubberMs]) of the held target, i.e.
+  /// the seek landed and the real position can take over again.
+  ///
+  /// Compared on magnitude, not just "has the stream passed the target": for
+  /// a *backward* seek the stale pre-seek position is already beyond the
+  /// target, so a one-sided test would release instantly and resurrect the
+  /// very snap-back this hold exists to hide (issue #660).
+  bool _streamCaughtUp(Duration pos, double durationSec) {
+    final pending = _pendingSeekFraction;
+    if (pending == null) return false;
+    final targetMs = (pending * durationSec * 1000).round();
+    return (pos.inMilliseconds - targetMs).abs() <= kPositionBucketScrubberMs;
+  }
+
+  void _holdPendingSeek(double fraction) {
+    _pendingSeekFraction = fraction;
+    _pendingSeekTimer?.cancel();
+    _pendingSeekTimer = Timer(_pendingSeekHold, _releasePendingSeek);
+  }
+
+  void _releasePendingSeek() {
+    _pendingSeekTimer?.cancel();
+    _pendingSeekTimer = null;
+    if (!mounted || _pendingSeekFraction == null) return;
+    setState(() => _pendingSeekFraction = null);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -98,9 +150,20 @@ class _TransportProgressStripState
     final streamFraction = durationSec > 0
         ? pos.inMilliseconds / 1000 / durationSec
         : 0.0;
-    // While dragging, render the thumb from the local drag value, not the
-    // stream position — the stream won't update until the seek completes.
-    final fraction = _dragFraction ?? streamFraction.clamp(0.0, 1.0);
+    // Render the thumb from the local override, not the stream position,
+    // while the user is dragging (#470) or while a just-issued seek has not
+    // landed yet (#660) — the stream reports the stale pre-seek position in
+    // both cases.
+    final holdFraction = _dragFraction ?? _pendingSeekFraction;
+    final fraction = holdFraction ?? streamFraction.clamp(0.0, 1.0);
+
+    // The stream caught up, so hand the thumb back to it. Done post-frame
+    // because this runs during build (pos arrives via ref.watch above).
+    if (_streamCaughtUp(pos, durationSec)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _releasePendingSeek();
+      });
+    }
 
     final timeStyle = tt.labelSmall?.copyWith(
       fontFeatures: const [FontFeature.tabularFigures()],
@@ -114,10 +177,9 @@ class _TransportProgressStripState
         children: [
           Text(
             formatDurationHms(
-              _dragFraction != null
+              holdFraction != null
                   ? Duration(
-                      milliseconds: (_dragFraction! * durationSec * 1000)
-                          .round(),
+                      milliseconds: (holdFraction * durationSec * 1000).round(),
                     )
                   : pos,
             ),
@@ -141,6 +203,10 @@ class _TransportProgressStripState
                   value: fraction.clamp(0, 1),
                   onChangeStart: (_) {
                     _scrubSecond = null;
+                    // A re-grab supersedes any hold from the previous seek;
+                    // the drag value wins for as long as the finger is down.
+                    _pendingSeekTimer?.cancel();
+                    _pendingSeekFraction = null;
                   },
                   onChanged: (v) {
                     if (_hapticScrub) {
@@ -153,7 +219,12 @@ class _TransportProgressStripState
                     setState(() => _dragFraction = v);
                   },
                   onChangeEnd: (v) {
-                    _dragFraction = null;
+                    // Keep the thumb on the target instead of snapping back
+                    // to the stale pre-seek stream position (issue #660).
+                    setState(() {
+                      _dragFraction = null;
+                      _holdPendingSeek(v);
+                    });
                     unawaited(
                       ref
                           .read(playerInteractionsProvider.notifier)

--- a/test/features/player/presentation/widgets/transport/transport_progress_strip_test.dart
+++ b/test/features/player/presentation/widgets/transport/transport_progress_strip_test.dart
@@ -1,0 +1,196 @@
+// Regression coverage for issue #660: after the user releases the scrubber the
+// thumb must stay on the requested target instead of rubber-banding back to the
+// stale pre-seek stream position.
+import 'dart:async';
+
+import 'package:enjoy_player/features/player/application/player_interactions.dart';
+import 'package:enjoy_player/features/player/application/transport_slider_position_provider.dart';
+import 'package:enjoy_player/features/player/domain/playback_session.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/transport/transport_progress_strip.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _durationSeconds = 120.0;
+
+final PlaybackChrome _chrome = (
+  mediaId: 'm1',
+  dexieTargetType: 'Audio',
+  mediaType: 'audio',
+  mediaTitle: 'Progress strip test',
+  thumbnailUrl: null,
+  durationSeconds: _durationSeconds,
+  language: 'en',
+);
+
+/// Records the seeks the strip issues without dragging a real engine in.
+class _RecordingInteractions extends PlayerInteractions {
+  final List<double> seekFractions = [];
+
+  @override
+  int build() => 0;
+
+  @override
+  Future<void> seekToProgressFraction(double fraction) async {
+    seekFractions.add(fraction);
+  }
+}
+
+double _sliderFraction(WidgetTester tester) =>
+    tester.widget<Slider>(find.byType(Slider)).value;
+
+void main() {
+  late StreamController<Duration> positions;
+  late _RecordingInteractions interactions;
+  late ProviderContainer container;
+
+  /// Pumps the strip on a position stream we drive by hand, then seeds the
+  /// first position (the StreamProvider only subscribes on the first watch).
+  Future<void> pumpStrip(WidgetTester tester) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Center(child: TransportProgressStrip(chrome: _chrome)),
+          ),
+        ),
+      ),
+    );
+    positions.add(const Duration(seconds: 10));
+    await tester.pump();
+  }
+
+  /// Drives the real slider callbacks through a full scrub to [fraction].
+  Future<void> scrubTo(WidgetTester tester, double fraction) async {
+    tester.widget<Slider>(find.byType(Slider)).onChangeStart!(fraction);
+    await tester.pump();
+    tester.widget<Slider>(find.byType(Slider)).onChanged!(fraction);
+    await tester.pump();
+    tester.widget<Slider>(find.byType(Slider)).onChangeEnd!(fraction);
+    await tester.pump();
+  }
+
+  setUp(() {
+    positions = StreamController<Duration>.broadcast();
+    interactions = _RecordingInteractions();
+    container = ProviderContainer(
+      overrides: [
+        transportSliderPositionProvider.overrideWith((ref) => positions.stream),
+        playerInteractionsProvider.overrideWith(() => interactions),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+    // Not awaited: awaiting a controller close inside the test's fake-async
+    // zone never completes and hangs the test.
+    unawaited(positions.close());
+  });
+
+  testWidgets('thumb holds the seek target until the stream catches up', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+    expect(_sliderFraction(tester), closeTo(10 / _durationSeconds, 1e-9));
+
+    await scrubTo(tester, 0.5);
+
+    // Straight after release the stream still reports 10s, but the thumb and
+    // the elapsed label already show the requested target.
+    expect(_sliderFraction(tester), 0.5);
+    expect(find.text('01:00'), findsOneWidget);
+    expect(interactions.seekFractions, [0.5]);
+
+    // Stale ticks arriving later do not pull the thumb back.
+    positions.add(const Duration(seconds: 11));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(_sliderFraction(tester), 0.5);
+    expect(find.text('01:00'), findsOneWidget);
+
+    // The engine finally reports the target: hold releases, stream takes over.
+    positions.add(const Duration(seconds: 60));
+    await tester.pump();
+    await tester.pump();
+    positions.add(const Duration(seconds: 61));
+    await tester.pump();
+    await tester.pump();
+    expect(_sliderFraction(tester), closeTo(61 / _durationSeconds, 1e-9));
+    expect(find.text('01:01'), findsOneWidget);
+  });
+
+  testWidgets('backward seek holds too (stream starts beyond the target)', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+
+    await scrubTo(tester, 0.25);
+    expect(_sliderFraction(tester), 0.25);
+
+    // The stale position is already past the target; the hold must not read
+    // that as "caught up".
+    positions.add(const Duration(seconds: 11));
+    await tester.pump();
+    await tester.pump();
+    expect(_sliderFraction(tester), 0.25);
+
+    positions.add(const Duration(seconds: 30));
+    await tester.pump();
+    await tester.pump();
+    positions.add(const Duration(seconds: 31));
+    await tester.pump();
+    await tester.pump();
+    expect(_sliderFraction(tester), closeTo(31 / _durationSeconds, 1e-9));
+    expect(find.text('00:31'), findsOneWidget);
+  });
+
+  testWidgets('hold releases on timeout when the stream never catches up', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+
+    await scrubTo(tester, 0.5);
+    expect(_sliderFraction(tester), 0.5);
+
+    // Still holding inside the 1.5s window.
+    await tester.pump(const Duration(seconds: 1));
+    expect(_sliderFraction(tester), 0.5);
+
+    // Past the window the (stale) stream position takes over again.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+    expect(_sliderFraction(tester), closeTo(10 / _durationSeconds, 1e-9));
+    expect(find.text('00:10'), findsOneWidget);
+  });
+
+  testWidgets('an active drag overrides the stream and any pending hold', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+
+    await scrubTo(tester, 0.5);
+    expect(_sliderFraction(tester), 0.5);
+
+    // Re-grab while the hold from the previous seek is still active.
+    tester.widget<Slider>(find.byType(Slider)).onChangeStart!(0.5);
+    await tester.pump();
+    tester.widget<Slider>(find.byType(Slider)).onChanged!(0.25);
+    await tester.pump();
+    expect(_sliderFraction(tester), 0.25);
+
+    // A position tick mid-drag does not move the thumb.
+    positions.add(const Duration(seconds: 60));
+    await tester.pump();
+    await tester.pump();
+    expect(_sliderFraction(tester), 0.25);
+    expect(find.text('00:30'), findsOneWidget);
+
+    // Releasing starts a fresh hold on the new target.
+    tester.widget<Slider>(find.byType(Slider)).onChangeEnd!(0.75);
+    await tester.pump();
+    expect(_sliderFraction(tester), 0.75);
+    expect(interactions.seekFractions, [0.5, 0.75]);
+  });
+}


### PR DESCRIPTION
## What

`TransportProgressStrip` now holds a `_pendingSeekFraction` for a short window after the drag ends, and renders the thumb **and** the elapsed label from it, instead of falling straight back to `transportSliderPositionProvider`.

## Why

`onChangeEnd` cleared `_dragFraction` and fired `seekToProgressFraction` in the same tick, so the thumb immediately rendered `streamFraction` again — which is still the PRE-seek position until the engine's seek completes. On YouTube (250 ms poll cadence + JS seek) that reads as a visible rubber-band: the thumb snaps back to where the user came from, then jumps forward 300-800 ms later.

Details:

- Mirrors the `_dragFraction` hold from #470 — same pattern, one field further along the interaction.
- Releases as soon as the stream lands within one scrubber bucket (`kPositionBucketScrubberMs`, 50 ms) of the target, checked in `build` and applied post-frame (the position arrives via `ref.watch`, so the release must not `setState` mid-build).
- Falls back to a 1.5 s timeout when the stream never reports the target (swallowed / failed seek), so the thumb can never stay pinned on a lie. That bound sits comfortably above YouTube's 250 ms poll cadence, so a healthy seek always releases through the catch-up check.
- The catch-up check compares **magnitude**, not "has the stream passed the target". For a backward seek the stale position is already beyond the target, so a one-sided test would release instantly and resurrect the snap-back.
- A re-grab cancels the hold, so an active drag keeps overriding everything exactly as before. Seek mechanics and the provider are untouched.
- `dispose()` cancels the timer.

## Test plan

- [x] New `transport_progress_strip_test.dart` (drives the slider's real callbacks against a hand-fed position stream, with a recording `PlayerInteractions`):
  - after `onChangeEnd` the rendered fraction equals the seek target immediately and holds across stale ticks, then hands back to the stream once the target arrives (elapsed text checked at each step)
  - a backward seek holds too — the stale position starting beyond the target does not count as caught up
  - the hold releases on the 1.5 s timeout when the stream never catches up
  - an active drag overrides the stream and any pending hold; releasing starts a fresh hold and issues a second seek
- [x] `flutter analyze` clean (only 4 pre-existing `prefer_const_constructors` infos in `test/core/`, untouched by this change)
- [x] `flutter test test/features/player` — 647 tests pass

Fixes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)