### PR TITLE
fix(player): stop self-dep Ref read in YouTube metadata refresh (#676)

### DIFF
--- a/lib/features/player/application/player_open_coordinator.dart
+++ b/lib/features/player/application/player_open_coordinator.dart
@@ -262,7 +262,14 @@ Future<void> runPlayerOpen(
   );
 
   if (playable is YoutubePlayableSource) {
-    scheduleYoutubeMetadataRefresh(ref, mediaId: mediaId, openGeneration: gen);
+    scheduleYoutubeMetadataRefresh(
+      ref,
+      mediaId: mediaId,
+      openGeneration: gen,
+      engine: engine,
+      currentOpenGeneration: () => host.openGeneration,
+      currentSessionMediaId: () => host.session?.mediaId,
+    );
   }
 
   if (kind == MediaKind.video &&

--- a/lib/features/player/application/player_open_side_effects.dart
+++ b/lib/features/player/application/player_open_side_effects.dart
@@ -13,7 +13,7 @@ import 'package:enjoy_player/data/db/app_database_provider.dart';
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
-import 'package:enjoy_player/features/player/application/player_controller.dart';
+import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_metadata_notifier.dart';
 import 'package:enjoy_player/features/sync/application/sync_providers.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_fetch_controller.dart';
@@ -89,16 +89,28 @@ Future<void> _runRecordingPull(
 }
 
 /// Lazy oEmbed retry after YouTube WebView reports playback-ready.
+///
+/// [engine] is the live playback engine and the freshness callbacks read the
+/// controller's state — both captured by the caller from the [PlayerOpenHost],
+/// never via `ref.read(playerControllerProvider...)`: this runs on the
+/// controller's own [Ref], and Riverpod asserts "A provider cannot depend on
+/// itself" when a provider reads itself (issue #676).
 void scheduleYoutubeMetadataRefresh(
   Ref ref, {
   required String mediaId,
   required int openGeneration,
+  required PlayerEngine engine,
+  required int Function() currentOpenGeneration,
+  required String? Function() currentSessionMediaId,
 }) {
   unawaited(
     _runYoutubeMetadataRefresh(
       ref,
       mediaId: mediaId,
       openGeneration: openGeneration,
+      engine: engine,
+      currentOpenGeneration: currentOpenGeneration,
+      currentSessionMediaId: currentSessionMediaId,
     ),
   );
 }
@@ -107,52 +119,60 @@ Future<void> _runYoutubeMetadataRefresh(
   Ref ref, {
   required String mediaId,
   required int openGeneration,
+  required PlayerEngine engine,
+  required int Function() currentOpenGeneration,
+  required String? Function() currentSessionMediaId,
 }) async {
-  final row = await ref.read(appDatabaseProvider).videoDao.getById(mediaId);
-  if (row == null || row.provider.toLowerCase() != 'youtube') return;
-  if (!_youtubeMetadataNeedsRefresh(row)) return;
+  // Same catch-and-log contract as the sibling helpers: this future is
+  // fire-and-forget, so an escaping throw becomes an unhandled async error.
+  try {
+    final row = await ref.read(appDatabaseProvider).videoDao.getById(mediaId);
+    if (row == null || row.provider.toLowerCase() != 'youtube') return;
+    if (!_youtubeMetadataNeedsRefresh(row)) return;
 
-  final controller = ref.read(playerControllerProvider.notifier);
-  final engine = controller.engine;
+    final ready = Completer<void>();
+    StreamSubscription<bool>? bufferingSub;
+    StreamSubscription<Duration>? durationSub;
+    Timer? timeout;
 
-  final ready = Completer<void>();
-  StreamSubscription<bool>? bufferingSub;
-  StreamSubscription<Duration>? durationSub;
-  Timer? timeout;
+    void finish() {
+      if (!ready.isCompleted) ready.complete();
+    }
 
-  void finish() {
-    if (!ready.isCompleted) ready.complete();
+    timeout = Timer(const Duration(seconds: 5), finish);
+    bufferingSub = engine.buffering.listen((buffering) {
+      if (!buffering) finish();
+    });
+    durationSub = engine.duration.listen((duration) {
+      if (duration > Duration.zero) finish();
+    });
+
+    await ready.future;
+    await bufferingSub.cancel();
+    await durationSub.cancel();
+    timeout.cancel();
+
+    if (currentOpenGeneration() != openGeneration) return;
+    if (currentSessionMediaId() != mediaId) return;
+
+    final patch = await ref
+        .read(mediaLibraryRepositoryProvider)
+        .refreshYoutubeMetadataIfNeeded(mediaId);
+    if (patch == null) return;
+
+    ref
+        .read(playerMetadataProvider.notifier)
+        .patchIfCurrent(
+          mediaId: mediaId,
+          openGeneration: openGeneration,
+          title: patch.title,
+          thumbnailUrl: patch.thumbnailUrl,
+        );
+  } on Object catch (e, st) {
+    logNamed(
+      'PlayerOpenSideEffects',
+    ).warning('youtube metadata refresh failed for $mediaId', e, st);
   }
-
-  timeout = Timer(const Duration(seconds: 5), finish);
-  bufferingSub = engine.buffering.listen((buffering) {
-    if (!buffering) finish();
-  });
-  durationSub = engine.duration.listen((duration) {
-    if (duration > Duration.zero) finish();
-  });
-
-  await ready.future;
-  await bufferingSub.cancel();
-  await durationSub.cancel();
-  timeout.cancel();
-
-  if (controller.openGeneration != openGeneration) return;
-  if (ref.read(playerControllerProvider)?.mediaId != mediaId) return;
-
-  final patch = await ref
-      .read(mediaLibraryRepositoryProvider)
-      .refreshYoutubeMetadataIfNeeded(mediaId);
-  if (patch == null) return;
-
-  ref
-      .read(playerMetadataProvider.notifier)
-      .patchIfCurrent(
-        mediaId: mediaId,
-        openGeneration: openGeneration,
-        title: patch.title,
-        thumbnailUrl: patch.thumbnailUrl,
-      );
 }
 
 bool _youtubeMetadataNeedsRefresh(VideoRow row) {

--- a/test/features/player/player_controller_test.dart
+++ b/test/features/player/player_controller_test.dart
@@ -5,6 +5,9 @@ import 'dart:typed_data';
 import 'package:drift/native.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/files/file_storage.dart';
+import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
+import 'package:enjoy_player/features/library/data/library_repository.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_controller.dart';
@@ -666,6 +669,85 @@ void main() {
       },
     );
 
+    test('YouTube placeholder-row open refreshes metadata without self-dep '
+        'Ref read (issue #676 regression)', () async {
+      // The lazy oEmbed side effect runs on the controller's own Ref. It
+      // must never `read(playerControllerProvider)` — Riverpod asserts "A
+      // provider cannot depend on itself" — so the coordinator now passes
+      // the engine + host freshness callbacks instead.
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final repo = _FakeYoutubeRefreshRepository(db);
+      final ytContainer = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          playerEngineTestDoubleProvider.overrideWithValue(fake),
+          transcriptRepositoryProvider.overrideWithValue(
+            TranscriptRepository(db),
+          ),
+          mediaLibraryRepositoryProvider.overrideWithValue(repo),
+        ],
+      );
+      addTearDown(ytContainer.dispose);
+
+      final id = await insertYoutubeRow(
+        db,
+        id: 'yt-placeholder',
+        title: 'YouTube video dQw4w9WgXcQ',
+        thumbnailUrl: null,
+      );
+
+      final n = ytContainer.read(playerControllerProvider.notifier);
+      // Before the fix this threw the Riverpod self-dependency assertion
+      // once the unawaited refresh reached the controller read.
+      await n.openMedia(id);
+      await _settleYoutubeRefresh(fake);
+
+      expect(repo.refreshCalls, contains(id));
+      // The patch landed through PlayerMetadataNotifier.patchIfCurrent.
+      expect(
+        ytContainer.read(playerControllerProvider)?.mediaTitle,
+        'Refreshed title',
+      );
+    });
+
+    test('YouTube metadata refresh failure is logged, never escapes as an '
+        'unhandled async error (issue #676)', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final repo = _ThrowingYoutubeRefreshRepository(db);
+      final ytContainer = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          playerEngineTestDoubleProvider.overrideWithValue(fake),
+          transcriptRepositoryProvider.overrideWithValue(
+            TranscriptRepository(db),
+          ),
+          mediaLibraryRepositoryProvider.overrideWithValue(repo),
+        ],
+      );
+      addTearDown(ytContainer.dispose);
+
+      final id = await insertYoutubeRow(
+        db,
+        id: 'yt-boom',
+        title: 'YouTube video dQw4w9WgXcQ',
+        thumbnailUrl: null,
+      );
+
+      final n = ytContainer.read(playerControllerProvider.notifier);
+      await n.openMedia(id);
+      // A bare throw inside the unawaited helper would be reported by the
+      // test zone as an unhandled async error and fail this test.
+      await _settleYoutubeRefresh(fake);
+
+      expect(repo.refreshCalls, contains(id));
+      // Session survives the failed refresh, unpatched.
+      expect(ytContainer.read(playerControllerProvider)?.mediaId, id);
+    });
+
     test('clear retains YoutubePlayerEngine without rev bump', () async {
       Future<String> insertYoutube({required String id}) async {
         final now = DateTime.now();
@@ -994,4 +1076,84 @@ void main() {
       expect(container.read(playerEngineRevProvider), 1);
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Issue #676 helpers
+// ---------------------------------------------------------------------------
+
+/// Emits `buffering=false` repeatedly for a short window so the unawaited
+/// metadata refresh catches it whenever it subscribes (its first DB read
+/// yields past the open call), then lets the whole side effect drain.
+Future<void> _settleYoutubeRefresh(FakePlayerEngine fake) async {
+  for (var i = 0; i < 20; i++) {
+    fake.emitBuffering(false);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  await pumpEventQueue();
+}
+
+/// Seeds a YouTube-provider video row the resolver turns into a
+/// [YoutubePlayableSource] (same shape as the side-effects test fixture).
+Future<String> insertYoutubeRow(
+  AppDatabase db, {
+  required String id,
+  required String title,
+  String? thumbnailUrl,
+}) async {
+  final now = DateTime.now();
+  await db.videoDao.insertRow(
+    VideoRow(
+      id: id,
+      vid: 'dQw4w9WgXcQ',
+      provider: 'youtube',
+      title: title,
+      description: null,
+      thumbnailUrl: thumbnailUrl,
+      durationSeconds: 212,
+      language: 'en',
+      source: 'youtube',
+      localUri: null,
+      md5: null,
+      size: null,
+      mediaUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      syncStatus: null,
+      serverUpdatedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+  return id;
+}
+
+/// Returns a fixed metadata patch instead of hitting oEmbed / the DB write.
+class _FakeYoutubeRefreshRepository extends MediaLibraryRepository {
+  _FakeYoutubeRefreshRepository(AppDatabase db)
+    : super(db, FileStorage(), enqueueSync: null);
+
+  final List<String> refreshCalls = [];
+
+  @override
+  Future<YoutubeMetadataPatch?> refreshYoutubeMetadataIfNeeded(
+    String mediaId,
+  ) async {
+    refreshCalls.add(mediaId);
+    return (title: 'Refreshed title', thumbnailUrl: null);
+  }
+}
+
+/// Throws like a failing oEmbed fetch / DB write would.
+class _ThrowingYoutubeRefreshRepository extends MediaLibraryRepository {
+  _ThrowingYoutubeRefreshRepository(AppDatabase db)
+    : super(db, FileStorage(), enqueueSync: null);
+
+  final List<String> refreshCalls = [];
+
+  @override
+  Future<YoutubeMetadataPatch?> refreshYoutubeMetadataIfNeeded(
+    String mediaId,
+  ) async {
+    refreshCalls.add(mediaId);
+    throw StateError('oembed_boom');
+  }
 }

--- a/test/features/player/player_open_side_effects_test.dart
+++ b/test/features/player/player_open_side_effects_test.dart
@@ -1,11 +1,17 @@
+import 'dart:async';
+
 import 'package:drift/native.dart';
 import 'package:enjoy_player/data/api/api_client.dart';
 import 'package:enjoy_player/data/api/services/recording_api.dart';
 import 'package:enjoy_player/data/db/app_database.dart';
 import 'package:enjoy_player/data/db/app_database_provider.dart';
+import 'package:enjoy_player/data/files/file_storage.dart';
 import 'package:enjoy_player/features/auth/application/auth_controller.dart';
 import 'package:enjoy_player/features/auth/domain/auth_state.dart';
 import 'package:enjoy_player/features/auth/domain/user_profile.dart';
+import 'package:enjoy_player/features/library/application/library_repository_provider.dart';
+import 'package:enjoy_player/features/library/data/library_repository.dart';
+import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
 import 'package:enjoy_player/features/player/application/player_open_side_effects.dart';
 import 'package:enjoy_player/features/sync/application/sync_providers.dart';
@@ -97,6 +103,29 @@ class _FakeRecordingTargetSyncService extends RecordingTargetSyncService {
   }
 }
 
+/// Records refresh calls without touching real DB / network.
+class _FakeMediaLibraryRepository extends MediaLibraryRepository {
+  _FakeMediaLibraryRepository(AppDatabase db)
+    : super(db, FileStorage(), enqueueSync: null);
+
+  static List<String> refreshCalls = [];
+  static Object? throwError;
+
+  static void reset() {
+    refreshCalls = [];
+    throwError = null;
+  }
+
+  @override
+  Future<YoutubeMetadataPatch?> refreshYoutubeMetadataIfNeeded(
+    String mediaId,
+  ) async {
+    refreshCalls.add(mediaId);
+    if (throwError != null) throw throwError!;
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -113,6 +142,9 @@ ProviderContainer _container({
     overrides: [
       appDatabaseProvider.overrideWithValue(db),
       playerEngineTestDoubleProvider.overrideWithValue(FakePlayerEngine()),
+      mediaLibraryRepositoryProvider.overrideWithValue(
+        _FakeMediaLibraryRepository(db),
+      ),
       authCtrlProvider.overrideWith(
         signedIn ? _SignedInAuthCtrl.new : _SignedOutAuthCtrl.new,
       ),
@@ -126,6 +158,38 @@ ProviderContainer _container({
 }
 
 Ref _ref(ProviderContainer container) => container.read(_refCapture);
+
+/// Schedules the refresh with [engine] plus host-style freshness callbacks,
+/// mirroring what [runPlayerOpen] passes — the helper itself must never read
+/// `playerControllerProvider` (issue #676).
+void _scheduleYoutubeRefresh(
+  ProviderContainer container, {
+  required String mediaId,
+  int openGeneration = 1,
+  PlayerEngine? engine,
+  int Function()? currentOpenGeneration,
+  String? Function()? currentSessionMediaId,
+}) {
+  scheduleYoutubeMetadataRefresh(
+    _ref(container),
+    mediaId: mediaId,
+    openGeneration: openGeneration,
+    engine: engine ?? FakePlayerEngine(),
+    currentOpenGeneration: currentOpenGeneration ?? () => openGeneration,
+    currentSessionMediaId: currentSessionMediaId ?? () => mediaId,
+  );
+}
+
+/// Emits `buffering=false` repeatedly for a short window so the helper
+/// catches it whenever it subscribes (its first DB read yields past the
+/// schedule call), then lets the whole side effect drain.
+Future<void> _driveYoutubeRefreshReady(FakePlayerEngine engine) async {
+  for (var i = 0; i < 20; i++) {
+    engine.emitBuffering(false);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  await pumpEventQueue();
+}
 
 Future<void> _insertVideoRow(
   AppDatabase db, {
@@ -172,6 +236,7 @@ void main() {
     db = AppDatabase(executor: NativeDatabase.memory());
     _FakeTranscriptFetchCtrl.reset();
     _FakeRecordingTargetSyncService.reset();
+    _FakeMediaLibraryRepository.reset();
   });
 
   tearDown(() async {
@@ -292,14 +357,10 @@ void main() {
       await container.read(authCtrlProvider.future);
 
       // No row inserted for 'missing-id' — should return early.
-      scheduleYoutubeMetadataRefresh(
-        _ref(container),
-        mediaId: 'missing-id',
-        openGeneration: 1,
-      );
+      _scheduleYoutubeRefresh(container, mediaId: 'missing-id');
 
       await pumpEventQueue();
-      // No crash; the function returned early after finding null row.
+      expect(_FakeMediaLibraryRepository.refreshCalls, isEmpty);
     });
 
     test('early return when provider is not youtube', () async {
@@ -314,14 +375,11 @@ void main() {
       addTearDown(container.dispose);
       await container.read(authCtrlProvider.future);
 
-      scheduleYoutubeMetadataRefresh(
-        _ref(container),
-        mediaId: 'v-user',
-        openGeneration: 1,
-      );
+      _scheduleYoutubeRefresh(container, mediaId: 'v-user');
 
       await pumpEventQueue();
-      // No crash; returned early because provider != 'youtube'.
+      // Returned early because provider != 'youtube'.
+      expect(_FakeMediaLibraryRepository.refreshCalls, isEmpty);
     });
 
     test('early return when metadata does not need refresh', () async {
@@ -337,21 +395,14 @@ void main() {
       addTearDown(container.dispose);
       await container.read(authCtrlProvider.future);
 
-      scheduleYoutubeMetadataRefresh(
-        _ref(container),
-        mediaId: 'v-complete',
-        openGeneration: 1,
-      );
+      _scheduleYoutubeRefresh(container, mediaId: 'v-complete');
 
       await pumpEventQueue();
-      // No crash; returned early because title is real and thumbnail exists.
+      // Returned early because title is real and thumbnail exists.
+      expect(_FakeMediaLibraryRepository.refreshCalls, isEmpty);
     });
 
     test('proceeds when title is placeholder (needs refresh)', () async {
-      // This row has a placeholder title — metadata needs refresh.
-      // The function will proceed past the guard but will fail at
-      // playerControllerProvider (no engine in test) — which is fine,
-      // we just verify it doesn't crash due to the unawaited wrapper.
       await _insertVideoRow(
         db,
         id: 'v-placeholder',
@@ -364,17 +415,15 @@ void main() {
       addTearDown(container.dispose);
       await container.read(authCtrlProvider.future);
 
-      // The function fires unawaited work that will hit the player controller.
-      // In test without a full player setup, this will throw internally but
-      // the error is swallowed by the unawaited future (no zone handler).
-      // We just verify no synchronous crash.
-      scheduleYoutubeMetadataRefresh(
-        _ref(container),
+      // Buffering settles so the readiness gate resolves.
+      final engine = FakePlayerEngine();
+      _scheduleYoutubeRefresh(
+        container,
         mediaId: 'v-placeholder',
-        openGeneration: 1,
+        engine: engine,
       );
-
-      await pumpEventQueue();
+      await _driveYoutubeRefreshReady(engine);
+      expect(_FakeMediaLibraryRepository.refreshCalls, ['v-placeholder']);
     });
 
     test('proceeds when thumbnail is empty string (needs refresh)', () async {
@@ -390,13 +439,60 @@ void main() {
       addTearDown(container.dispose);
       await container.read(authCtrlProvider.future);
 
+      final engine = FakePlayerEngine();
+      _scheduleYoutubeRefresh(
+        container,
+        mediaId: 'v-empty-thumb',
+        engine: engine,
+      );
+      await _driveYoutubeRefreshReady(engine);
+      expect(_FakeMediaLibraryRepository.refreshCalls, ['v-empty-thumb']);
+    });
+
+    test('skips refresh when open generation went stale', () async {
+      await _insertVideoRow(
+        db,
+        id: 'v-stale',
+        vid: 'dQw4w9WgXcQ',
+        provider: 'youtube',
+        title: 'YouTube video dQw4w9WgXcQ',
+      );
+      final container = _container(db: db, signedIn: false);
+      addTearDown(container.dispose);
+      await container.read(authCtrlProvider.future);
+
+      final engine = FakePlayerEngine();
       scheduleYoutubeMetadataRefresh(
         _ref(container),
-        mediaId: 'v-empty-thumb',
+        mediaId: 'v-stale',
         openGeneration: 1,
+        engine: engine,
+        // A newer open landed meanwhile — the host reports generation 2.
+        currentOpenGeneration: () => 2,
+        currentSessionMediaId: () => 'v-stale',
       );
+      await _driveYoutubeRefreshReady(engine);
+      expect(_FakeMediaLibraryRepository.refreshCalls, isEmpty);
+    });
 
-      await pumpEventQueue();
+    test('repository error is caught and does not escape', () async {
+      await _insertVideoRow(
+        db,
+        id: 'v-boom',
+        vid: 'dQw4w9WgXcQ',
+        provider: 'youtube',
+        title: 'YouTube video dQw4w9WgXcQ',
+      );
+      _FakeMediaLibraryRepository.throwError = StateError('oembed_boom');
+      final container = _container(db: db, signedIn: false);
+      addTearDown(container.dispose);
+      await container.read(authCtrlProvider.future);
+
+      // Should not surface as an unhandled async error despite the throw.
+      final engine = FakePlayerEngine();
+      _scheduleYoutubeRefresh(container, mediaId: 'v-boom', engine: engine);
+      await _driveYoutubeRefreshReady(engine);
+      expect(_FakeMediaLibraryRepository.refreshCalls, ['v-boom']);
     });
   });
 }

--- a/test/support/fake_player_engine.dart
+++ b/test/support/fake_player_engine.dart
@@ -45,6 +45,11 @@ class FakePlayerEngine implements PlayerEngine {
     if (!_duration.isClosed) _duration.add(d);
   }
 
+  /// Simulates a buffering transition (used by post-open readiness gates).
+  void emitBuffering(bool value) {
+    if (!_buffering.isClosed) _buffering.add(value);
+  }
+
   /// Simulates end-of-media (fires the [completed] stream once).
   void emitCompleted() {
     if (!_completed.isClosed) _completed.add(null);


### PR DESCRIPTION
## Summary

Fixes #676.

`_runYoutubeMetadataRefresh` (scheduled from `runPlayerOpen`, which runs on the **controller's own** `Ref`) did `ref.read(playerControllerProvider.notifier)` and `ref.read(playerControllerProvider)` — tripping Riverpod 3's "A provider cannot depend on itself" debug assertion on exactly the placeholder-row YouTube opens where the lazy oEmbed refresh runs. The helper was also unguarded: a throwing `refreshYoutubeMetadataIfNeeded` escaped the `unawaited(...)` future as an unhandled async error.

Audit of the issue confirmed both claims at HEAD (a8f5b045); this PR implements the fix as scoped in the issue:

- `scheduleYoutubeMetadataRefresh` now receives the live `PlayerEngine` plus host-style freshness callbacks (`currentOpenGeneration` / `currentSessionMediaId`), mirroring the existing `VideoPosterCaptureService.scheduleCapture` pattern — the coordinator passes `engine` / `() => host.openGeneration` / `() => host.session?.mediaId`. The side-effects module no longer imports `player_controller.dart` at all.
- The whole helper is wrapped in the same try/catch + `logNamed('PlayerOpenSideEffects')` pattern as its `_runTranscriptResolve` / `_runRecordingPull` siblings.

No behavior change beyond the two defects: freshness checks read the same values (host generation / session mediaId) at the same points in the flow.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Platform tested

- [x] Linux (automated suite host; debug-mode asserts active in `flutter test`)

## Checklist

- [x] `bash .github/scripts/validate_ci_gates.sh` passes (Dart format + codegen drift, zero tree drift afterwards)
- [x] `flutter analyze` is clean (only 4 pre-existing `prefer_const_constructors` infos in untouched notice/nav test files)
- [x] `flutter test` passes — full suite green (5851 passed, 2 pre-existing skips)
- [x] No new `print()` / `kIsWeb` branches / SQL outside Drift DAOs / `Player()` instances
- [x] New public API parameters documented (doc comment on `scheduleYoutubeMetadataRefresh` explaining the self-dep rule)
- N/A Drift / Riverpod / Freezed annotations unchanged — no codegen to commit
- N/A No user-visible behavior change, so no `docs/features` update

## Test plan

- `test/features/player/player_controller_test.dart` (**new**, per the issue's acceptance criteria):
  - opens a YouTube media whose row has a placeholder title / null thumbnail through the real `PlayerController.openMedia` (the path that carries the controller's own `Ref`) → no self-dependency assertion, the refresh runs and the returned patch lands on the session via `patchIfCurrent`;
  - a throwing repository is logged and does not escape as an unhandled async error (the test zone would fail if it did);
  - **red/green verified**: reverting the helper to the old self-dep reads makes both new controller tests fail; with the fix the whole suite passes.
- `test/features/player/player_open_side_effects_test.dart`: existing early-return cases tightened to assert the repository is *not* reached; placeholder/blank-thumbnail cases now drive the readiness gate (`buffering=false`) and assert the refresh *is* reached; new stale-generation skip case; new repository-throw swallowed case. `FakePlayerEngine` gains `emitBuffering`.
- Focused runs: `flutter test test/features/player/player_open_side_effects_test.dart`, `flutter test test/features/player/player_controller_test.dart`.

## Out of scope / follow-up

- `_runTranscriptResolve` / `_runRecordingPull` already catch-and-log; unchanged.
- `schedulePlayerOpenSideEffects` reads `authCtrlProvider` (a different provider) — legal dependency, untouched.

## Human / owner follow-up

- None
