### PR TITLE
refactor(player): one single-flight gate, one engine-swap seam

### DIFF
--- a/lib/features/player/application/completion_loop.dart
+++ b/lib/features/player/application/completion_loop.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/single_flight_gate.dart';
 import 'package:enjoy_player/features/player/domain/echo_window.dart';
 import 'package:enjoy_player/features/player/domain/player_settings.dart';
 import 'package:enjoy_player/features/player/domain/transport_decisions.dart';
@@ -16,12 +17,17 @@ typedef CompletionEchoSnapshot = ({bool active, double startTimeSeconds});
 
 /// Generation-guarded await-completion loop shared by every [PlayerEngine].
 ///
-/// Mirrors the generation-counter + single-flight pattern from
-/// `EchoEnforcer._epoch` / `PlayerController._openGeneration`: the transport
-/// drives itself off `await`ed completion futures instead of polling the
-/// position stream, and every in-flight await captures a generation id so a
-/// stale completion from a previous media (or a duplicate `completed` event
-/// from mpv) is a no-op.
+/// Same concept as [SingleFlightGate] — a monotonic generation captured at
+/// entry and re-checked after every `await`, so a stale completion from a
+/// previous media (or a duplicate `completed` event from mpv) is a no-op —
+/// but it keeps its own fields because two of its mechanics diverge:
+///
+/// - the in-flight await is **cancelable**: [bump] completes a `Completer`
+///   that the pending `engine.completed` await races, rather than letting it
+///   drain (a completion stream may simply never fire again after a seek);
+/// - the "a loop is running" marker is keyed *by generation*
+///   ([_activeLoopGen]), not by op identity, so a loop that is mid-drain
+///   cannot block [arm] for the new stint.
 ///
 /// This is the **single consumer** of [PlayerEngine.completed] for repeat
 /// policy — engine-internal poll loops (e.g. YouTube) only surface the

--- a/lib/features/player/application/echo_enforcer.dart
+++ b/lib/features/player/application/echo_enforcer.dart
@@ -17,6 +17,7 @@ import 'package:enjoy_player/data/subtitle/transcript_line.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_engine_constants.dart';
+import 'package:enjoy_player/features/player/application/single_flight_gate.dart';
 import 'package:enjoy_player/features/player/domain/echo_window.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 
@@ -48,15 +49,12 @@ class EchoEnforcer {
   /// time so a re-segmented transcript yields fresh boundaries (M4).
   final List<TranscriptLine>? Function() getLines;
 
-  /// Bumped by [reset]; in-flight ops capture the value at start and bail if
-  /// it changed, so a media switch mid-enforcement is a no-op rather than a
-  /// stray seek on the next media.
-  int _epoch = 0;
-
-  /// Non-null while an enforcement op is running. Set synchronously before the
-  /// first await, so the "is something in flight?" check is race-free across
-  /// two synchronous position events.
-  Future<void>? _inFlight;
+  /// Generation + single-flight slot. Bumped by [reset]; in-flight ops capture
+  /// the generation at start and bail if it changed, so a media switch
+  /// mid-enforcement is a no-op rather than a stray seek on the next media.
+  /// While one op holds the slot, concurrent ticks are dropped and concurrent
+  /// clamps wait (bounded — see [clampAndSeek]).
+  final SingleFlightGate _gate = SingleFlightGate();
 
   /// Inputs behind the memoized window in [_windowCache]: the fields the hot
   /// path can compare for free (echo state by value, session duration). The
@@ -73,19 +71,13 @@ class EchoEnforcer {
   /// the in-flight action already corrected playback and the next tick
   /// re-evaluates against the post-correction position.
   Future<void> enforceTick(double positionSeconds) async {
-    if (_inFlight != null) return;
+    if (_gate.inFlight) return;
     final window = _resolveWindow();
     if (window == null) return;
     final decision = decideEchoPlaybackTime(positionSeconds, window);
     if (decision is EchoOk) return;
-    final epoch = _epoch;
-    final future = _applyDecision(decision, epoch);
-    _inFlight = future;
-    try {
-      await future;
-    } finally {
-      if (_inFlight == future) _inFlight = null;
-    }
+    final epoch = _gate.generation;
+    await _gate.run(_applyDecision(decision, epoch));
   }
 
   /// Proactive seek clamp (user tapped a cue / scrubbed). Clamps the requested
@@ -102,21 +94,15 @@ class EchoEnforcer {
     // in-flight enforcement, the requested target belongs to media that is
     // gone, and re-entering the loop with a fresh epoch would seek the old
     // target onto the new engine (unclamped, its echo being inactive).
-    final epoch = _epoch;
-    while (_epoch == epoch) {
-      final pending = _inFlight;
+    final epoch = _gate.generation;
+    while (!_gate.isStale(epoch)) {
+      final pending = _gate.pending;
       if (pending == null) {
         final window = _resolveWindow(override: override);
         final target = window == null
             ? requestedSeconds
             : clampSeekTimeToEchoWindow(requestedSeconds, window);
-        final future = _seek(target, epoch);
-        _inFlight = future;
-        try {
-          await future;
-        } finally {
-          if (_inFlight == future) _inFlight = null;
-        }
+        await _gate.run(_seek(target, epoch));
         return target;
       }
       // An enforcement is running; wait for it (bounded — a wedged engine seek
@@ -131,7 +117,7 @@ class EchoEnforcer {
         );
         // The wedged op's own finally is guarded by identity, so clearing here
         // cannot race it out of a slot it still owns.
-        if (_inFlight == pending) _inFlight = null;
+        _gate.release(pending);
         return requestedSeconds;
       }
     }
@@ -142,8 +128,7 @@ class EchoEnforcer {
   /// media switch / clear so a pending pause-and-rewind can't seek a stale
   /// engine or hold the slot forever (which would block all future enforcement).
   void reset() {
-    _epoch++;
-    _inFlight = null;
+    _gate.cancel();
     // The window is derived from the previous media's session; re-derive for
     // the next one rather than serving a cached duration / transcript.
     _windowCacheKey = null;
@@ -151,7 +136,7 @@ class EchoEnforcer {
   }
 
   Future<void> _applyDecision(EchoPlaybackDecision decision, int epoch) async {
-    if (_epoch != epoch) return;
+    if (_gate.isStale(epoch)) return;
     switch (decision) {
       case EchoOk():
         return;
@@ -161,13 +146,13 @@ class EchoEnforcer {
         await getEngine().pause();
         // A reset may have landed between pause and seek; don't seek a stale
         // engine onto the next media.
-        if (_epoch != epoch) return;
+        if (_gate.isStale(epoch)) return;
         await getEngine().seek(durationFromSeconds(timeSeconds));
     }
   }
 
   Future<void> _seek(double targetSeconds, int epoch) async {
-    if (_epoch != epoch) return;
+    if (_gate.isStale(epoch)) return;
     await getEngine().seek(durationFromSeconds(targetSeconds));
   }
 

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -12,6 +12,7 @@ import 'package:enjoy_player/features/player/application/completion_loop.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/engines/youtube/youtube_player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/player_engine_binding.dart';
 import 'package:enjoy_player/features/player/application/player_engine_rev.dart';
 import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
 import 'package:enjoy_player/features/player/application/player_open_coordinator.dart';
@@ -342,10 +343,16 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
       // pump (2026-08-29 field report).
       return;
     }
-    // Genuinely no engine yet — install the YouTube one. Bump before warming
-    // (ADR-0057) so PlayerSurfaceHost keys a stage for the new engine.
-    _ownedEngine = YoutubePlayerEngine();
-    ref.read(playerEngineRevProvider.notifier).bump();
+    // Genuinely no engine yet — install the YouTube one. [EngineSwap.install]
+    // bumps the rev (ADR-0057) so PlayerSurfaceHost keys a stage for the new
+    // engine. There is no prior engine to tear down, and this path never
+    // calls [EngineSwap.discardWithoutAwaiting]: a speculative warm must not
+    // be able to dispose an engine even if the guards above rot.
+    EngineSwap(
+      ref: ref,
+      getOwnedEngine: () => _ownedEngine,
+      setOwnedEngine: (next) => _ownedEngine = next,
+    ).install(YoutubePlayerEngine());
     _ownedEngine!.warmVideoSurface();
   }
 

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -17,6 +17,7 @@ import 'package:enjoy_player/features/player/application/player_engine_test_doub
 import 'package:enjoy_player/features/player/application/player_open_coordinator.dart';
 import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
 import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
+import 'package:enjoy_player/features/player/application/single_flight_gate.dart';
 import 'package:enjoy_player/features/player/domain/echo_window.dart';
 import 'package:enjoy_player/features/player/domain/open_media_options.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
@@ -31,7 +32,7 @@ part 'player_controller.g.dart';
 /// Deterministic end-of-media completion loop (ADR-0044).
 ///
 /// Mirrors the generation-counter + single-flight pattern from
-/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// [SingleFlightGate]: the transport drives itself off
 /// `await`ed completion futures instead of polling the position stream, and
 /// every in-flight await captures a generation id so a stale completion from a
 /// previous media (or a duplicate `completed` event from mpv) is a no-op.
@@ -45,16 +46,24 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     getEngine: () => activeEngine,
     getSession: () => state,
     setSession: (next) => state = next,
-    currentOpenGeneration: () => _openGeneration,
+    currentOpenGeneration: () => _openGate.generation,
   );
 
-  /// Incremented on each [openMedia] call; stale async work bails out.
-  int _openGeneration = 0;
+  /// The open generation: bumped by [openMedia], [clear] and
+  /// [abandonPendingOpen]; every async step of an open captures it at entry
+  /// ([openGeneration] / [isOpenStale]) and bails when it has moved on. The
+  /// single-flight slot is unused here — see [_openInFlight].
+  final SingleFlightGate _openGate = SingleFlightGate();
 
-  /// True between [openMedia] bumping [_openGeneration] and the session being
-  /// published (or the open failing): `state` is still `null`, so this is the
-  /// only signal that an engine swap is already coordinated and in flight.
-  /// [warmYoutubeSurface] consults it — issue #657.
+  /// True between [openMedia] bumping the open generation and the session
+  /// being published (or the open failing): `state` is still `null`, so this
+  /// is the only signal that an engine swap is already coordinated and in
+  /// flight. [warmYoutubeSurface] consults it — issue #657.
+  ///
+  /// Deliberately *not* the gate's in-flight slot: it is a latch keyed by
+  /// generation (cleared in `finally` only when the open is still current, and
+  /// cleared unconditionally by [clear] with no future completing), which is
+  /// not the identity-guarded "one op owns the slot" contract the gate models.
   bool _openInFlight = false;
 
   /// Deterministic end-of-media loop (ADR-0044). Owns the playback
@@ -82,10 +91,10 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
   Future<void> get teardown => _teardown;
 
   @override
-  int get openGeneration => _openGeneration;
+  int get openGeneration => _openGate.generation;
 
   @override
-  bool isOpenStale(int gen) => gen != _openGeneration;
+  bool isOpenStale(int gen) => _openGate.isStale(gen);
 
   @override
   PlayerEngine? get ownedEngine => _ownedEngine;
@@ -184,7 +193,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
       return;
     }
 
-    final gen = ++_openGeneration;
+    final gen = _openGate.bump();
     // Marked before the first await so a speculative [warmYoutubeSurface] that
     // lands inside this window sees the open that is already coordinating the
     // engine (issue #657).
@@ -198,7 +207,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
         mediaId,
         options: options,
         onFailureResetSession: () {
-          if (gen == _openGeneration) {
+          if (!_openGate.isStale(gen)) {
             state = null;
           }
         },
@@ -206,7 +215,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     } finally {
       // Only a still-current open clears the flag — an open superseded by a
       // newer one must not report "idle" while that newer one is still running.
-      if (gen == _openGeneration) {
+      if (!_openGate.isStale(gen)) {
         _openInFlight = false;
       }
     }
@@ -214,7 +223,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     // Start the deterministic completion loop for the new playback stint
     // (ADR-0044). Only when the open actually landed (state's mediaId matches
     // and the generation is still current).
-    if (!_disposed && gen == _openGeneration && state?.mediaId == mediaId) {
+    if (!_disposed && !_openGate.isStale(gen) && state?.mediaId == mediaId) {
       _completionLoop.arm();
       // Promote to Home "Recent media" even if playback is still starting.
       unawaited(
@@ -288,7 +297,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
       persister.cancel();
     }
 
-    _openGeneration++;
+    _openGate.bump();
     // Clear invalidates any open still in flight, so drop the flag too — that
     // open's `finally` skips the reset (its generation is stale) and the latch
     // would otherwise disable speculative warming for the rest of the session
@@ -341,7 +350,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
   }
 
   void abandonPendingOpen() {
-    _openGeneration++;
+    _openGate.bump();
     _completionLoop.bump();
   }
 

--- a/lib/features/player/application/player_engine_binding.dart
+++ b/lib/features/player/application/player_engine_binding.dart
@@ -16,6 +16,83 @@ import 'package:enjoy_player/features/player/application/player_engine_test_doub
 
 final _bindLog = logNamed('PlayerEngineBinding');
 
+/// The mechanics every engine swap shares: install [PlayerEngine] as the owned
+/// engine and bump [playerEngineRevProvider] so the permanent
+/// [PlayerSurfaceHost] re-keys its stage (ADR-0057), plus the teardown of the
+/// engine that was replaced.
+///
+/// Only mechanics live here. *Policy* stays at the call sites — whether a swap
+/// is allowed at all, which generation guards apply around each await, and
+/// what must happen before MediaKit may allocate mpv:
+///
+/// - [ensureEngineForPlayableSource] runs the full open-path choreography:
+///   install + bump, let the host drop the old stage, wait for the prior
+///   surface to detach, settle, discard the old engine without awaiting it,
+///   prepare the native backend, bump again.
+/// - `PlayerController.warmYoutubeSurface` installs only when there is no
+///   engine at all and never calls [discardWithoutAwaiting] — that is what
+///   makes its "must never dispose a live / parked MediaKit engine" rule true
+///   by construction rather than by an assertion in the call site.
+/// - [replaceWedgedLocalEngine] installs a replacement for a wedged local
+///   engine and discards the wedged one unawaited.
+class EngineSwap {
+  EngineSwap({
+    required this.ref,
+    required this.getOwnedEngine,
+    required this.setOwnedEngine,
+  });
+
+  final Ref ref;
+  final PlayerEngine? Function() getOwnedEngine;
+  final void Function(PlayerEngine? next) setOwnedEngine;
+
+  /// Installs [next] as the owned engine and notifies the surface host.
+  /// Returns the engine that was replaced, or `null` when there was none —
+  /// the caller owns its teardown, under its own contract.
+  PlayerEngine? install(PlayerEngine next) {
+    final previous = getOwnedEngine();
+    setOwnedEngine(next);
+    bumpRev();
+    return previous;
+  }
+
+  /// Notifies [PlayerSurfaceHost] that the engine identity changed.
+  ///
+  /// [ensureEngineForPlayableSource] bumps **twice**: the first bump drops the
+  /// old engine's `buildVideoStage` before teardown, the second follows
+  /// [PlayerEngine.prepareNativeBackend] so the MediaKit `Video` may mount
+  /// into the already-keyed loading stage.
+  void bumpRev() => ref.read(playerEngineRevProvider.notifier).bump();
+
+  /// Waits for [previous]'s platform view to drop (bounded by
+  /// [kEngineSurfaceDetachTimeout]) and lets the surface settle
+  /// ([kEngineSurfaceSettleDelay]) so MediaKit never allocates [Player] while
+  /// InAppWebView is still destroying.
+  Future<void> awaitPriorSurfaceSettled(PlayerEngine previous) async {
+    try {
+      await previous.awaitSurfaceDetached().timeout(
+        kEngineSurfaceDetachTimeout,
+      );
+    } on TimeoutException {
+      _bindLog.warning(
+        'prior engine surface detach timed out after '
+        '$kEngineSurfaceDetachTimeout; continuing swap',
+      );
+    }
+    await Future<void>.delayed(kEngineSurfaceSettleDelay);
+  }
+
+  /// Starts [previous]'s teardown without awaiting it.
+  ///
+  /// YouTube `closeStreams` can hang for seconds while listeners drain
+  /// (2026-08-30 Android: 5 s skeleton on a 4 s local file — the log was this
+  /// exact timeout). The replacement is already installed; a leaked old
+  /// teardown beats a spinner.
+  void discardWithoutAwaiting(PlayerEngine previous) {
+    unawaited(previous.dispose());
+  }
+}
+
 /// Ensures [_ownedEngine] matches [playable] (YouTube vs MediaKit), bumping
 /// [playerEngineRevProvider] when the implementation changes.
 ///
@@ -66,9 +143,13 @@ Future<bool> ensureEngineForPlayableSource(
   if (owned != null && haveYt == wantYt) return false;
   if (currentOpenGeneration() != openGeneration) return false;
 
+  final swap = EngineSwap(
+    ref: ref,
+    getOwnedEngine: getOwnedEngine,
+    setOwnedEngine: setOwnedEngine,
+  );
   final next = wantYt ? YoutubePlayerEngine() : MediaKitPlayerEngine();
-  setOwnedEngine(next);
-  ref.read(playerEngineRevProvider.notifier).bump();
+  swap.install(next);
   // Let PlayerSurfaceHost drop the old ObjectKey stage before teardown.
   // MediaKit must not allocate [Player] yet — [prepareNativeBackend] runs
   // only after the prior surface has detached.
@@ -78,24 +159,12 @@ Future<bool> ensureEngineForPlayableSource(
     return false;
   }
   if (owned != null) {
-    try {
-      await owned.awaitSurfaceDetached().timeout(kEngineSurfaceDetachTimeout);
-    } on TimeoutException {
-      _bindLog.warning(
-        'prior engine surface detach timed out after '
-        '$kEngineSurfaceDetachTimeout; continuing swap',
-      );
-    }
-    await Future<void>.delayed(kEngineSurfaceSettleDelay);
+    await swap.awaitPriorSurfaceSettled(owned);
     if (currentOpenGeneration() != openGeneration) {
       await next.dispose();
       return false;
     }
-    // Do not await dispose on the open path. YouTube closeStreams can hang
-    // for seconds while listeners drain (2026-08-30 Android: 5 s skeleton
-    // on a 4 s local file — the log was this exact timeout). The new
-    // engine is already installed; a leaked old teardown beats a spinner.
-    unawaited(owned.dispose());
+    swap.discardWithoutAwaiting(owned);
   }
   if (currentOpenGeneration() != openGeneration) {
     await next.dispose();
@@ -104,7 +173,7 @@ Future<bool> ensureEngineForPlayableSource(
   next.prepareNativeBackend();
   // Second bump: MediaKit Video may now mount (loading stage already has a
   // target). First bump only dropped the YouTube WebView.
-  ref.read(playerEngineRevProvider.notifier).bump();
+  swap.bumpRev();
   return true;
 }
 
@@ -121,9 +190,13 @@ Future<void> replaceWedgedLocalEngine(
   if (ref.read(playerEngineTestDoubleProvider) != null) return;
   final old = getOwnedEngine();
   if (old == null || old.supportsYouTubePlayback) return;
+  final swap = EngineSwap(
+    ref: ref,
+    getOwnedEngine: getOwnedEngine,
+    setOwnedEngine: setOwnedEngine,
+  );
   final next = MediaKitPlayerEngine();
   next.prepareNativeBackend();
-  setOwnedEngine(next);
-  ref.read(playerEngineRevProvider.notifier).bump();
-  unawaited(old.dispose());
+  swap.install(next);
+  swap.discardWithoutAwaiting(old);
 }

--- a/lib/features/player/application/single_flight_gate.dart
+++ b/lib/features/player/application/single_flight_gate.dart
@@ -1,0 +1,95 @@
+/// One generation-guard / single-flight primitive for engine-adjacent async work.
+library;
+
+/// Monotonic generation guard plus an identity-guarded in-flight slot.
+///
+/// Four call sites (`EchoEnforcer`, `WordLoopEnforcer`,
+/// `CompletionLoop`, `PlayerController._openGeneration`) hand-rolled the same
+/// trio of fields — a counter that is bumped on every event that invalidates
+/// the current stint, a value captured at entry, and a staleness check after
+/// each `await`. This extracts the shared mechanics; the per-site *policy*
+/// (what a generation means, when to bump, whether an op may be cancelled
+/// mid-await) stays at the call site.
+///
+/// Capture-at-entry / staleness:
+/// ```dart
+/// final gen = gate.generation; // capture before the first await
+/// await engine.seek(...);
+/// if (gate.isStale(gen)) return; // a bump landed while we awaited
+/// ```
+///
+/// Single-flight: at most one op holds [run]'s slot at a time. The slot is
+/// claimed synchronously, so two synchronous position events cannot both
+/// enter. Completion clears the slot only if the completing op still owns it,
+/// so a slot dropped by [cancel] (or by [release]) cannot be clobbered by a
+/// draining op's late `finally`.
+///
+/// Not every variant fits. `CompletionLoop` needs a *cancelable* await (its
+/// `bump` completes a `Completer` that the in-flight await races) and keys its
+/// "loop is running" marker by generation rather than by op identity — it
+/// keeps those as local fields and only shares this class's *concept*.
+class SingleFlightGate {
+  /// Bumped by [bump] / [cancel]; ops bail when their captured value differs.
+  int _generation = 0;
+
+  /// The op currently holding the slot, or `null`. Set synchronously by
+  /// [run], so the "is something in flight?" check is race-free across two
+  /// synchronous events.
+  Future<void>? _inFlight;
+
+  /// The current generation. Capture it into a local before the first `await`
+  /// and pass it back to [isStale] afterwards.
+  int get generation => _generation;
+
+  /// Whether [generation] has been superseded by a [bump] / [cancel].
+  bool isStale(int generation) => generation != _generation;
+
+  /// True while an op holds the slot. Callers that should drop work when an
+  /// op is already running check this *before* doing anything else.
+  bool get inFlight => _inFlight != null;
+
+  /// The op currently holding the slot, or `null`.
+  ///
+  /// Exposed for the bounded-wait pattern: a caller that must not be held
+  /// hostage by a wedged engine command awaits [pending] with a timeout and
+  /// calls [release] when the timeout fires.
+  Future<void>? get pending => _inFlight;
+
+  /// Invalidates every captured generation and drops the slot.
+  ///
+  /// The op that was holding the slot keeps draining, but its own completion
+  /// no longer finds itself in the slot (identity-guarded), and any post-`await`
+  /// [isStale] check stops it from acting on the next stint.
+  void cancel() {
+    _generation++;
+    _inFlight = null;
+  }
+
+  /// Invalidates every captured generation without touching the slot.
+  ///
+  /// For sites whose in-flight slot is not owned by [run] (e.g. a latch reset
+  /// under other conditions) but whose captured generations must be invalidated.
+  int bump() => ++_generation;
+
+  /// Claims the slot for [op] and awaits it to completion, rethrowing any
+  /// error [op] throws after clearing the slot.
+  ///
+  /// [op] is created by the caller so its synchronous prefix runs before the
+  /// claim — exactly where the call site used to build its future.
+  Future<void> run(Future<void> op) async {
+    _inFlight = op;
+    try {
+      await op;
+    } finally {
+      release(op);
+    }
+  }
+
+  /// Drops the slot if [op] still owns it.
+  ///
+  /// Called by [run]'s `finally` and directly by a caller that gave up on a
+  /// wedged [pending] after its own timeout.
+  void release(Future<void> op) {
+    if (identical(_inFlight, op)) _inFlight = null;
+  }
+}

--- a/lib/features/player/application/word_loop_enforcer.dart
+++ b/lib/features/player/application/word_loop_enforcer.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:enjoy_player/core/logging/log.dart';
 import 'package:enjoy_player/features/player/application/echo_mode_provider.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
+import 'package:enjoy_player/features/player/application/single_flight_gate.dart';
 import 'package:enjoy_player/features/player/domain/echo_window.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'package:enjoy_player/features/player/domain/word_loop.dart';
@@ -25,8 +26,10 @@ class WordLoopEnforcer {
   final PlayerEngine Function() getEngine;
   final PlaybackSession? Function() getSession;
 
-  int _epoch = 0;
-  Future<void>? _inFlight;
+  /// Generation + single-flight slot: a wrap seek holds the slot while it
+  /// runs, concurrent ticks are dropped, and [reset] invalidates any wrap
+  /// whose media is gone. Same mechanics as [EchoEnforcer].
+  final SingleFlightGate _gate = SingleFlightGate();
 
   /// Reactive wrap. Returns whether echo enforcement should skip this tick.
   Future<bool> enforceTick(int positionMs) async {
@@ -57,17 +60,13 @@ class WordLoopEnforcer {
         ref.read(wordPracticeSessionProvider(mediaId).notifier).clearLoop();
         return false;
       case WordLoopTickDecision.wrap:
-        if (_inFlight != null) return true;
-        final epoch = _epoch;
+        if (_gate.inFlight) return true;
+        final epoch = _gate.generation;
         final startMs = loop.loopStartMs!;
-        final future = _seek(startMs, epoch);
-        _inFlight = future;
         try {
-          await future;
+          await _gate.run(_seek(startMs, epoch));
         } catch (e, st) {
           _log.warning('word loop wrap failed', e, st);
-        } finally {
-          if (_inFlight == future) _inFlight = null;
         }
         return true;
     }
@@ -76,14 +75,13 @@ class WordLoopEnforcer {
   /// Neutralizes any in-flight wrap. Must not read [Ref] or [getSession] —
   /// [PlayerPositionTracker.cancel] also runs from `PlayerController` dispose.
   void reset() {
-    _epoch++;
-    _inFlight = null;
+    _gate.cancel();
   }
 
   Future<void> _seek(int startMs, int epoch) async {
-    if (_epoch != epoch) return;
+    if (_gate.isStale(epoch)) return;
     await getEngine().seek(durationFromSeconds(startMs / 1000.0));
-    if (_epoch != epoch) return;
+    if (_gate.isStale(epoch)) return;
     await getEngine().play();
   }
 }

--- a/test/features/player/application/single_flight_gate_test.dart
+++ b/test/features/player/application/single_flight_gate_test.dart
@@ -1,0 +1,108 @@
+/// Unit tests for the shared generation-guard / single-flight primitive.
+library;
+
+import 'dart:async';
+
+import 'package:enjoy_player/features/player/application/single_flight_gate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SingleFlightGate generation', () {
+    test('isStale is false for a fresh capture and true after a bump', () {
+      final gate = SingleFlightGate();
+      final gen = gate.generation;
+
+      expect(gate.isStale(gen), isFalse);
+      gate.bump();
+      expect(gate.isStale(gen), isTrue);
+      expect(gate.generation, gen + 1);
+    });
+
+    test('bump returns the new generation', () {
+      final gate = SingleFlightGate();
+      expect(gate.bump(), gate.generation);
+    });
+
+    test(
+      'cancel invalidates captured generations and drops the slot',
+      () async {
+        final gate = SingleFlightGate();
+        final gen = gate.generation;
+        final wedged = Completer<void>();
+        final done = gate.run(wedged.future);
+
+        expect(gate.inFlight, isTrue);
+        gate.cancel();
+
+        expect(gate.isStale(gen), isTrue);
+        expect(gate.inFlight, isFalse);
+
+        // The abandoned op settles late; its release must not restore it.
+        wedged.complete();
+        await done;
+        expect(gate.inFlight, isFalse);
+      },
+    );
+  });
+
+  group('SingleFlightGate slot', () {
+    test(
+      'run claims the slot synchronously and clears it on completion',
+      () async {
+        final gate = SingleFlightGate();
+        final op = Completer<void>();
+        final done = gate.run(op.future);
+
+        expect(gate.inFlight, isTrue);
+        expect(gate.pending, same(op.future));
+
+        op.complete();
+        await done;
+        expect(gate.inFlight, isFalse);
+        expect(gate.pending, isNull);
+      },
+    );
+
+    test('run rethrows the op error and still clears the slot', () async {
+      final gate = SingleFlightGate();
+      final op = Completer<void>();
+
+      final done = gate.run(op.future);
+      op.completeError(StateError('seek wedged'));
+
+      await expectLater(done, throwsStateError);
+      expect(gate.inFlight, isFalse);
+    });
+
+    test('a draining op cannot reclaim a slot it no longer owns', () async {
+      final gate = SingleFlightGate();
+      final wedged = Completer<void>();
+      final done = gate.run(wedged.future);
+
+      // Bounded-wait pattern: the caller gave up and released the slot.
+      gate.release(wedged.future);
+      expect(gate.inFlight, isFalse);
+
+      final next = Completer<void>();
+      final nextDone = gate.run(next.future);
+      expect(gate.pending, same(next.future));
+
+      // The wedged op finally settles; its release must be a no-op.
+      wedged.complete();
+      await done;
+      expect(gate.pending, same(next.future));
+
+      next.complete();
+      await nextDone;
+      expect(gate.inFlight, isFalse);
+    });
+
+    test('release is a no-op for a future that never owned the slot', () {
+      final gate = SingleFlightGate();
+      final held = Completer<void>().future;
+
+      gate.release(held);
+      expect(gate.inFlight, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What / why

Two refactors closing #666, no behavior change. All the bug-fix choreography these sites accumulated (#673 echo entry-epoch + timeout, #674 completion-loop replay guard, #675 warm idle gate + `_openInFlight`) is preserved exactly — every previously-green test passes with no edits.

### Commit 1 — `SingleFlightGate`

Four sites hand-rolled the same trio: a generation counter bumped on every event that invalidates the current stint, a value captured at entry, and a staleness check after each `await` (two of them plus an identity-guarded in-flight slot). New `lib/features/player/application/single_flight_gate.dart` extracts the mechanics; policy stays at the call sites.

```dart
class SingleFlightGate {
  int get generation;              // capture into a local before the first await
  bool isStale(int generation);    // re-check after every await
  bool get inFlight;               // is the slot claimed?
  Future<void>? get pending;       // bounded-wait on a possibly wedged op
  int bump();                      // invalidate captured generations, keep the slot
  void cancel();                   // bump + drop the slot
  Future<void> run(Future<void> op);   // claim synchronously, await, rethrow
  void release(Future<void> op);       // identity-guarded drop
}
```

`run` claims the slot synchronously (the race-free "is something in flight?" check the enforcers relied on) and clears it only if the completing op still owns it, so a slot dropped by `cancel`/`release` cannot be clobbered by a draining op's late `finally`.

**Migrated:** `EchoEnforcer` (`_epoch`/`_inFlight` — incl. the #673 entry-epoch capture and the bounded wait + identity-guarded release on timeout), `WordLoopEnforcer` (same shape), `PlayerController._openGeneration` (the gate backs `openGeneration` / `isOpenStale`; the `PlayerOpenHost` interface is untouched).

**Stayed local, on purpose:**
- `CompletionLoop` — its await is *cancelable* (`bump` completes a `Completer` the pending `completed` await races, because the completion stream may never fire again after a seek) and its "loop is running" marker is keyed by generation, not op identity, so a mid-drain loop cannot block `arm()` for the new stint. Forcing that into `run`'s identity-guarded slot would have changed #674's semantics. Its doc comment now points at the gate and says why it diverges.
- `PlayerController._openInFlight` — a latch keyed by *generation* (cleared in `finally` only while the open is still current, and cleared unconditionally by `clear()` with no future completing), which is not the identity-guarded one-op slot the gate models. Documented in place.

### Commit 2 — `EngineSwap`

`warmYoutubeSurface`, `ensureEngineForPlayableSource` and `replaceWedgedLocalEngine` each hand-rolled "install the new engine, bump the rev, tear down the old one". Chose the thin unification the issue allowed: a shared **mechanics** class in `player_engine_binding.dart`, called by all three, with policy left at the call sites.

```dart
class EngineSwap {
  PlayerEngine? install(PlayerEngine next);                  // set + bumpRev, returns the replaced engine
  void bumpRev();                                            // surface-host stage re-key (ADR-0057)
  Future<void> awaitPriorSurfaceSettled(PlayerEngine prev);  // bounded detach wait + settle delay
  void discardWithoutAwaiting(PlayerEngine prev);            // fire-and-forget old dispose
}
```

Invariants from the merged fixes are untouched:
- **warm** keeps its idle gate (no-op when a session is live, an open is in flight, or the engine is disposed) and still never disposes a live/parked MediaKit engine — and because dispose lives in a method warm never calls, that invariant now holds by construction rather than by an assertion in the call site.
- **open path** keeps its full choreography: generation check between every await, `Duration.zero` so the host drops the old stage first, detach wait + settle delay before `prepareNativeBackend`, fire-and-forget old dispose, double rev bump.
- `replaceWedgedLocalEngine` reuses install + discard (prepare-before-install, unawaited old dispose).

Signatures of `ensureEngineForPlayableSource` / `replaceWedgedLocalEngine` are unchanged.

## Test plan

- [x] `flutter analyze` — clean (same 5 pre-existing infos on `main`, none in touched files)
- [x] `dart format` — clean
- [x] `flutter test test/features/player` — **697 passed** (690 before, +7 new helper tests), no existing test edited
- [x] `flutter test` (whole repo) — 5901 passed, 2 skipped
- [x] New `test/features/player/application/single_flight_gate_test.dart` covers the helper only: capture/staleness, `bump`/`cancel`, synchronous slot claim, rethrow-and-clear, and the "a draining op cannot reclaim a released slot" invariant the echo clamp-wait depends on

Fixes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)
