### PR TITLE
cleanup(player): consolidate duplicated widgets, constants, and reset blocks

### DIFF
--- a/lib/features/craft/application/craft_preferences_provider.g.dart
+++ b/lib/features/craft/application/craft_preferences_provider.g.dart
@@ -42,7 +42,7 @@ final class CraftPreferencesCtrlProvider
 }
 
 String _$craftPreferencesCtrlHash() =>
-    r'dc6882f7fb7ebfcccdcd00096342ebeee237adae';
+    r'032a9442bd80c20b710aee6e058ce30b106444c3';
 
 abstract class _$CraftPreferencesCtrl extends $Notifier<CraftPreferences> {
   CraftPreferences build();

--- a/lib/features/discover/presentation/discover_feed_tile.dart
+++ b/lib/features/discover/presentation/discover_feed_tile.dart
@@ -121,7 +121,7 @@ class _DiscoverFeedTileState extends ConsumerState<DiscoverFeedTile> {
       provider: 'youtube',
       vid: widget.entry.videoId,
     );
-    warmYoutubeSurfaceForVideoId(ref);
+    warmYoutubeSurfaceIfNeeded(ref, provider: 'youtube');
     openPlayerRoute(context, mediaId);
   }
 

--- a/lib/features/hotkeys/presentation/app_hotkeys_keyboard_listener.dart
+++ b/lib/features/hotkeys/presentation/app_hotkeys_keyboard_listener.dart
@@ -247,23 +247,23 @@ class _AppHotkeysKeyboardListenerState
       }
 
       if (_matches(event, ctrl, 'player.prevLine')) {
-        unawaited(ref.read(playerInteractionsProvider.notifier).prevLine());
+        unawaited(ref.read(playerInteractionsProvider).prevLine());
         return true;
       }
       if (_matches(event, ctrl, 'player.nextLine')) {
-        unawaited(ref.read(playerInteractionsProvider.notifier).nextLine());
+        unawaited(ref.read(playerInteractionsProvider).nextLine());
         return true;
       }
       if (_matches(event, ctrl, 'player.replayLine')) {
-        unawaited(ref.read(playerInteractionsProvider.notifier).replayLine());
+        unawaited(ref.read(playerInteractionsProvider).replayLine());
         return true;
       }
       if (_matches(event, ctrl, 'player.toggleEchoMode')) {
-        unawaited(ref.read(playerInteractionsProvider.notifier).toggleEcho());
+        unawaited(ref.read(playerInteractionsProvider).toggleEcho());
         return true;
       }
       if (_matches(event, ctrl, 'player.toggleBlurPractice')) {
-        unawaited(ref.read(playerInteractionsProvider.notifier).toggleBlur());
+        unawaited(ref.read(playerInteractionsProvider).toggleBlur());
         return true;
       }
 
@@ -289,27 +289,19 @@ class _AppHotkeysKeyboardListenerState
       }
 
       if (_matches(event, ctrl, 'player.expandEchoBackward')) {
-        unawaited(
-          ref.read(playerInteractionsProvider.notifier).expandEchoBackward(),
-        );
+        unawaited(ref.read(playerInteractionsProvider).expandEchoBackward());
         return true;
       }
       if (_matches(event, ctrl, 'player.expandEchoForward')) {
-        unawaited(
-          ref.read(playerInteractionsProvider.notifier).expandEchoForward(),
-        );
+        unawaited(ref.read(playerInteractionsProvider).expandEchoForward());
         return true;
       }
       if (_matches(event, ctrl, 'player.shrinkEchoBackward')) {
-        unawaited(
-          ref.read(playerInteractionsProvider.notifier).shrinkEchoBackward(),
-        );
+        unawaited(ref.read(playerInteractionsProvider).shrinkEchoBackward());
         return true;
       }
       if (_matches(event, ctrl, 'player.shrinkEchoForward')) {
-        unawaited(
-          ref.read(playerInteractionsProvider.notifier).shrinkEchoForward(),
-        );
+        unawaited(ref.read(playerInteractionsProvider).shrinkEchoForward());
         return true;
       }
     }

--- a/lib/features/player/application/echo_mode_provider.g.dart
+++ b/lib/features/player/application/echo_mode_provider.g.dart
@@ -40,7 +40,7 @@ final class EchoModeProvider extends $NotifierProvider<EchoMode, EchoState> {
   }
 }
 
-String _$echoModeHash() => r'ec062e1ba5b5e71353ea1590a01804473a36435c';
+String _$echoModeHash() => r'fe1d427a5c3fcb8bd325c13e01bbccbc058a56ea';
 
 abstract class _$EchoMode extends $Notifier<EchoState> {
   EchoState build();

--- a/lib/features/player/application/engines/youtube/youtube_session.dart
+++ b/lib/features/player/application/engines/youtube/youtube_session.dart
@@ -229,13 +229,17 @@ class YoutubeSession {
   /// directly instead of reloading the watch page (ADR-0044).
   void resetCompletionFlag() => _playbackCompleted = false;
 
-  void resetForOpen(String newVideoId) {
+  /// Latches and one-shot bookkeeping that open and clear must both clear, so
+  /// the two paths cannot drift apart (issue #668).
+  ///
+  /// Deliberately open-only stays out: [_loggedFirstPlaying],
+  /// [_firstBufferingOffReceived] and the document bump are open-specific, and
+  /// [_mountRequested] is clear-specific. Emits are left to the callers — open
+  /// and clear transition buffering in opposite directions.
+  void _resetTransportLatches({required String videoId}) {
     _cancelHint();
     _playBudgetEpisodeAt = null;
     _tapToPlayHintActive = false;
-    _loggedFirstPlaying = false;
-    resetWatchPageExpectations(firstPlaying: false);
-    _firstBufferingOffReceived = false;
     _explicitPlayAttempted = false;
     _userPlayInFlight = false;
     _lastAutoPlayRetryAt = null;
@@ -243,11 +247,18 @@ class YoutubeSession {
     _lastPlayingFromAutoRetry = false;
     _pendingAutoRetryAttribution = false;
     clearVolumeRestorePending();
-    noteWatchDocumentLoaded();
     _volumeRestoredDocGen = -1;
     _lastPlayingAt = null;
-    _videoId = newVideoId;
+    _videoId = videoId;
     _playbackCompleted = false;
+    resetWatchPageExpectations(firstPlaying: false);
+  }
+
+  void resetForOpen(String newVideoId) {
+    _resetTransportLatches(videoId: newVideoId);
+    _loggedFirstPlaying = false;
+    _firstBufferingOffReceived = false;
+    noteWatchDocumentLoaded();
     emitBuffering(true);
     emitPlaying(false);
     emitPosition(Duration.zero);
@@ -255,22 +266,8 @@ class YoutubeSession {
   }
 
   void resetForClear({bool keepMounted = false}) {
-    _cancelHint();
-    _playBudgetEpisodeAt = null;
-    _tapToPlayHintActive = false;
-    _explicitPlayAttempted = false;
-    _userPlayInFlight = false;
-    _lastAutoPlayRetryAt = null;
-    _autoRetriesIssued = 0;
-    _lastPlayingFromAutoRetry = false;
-    _pendingAutoRetryAttribution = false;
-    clearVolumeRestorePending();
-    _volumeRestoredDocGen = -1;
-    _lastPlayingAt = null;
-    _videoId = '';
+    _resetTransportLatches(videoId: '');
     _mountRequested = keepMounted;
-    _playbackCompleted = false;
-    resetWatchPageExpectations(firstPlaying: false);
     emitPlaying(false);
     emitBuffering(false);
     emitPosition(Duration.zero);

--- a/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_navigation.dart
@@ -47,7 +47,9 @@ class YoutubeWebViewNavigation {
     final controller = webController();
     if (controller == null || session.videoId.isEmpty) return;
     final videoId = session.videoId;
-    final navGen = bumpNavGeneration();
+    // Bumped so a verify scheduled from this load cannot judge a superseding
+    // navigation current.
+    bumpNavGeneration();
     try {
       await YoutubeWebViewBridge.loadWatchPage(controller, videoId);
     } on MissingPluginException catch (e, st) {
@@ -55,9 +57,7 @@ class YoutubeWebViewNavigation {
         onStaleWebView();
       }
       _logNav.fine('Ignoring loadUrl on stale YouTube WebView', e, st);
-      return;
     }
-    if (currentNavGeneration() != navGen || session.videoId != videoId) return;
   }
 
   Future<void> ensureWatchPageLoadedAfterDelay({

--- a/lib/features/player/application/playback_session_persister.dart
+++ b/lib/features/player/application/playback_session_persister.dart
@@ -13,19 +13,11 @@ import '../../transcript/application/transcript_blur_mode_provider.dart';
 import '../domain/echo_window.dart';
 import '../domain/playback_session.dart';
 import 'echo_mode_provider.dart';
+// The debounce / max-age constants live in [position_buckets] next to the
+// emit bucket they must stay coherent with (issue #668).
+import 'position_buckets.dart';
 
 final _persisterLog = logNamed('PlaybackSessionPersister');
-
-/// Debounce window for coalescing rapid position updates into one DB write.
-const int kPlaybackSessionDebounceMs = 450;
-
-/// Upper bound on how long a position update can stay unwritten, regardless of
-/// debounce. The position tracker emits on a 400 ms grid, so at 1× the 450 ms
-/// debounce would otherwise be re-armed forever and never fire during
-/// continuous playback — and at 2× the emit cadence (200 ms) is even faster.
-/// Forcing a flush once pending data is older than this guarantees a crash
-/// never loses more than ~2 s of progress (issue #280, P9).
-const int kMaxPendingPositionAgeMs = 2000;
 
 class PlaybackSessionPersister {
   PlaybackSessionPersister(this._ref);

--- a/lib/features/player/application/player_controller.dart
+++ b/lib/features/player/application/player_controller.dart
@@ -345,7 +345,7 @@ class PlayerController extends _$PlayerController implements PlayerOpenHost {
     _completionLoop.bump();
   }
 
-  /// Called by [PlayerMetadataNotifier] after lazy title/thumbnail refresh.
+  /// Called by [PlayerMetadataService] after lazy title/thumbnail refresh.
   void applySessionPatch(PlaybackSession patched) {
     if (state?.mediaId != patched.mediaId) return;
     state = patched;

--- a/lib/features/player/application/player_controller.g.dart
+++ b/lib/features/player/application/player_controller.g.dart
@@ -62,7 +62,7 @@ final class PlayerControllerProvider
   }
 }
 
-String _$playerControllerHash() => r'e43a1b6fd3beb418d05c7e3b12ed2c42d513c0fd';
+String _$playerControllerHash() => r'8117ab2f35045b90b8cee1852f80664a709e81b1';
 
 /// Deterministic end-of-media completion loop (ADR-0044).
 ///

--- a/lib/features/player/application/player_interactions.dart
+++ b/lib/features/player/application/player_interactions.dart
@@ -15,6 +15,14 @@ import 'player_controller.dart';
 
 part 'player_interactions.g.dart';
 
+/// Builds the line-control service.
+///
+/// A state-less service (issue #668): [PlayerInteractions] holds a lines cache
+/// but exposes no provider state, so it is handed out by a plain keepAlive
+/// [Provider] rather than a `build() => 0` notifier wearing dummy state.
+@Riverpod(keepAlive: true)
+PlayerInteractions playerInteractions(Ref ref) => PlayerInteractions(ref);
+
 int indexOfActiveLine(List<TranscriptLine> lines, double t) {
   for (var i = 0; i < lines.length; i++) {
     final line = lines[i];
@@ -60,10 +68,15 @@ int prevLineNavigationIndex({
   return idx > 0 ? idx - 1 : 0;
 }
 
-@Riverpod(keepAlive: true)
-class PlayerInteractions extends _$PlayerInteractions {
-  @override
-  int build() => 0;
+/// Line-level controls service: prev / next / replay / echo toggle (maps web
+/// `usePlayerControls`).
+///
+/// Holds no provider state — only a memoized decode of the active transcript
+/// row, invalidated when that row changes.
+class PlayerInteractions {
+  PlayerInteractions(this.ref);
+
+  final Ref ref;
 
   /// Identity of the transcript row the line cache was decoded from.
   ///

--- a/lib/features/player/application/player_interactions.g.dart
+++ b/lib/features/player/application/player_interactions.g.dart
@@ -8,12 +8,34 @@ part of 'player_interactions.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Builds the line-control service.
+///
+/// A state-less service (issue #668): [PlayerInteractions] holds a lines cache
+/// but exposes no provider state, so it is handed out by a plain keepAlive
+/// [Provider] rather than a `build() => 0` notifier wearing dummy state.
 
-@ProviderFor(PlayerInteractions)
+@ProviderFor(playerInteractions)
 final playerInteractionsProvider = PlayerInteractionsProvider._();
 
+/// Builds the line-control service.
+///
+/// A state-less service (issue #668): [PlayerInteractions] holds a lines cache
+/// but exposes no provider state, so it is handed out by a plain keepAlive
+/// [Provider] rather than a `build() => 0` notifier wearing dummy state.
+
 final class PlayerInteractionsProvider
-    extends $NotifierProvider<PlayerInteractions, int> {
+    extends
+        $FunctionalProvider<
+          PlayerInteractions,
+          PlayerInteractions,
+          PlayerInteractions
+        >
+    with $Provider<PlayerInteractions> {
+  /// Builds the line-control service.
+  ///
+  /// A state-less service (issue #668): [PlayerInteractions] holds a lines cache
+  /// but exposes no provider state, so it is handed out by a plain keepAlive
+  /// [Provider] rather than a `build() => 0` notifier wearing dummy state.
   PlayerInteractionsProvider._()
     : super(
         from: null,
@@ -30,34 +52,23 @@ final class PlayerInteractionsProvider
 
   @$internal
   @override
-  PlayerInteractions create() => PlayerInteractions();
+  $ProviderElement<PlayerInteractions> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  PlayerInteractions create(Ref ref) {
+    return playerInteractions(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(int value) {
+  Override overrideWithValue(PlayerInteractions value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<int>(value),
+      providerOverride: $SyncValueProvider<PlayerInteractions>(value),
     );
   }
 }
 
 String _$playerInteractionsHash() =>
-    r'4d1f012927bdf3d38c07671e4b6926ebc531fa83';
-
-abstract class _$PlayerInteractions extends $Notifier<int> {
-  int build();
-  @$mustCallSuper
-  @override
-  WhenComplete runBuild() {
-    final ref = this.ref as $Ref<int, int>;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<int, int>,
-              int,
-              Object?,
-              Object?
-            >;
-    return element.handleCreate(ref, build);
-  }
-}
+    r'0bea819a31968a45e81767b30aa1c8fec3446d98';

--- a/lib/features/player/application/player_metadata_notifier.dart
+++ b/lib/features/player/application/player_metadata_notifier.dart
@@ -7,10 +7,18 @@ import 'package:enjoy_player/features/player/application/player_controller.dart'
 
 part 'player_metadata_notifier.g.dart';
 
+/// Applies the lazy YouTube metadata patch to the open session.
+///
+/// A state-less service (issue #668): it holds no state of its own, so it is
+/// exposed by a plain keepAlive [Provider] rather than a `void build()`
+/// notifier wearing dummy state.
 @Riverpod(keepAlive: true)
-class PlayerMetadataNotifier extends _$PlayerMetadataNotifier {
-  @override
-  void build() {}
+PlayerMetadataService playerMetadata(Ref ref) => PlayerMetadataService(ref);
+
+class PlayerMetadataService {
+  PlayerMetadataService(this.ref);
+
+  final Ref ref;
 
   /// Updates session chrome when [openGeneration] and [mediaId] still match.
   void patchIfCurrent({

--- a/lib/features/player/application/player_metadata_notifier.g.dart
+++ b/lib/features/player/application/player_metadata_notifier.g.dart
@@ -8,13 +8,35 @@ part of 'player_metadata_notifier.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Applies the lazy YouTube metadata patch to the open session.
+///
+/// A state-less service (issue #668): it holds no state of its own, so it is
+/// exposed by a plain keepAlive [Provider] rather than a `void build()`
+/// notifier wearing dummy state.
 
-@ProviderFor(PlayerMetadataNotifier)
-final playerMetadataProvider = PlayerMetadataNotifierProvider._();
+@ProviderFor(playerMetadata)
+final playerMetadataProvider = PlayerMetadataProvider._();
 
-final class PlayerMetadataNotifierProvider
-    extends $NotifierProvider<PlayerMetadataNotifier, void> {
-  PlayerMetadataNotifierProvider._()
+/// Applies the lazy YouTube metadata patch to the open session.
+///
+/// A state-less service (issue #668): it holds no state of its own, so it is
+/// exposed by a plain keepAlive [Provider] rather than a `void build()`
+/// notifier wearing dummy state.
+
+final class PlayerMetadataProvider
+    extends
+        $FunctionalProvider<
+          PlayerMetadataService,
+          PlayerMetadataService,
+          PlayerMetadataService
+        >
+    with $Provider<PlayerMetadataService> {
+  /// Applies the lazy YouTube metadata patch to the open session.
+  ///
+  /// A state-less service (issue #668): it holds no state of its own, so it is
+  /// exposed by a plain keepAlive [Provider] rather than a `void build()`
+  /// notifier wearing dummy state.
+  PlayerMetadataProvider._()
     : super(
         from: null,
         argument: null,
@@ -26,38 +48,26 @@ final class PlayerMetadataNotifierProvider
       );
 
   @override
-  String debugGetCreateSourceHash() => _$playerMetadataNotifierHash();
+  String debugGetCreateSourceHash() => _$playerMetadataHash();
 
   @$internal
   @override
-  PlayerMetadataNotifier create() => PlayerMetadataNotifier();
+  $ProviderElement<PlayerMetadataService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  PlayerMetadataService create(Ref ref) {
+    return playerMetadata(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(void value) {
+  Override overrideWithValue(PlayerMetadataService value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<void>(value),
+      providerOverride: $SyncValueProvider<PlayerMetadataService>(value),
     );
   }
 }
 
-String _$playerMetadataNotifierHash() =>
-    r'a803fb6b0d3daf39469ec97860ec838e5dee1e8a';
-
-abstract class _$PlayerMetadataNotifier extends $Notifier<void> {
-  void build();
-  @$mustCallSuper
-  @override
-  WhenComplete runBuild() {
-    final ref = this.ref as $Ref<void, void>;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<void, void>,
-              void,
-              Object?,
-              Object?
-            >;
-    return element.handleCreate(ref, build);
-  }
-}
+String _$playerMetadataHash() => r'dd2d0e814bb0a818f8087d6a2b854780f28a78f3';

--- a/lib/features/player/application/player_open_side_effects.dart
+++ b/lib/features/player/application/player_open_side_effects.dart
@@ -161,7 +161,7 @@ Future<void> _runYoutubeMetadataRefresh(
     if (patch == null) return;
 
     ref
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: mediaId,
           openGeneration: openGeneration,

--- a/lib/features/player/application/player_position_tracker.dart
+++ b/lib/features/player/application/player_position_tracker.dart
@@ -69,12 +69,21 @@ class PlayerPositionTracker {
   StreamSubscription<Duration>? _durationSub;
   int? _lastPositionEmitBucket;
 
-  Future<void> cancel() async {
-    await _positionSub?.cancel();
-    await _durationSub?.cancel();
+  /// Detaches and cancels the live engine subscriptions.
+  ///
+  /// Cancels without awaiting and nulls the fields synchronously, so
+  /// [subscribe] can drop a stale pair before installing a fresh one without
+  /// the async cancel re-nulling the new fields.
+  void _detachSubscriptions() {
+    unawaited(_positionSub?.cancel());
+    unawaited(_durationSub?.cancel());
     _positionSub = null;
     _durationSub = null;
     _lastPositionEmitBucket = null;
+  }
+
+  Future<void> cancel() async {
+    _detachSubscriptions();
     // Release the enforcement slot and neutralize any in-flight op so a
     // pending pause-and-rewind can't seek a stale engine or block the next
     // media's enforcement.
@@ -97,6 +106,10 @@ class PlayerPositionTracker {
     required VideoRow? video,
     required AudioRow? audio,
   }) {
+    // Defensive: since #674 only the open coordinator calls this, and only
+    // after [cancel] — but overwriting a live subscription would leak the
+    // previous engine's stream, so detach instead of trusting the convention.
+    _detachSubscriptions();
     _subscribedGeneration = openGeneration;
     _subscribedMediaId = mediaId;
     _lastPositionEmitBucket = null;

--- a/lib/features/player/application/player_preferences_provider.dart
+++ b/lib/features/player/application/player_preferences_provider.dart
@@ -14,6 +14,16 @@ part 'player_preferences_provider.g.dart';
 
 const playerPreferencesStorageKey = 'player_preferences_v1';
 
+/// Field-wise comparison for [PlayerPreferences].
+///
+/// The model deliberately leaves `==` as identity so the notifier keeps
+/// notifying on every setter; hydration only needs value comparison.
+bool _hasSameValues(PlayerPreferences a, PlayerPreferences b) =>
+    a.volume == b.volume &&
+    a.playbackRate == b.playbackRate &&
+    a.repeatMode == b.repeatMode &&
+    a.videoTranscriptSplitWidthPx == b.videoTranscriptSplitWidthPx;
+
 @Riverpod(keepAlive: true)
 class PlayerPreferencesCtrl extends _$PlayerPreferencesCtrl {
   /// Last audible level used when restoring from mute (not persisted).
@@ -26,19 +36,26 @@ class PlayerPreferencesCtrl extends _$PlayerPreferencesCtrl {
   }
 
   Future<void> _hydrate() async {
-    final db = ref.read(appDatabaseProvider);
-    final raw = await db.settingsDao.getValue(playerPreferencesStorageKey);
-    if (raw == null) return;
+    // The read is inside the try on purpose: a Drift throw here would escape
+    // [build]'s microtask as an unhandled async error and kill the provider.
     try {
+      final db = ref.read(appDatabaseProvider);
+      final raw = await db.settingsDao.getValue(playerPreferencesStorageKey);
+      if (raw == null) return;
       final map = jsonDecode(raw) as Map<String, dynamic>;
       final repeatIdx = (map['repeat'] as int?) ?? 0;
-      state = PlayerPreferences(
+      final hydrated = PlayerPreferences(
         volume: ((map['volume'] as num?)?.toDouble() ?? 1).clamp(0, 1),
         playbackRate: ((map['rate'] as num?)?.toDouble() ?? 1).clamp(0.25, 2),
         repeatMode:
             RepeatMode.values[repeatIdx.clamp(0, RepeatMode.values.length - 1)],
         videoTranscriptSplitWidthPx: (map['splitPx'] as num?)?.toDouble(),
       );
+      // Hydration is a microtask behind [build], so the learner may already
+      // have changed volume / rate in this session. Only apply the stored
+      // values when nothing has moved off the defaults (issue #668).
+      if (!_hasSameValues(state, PlayerPreferences.defaults)) return;
+      state = hydrated;
       final v = state.volume;
       _lastNonZeroVolume = v > 0.01 ? v : 1;
       await applyCurrentToEngine();

--- a/lib/features/player/application/player_preferences_provider.g.dart
+++ b/lib/features/player/application/player_preferences_provider.g.dart
@@ -42,7 +42,7 @@ final class PlayerPreferencesCtrlProvider
 }
 
 String _$playerPreferencesCtrlHash() =>
-    r'cd0ae1fe005341a834dfcabcb092e552f6242f5a';
+    r'7644afdc2c63aa81c6cdc2f85fc0d10ce9caf12f';
 
 abstract class _$PlayerPreferencesCtrl extends $Notifier<PlayerPreferences> {
   PlayerPreferences build();

--- a/lib/features/player/application/position_buckets.dart
+++ b/lib/features/player/application/position_buckets.dart
@@ -15,6 +15,21 @@ library;
 /// to this bucket.
 const int kPositionBucketSessionEmitMs = 400;
 
+/// Debounce window for coalescing rapid position updates into one DB write.
+///
+/// Coherent with [kPositionBucketSessionEmitMs]: see
+/// [kMaxPendingPositionAgeMs] for why the two must move together.
+const int kPlaybackSessionDebounceMs = 450;
+
+/// Upper bound on how long a position update can stay unwritten, regardless of
+/// debounce. The position tracker emits on the [kPositionBucketSessionEmitMs]
+/// (400 ms) grid, so at 1x the 450 ms [kPlaybackSessionDebounceMs] would
+/// otherwise be re-armed forever and never fire during continuous playback —
+/// and at 2x the emit cadence (200 ms) is even faster. Forcing a flush once
+/// pending data is older than this guarantees a crash never loses more than
+/// ~2 s of progress (issue #280, P9).
+const int kMaxPendingPositionAgeMs = 2000;
+
 const int kPositionBucketDisplayMs = 400;
 
 const int kPositionBucketScrubberMs = 50;

--- a/lib/features/player/application/youtube_warm.dart
+++ b/lib/features/player/application/youtube_warm.dart
@@ -5,11 +5,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/features/player/application/player_controller.dart';
 
+/// Warms the YouTube surface when [provider] names YouTube.
+///
+/// Previously there was a second `warmYoutubeSurfaceForVideoId` helper for
+/// callers that already knew the target was YouTube; it ignored the videoId
+/// its name advertised and did exactly this, so it was folded in (issue #668).
+/// Call it with `provider: 'youtube'` in that case.
 void warmYoutubeSurfaceIfNeeded(WidgetRef ref, {required String? provider}) {
   if (provider?.toLowerCase() != 'youtube') return;
-  ref.read(playerControllerProvider.notifier).warmYoutubeSurface();
-}
-
-void warmYoutubeSurfaceForVideoId(WidgetRef ref) {
   ref.read(playerControllerProvider.notifier).warmYoutubeSurface();
 }

--- a/lib/features/player/presentation/expanded_player_widgets.dart
+++ b/lib/features/player/presentation/expanded_player_widgets.dart
@@ -1,15 +1,12 @@
 /// Scaffold bodies for [ExpandedPlayerScreen] (loading, error, main chrome).
 library;
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/theme/widgets/app_background.dart';
 import 'package:enjoy_player/core/theme/widgets/skeleton.dart';
 import 'package:enjoy_player/core/utils/local_thumbnail.dart';
-import 'package:enjoy_player/features/player/application/player_collapse.dart';
 import 'package:enjoy_player/features/player/application/player_engine_provider.dart';
 import 'package:enjoy_player/features/player/application/player_preferences_provider.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
@@ -20,8 +17,8 @@ import 'package:enjoy_player/l10n/app_localizations.dart';
 
 import 'package:enjoy_player/features/player/application/player_surface_registry.dart';
 import 'package:enjoy_player/features/player/application/youtube_open_preview_provider.dart';
-import 'package:enjoy_player/features/player/presentation/widgets/player_frosted_back_button.dart';
-import 'package:enjoy_player/features/player/presentation/widgets/player_surface_target.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_collapse_control.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_loading_stage.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/youtube_loading_video_stage.dart';
 
 import 'package:enjoy_player/features/transcript/presentation/transcript_panel.dart';
@@ -62,8 +59,10 @@ class ExpandedPlayerLoadingBody extends ConsumerWidget {
               alignment: Alignment.topCenter,
               child: YoutubeLoadingVideoStage(
                 mediaId: mediaId,
+                // Painted by the surface host inside the already-inset 16:9
+                // stage, so this one carries no SafeArea of its own.
                 overlayBuilder: (_) =>
-                    const _VideoCollapseOnlyOverlay(useSafeArea: false),
+                    const PlayerCollapseControl.loadingChrome(),
               ),
             )
           else if (isLocalVideo)
@@ -80,7 +79,9 @@ class ExpandedPlayerLoadingBody extends ConsumerWidget {
           if (!isYoutube)
             const Align(
               alignment: Alignment.topCenter,
-              child: _VideoCollapseOnlyOverlay(),
+              // Placed directly in the body stack, so it must clear the
+              // status bar itself.
+              child: PlayerCollapseControl.loadingChrome(useSafeArea: true),
             ),
         ],
       ),
@@ -92,9 +93,6 @@ class ExpandedPlayerLoadingBody extends ConsumerWidget {
 class _LocalLoadingVideoStage extends StatelessWidget {
   const _LocalLoadingVideoStage({this.thumbnailUrl});
 
-  static const double aspectWidth = 16;
-  static const double aspectHeight = 9;
-
   /// Local artwork for the media being opened, shown under the skeleton so
   /// the open window reads as "this video is loading" instead of a black
   /// flash.
@@ -103,30 +101,21 @@ class _LocalLoadingVideoStage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final thumb = localThumbnailFile(thumbnailUrl);
-    return SafeArea(
-      top: true,
-      bottom: false,
-      left: false,
-      right: false,
-      child: AspectRatio(
-        aspectRatio: aspectWidth / aspectHeight,
-        child: PlayerSurfaceTarget(
-          // Share the chrome viewport id so loading → player does not park
-          // (unmount) the media_kit Texture. A distinct id raced detach/attach
-          // and left ~1s of picture then a black stage until resize.
-          id: PlayerSurfaceIds.expandedPlayer,
-          overlayBuilder: (_) => const SizedBox.shrink(),
-          child: ColoredBox(
-            color: Colors.black,
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                if (thumb != null)
-                  Image.file(thumb, fit: BoxFit.cover, gaplessPlayback: true),
-                const Center(child: SkeletonAppBootstrap()),
-              ],
-            ),
-          ),
+    return PlayerLoadingStage(
+      // Share the chrome viewport id so loading → player does not park
+      // (unmount) the media_kit Texture. A distinct id raced detach/attach
+      // and left ~1s of picture then a black stage until resize.
+      surfaceId: PlayerSurfaceIds.expandedPlayer,
+      overlayBuilder: (_) => const SizedBox.shrink(),
+      child: ColoredBox(
+        color: Colors.black,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            if (thumb != null)
+              Image.file(thumb, fit: BoxFit.cover, gaplessPlayback: true),
+            const Center(child: SkeletonAppBootstrap()),
+          ],
         ),
       ),
     );
@@ -185,7 +174,7 @@ class ExpandedPlayerYoutubeUnavailableBody extends StatelessWidget {
           // loading body's collapse-only chrome.
           const Align(
             alignment: Alignment.topCenter,
-            child: _VideoCollapseOnlyOverlay(),
+            child: PlayerCollapseControl.loadingChrome(useSafeArea: true),
           ),
         ],
       ),
@@ -243,30 +232,5 @@ class ExpandedPlayerChromeBody extends ConsumerWidget {
         body: mediaBody,
       ),
     );
-  }
-}
-
-/// Collapse control only (loading / minimal chrome).
-class _VideoCollapseOnlyOverlay extends ConsumerWidget {
-  const _VideoCollapseOnlyOverlay({this.useSafeArea = true});
-
-  final bool useSafeArea;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final content = SizedBox(
-      height: kToolbarHeight,
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Padding(
-          padding: const EdgeInsets.only(left: 8),
-          child: PlayerFrostedBackButton(
-            onPressed: () => unawaited(collapseExpandedPlayer(ref, context)),
-          ),
-        ),
-      ),
-    );
-    if (!useSafeArea) return content;
-    return SafeArea(bottom: false, left: false, right: false, child: content);
   }
 }

--- a/lib/features/player/presentation/layouts/audio_player_layout.dart
+++ b/lib/features/player/presentation/layouts/audio_player_layout.dart
@@ -6,15 +6,12 @@
 /// and there is no reserved toolbar slot (ADR-0085 supersedes ADR-0077).
 library;
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/window/desktop_window.dart';
-import 'package:enjoy_player/features/player/application/player_collapse.dart';
-import 'package:enjoy_player/features/player/presentation/widgets/player_frosted_back_button.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_collapse_control.dart';
 
 class AudioPlayerLayout extends ConsumerWidget {
   const AudioPlayerLayout({required this.transcript, super.key});
@@ -56,15 +53,10 @@ class AudioPlayerLayout extends ConsumerWidget {
               ),
             ),
           ),
-          Align(
-            alignment: Alignment.topLeft,
-            child: Padding(
-              padding: EdgeInsets.only(left: t.space8, top: t.space8),
-              child: PlayerFrostedBackButton(
-                onPressed: () =>
-                    unawaited(collapseExpandedPlayer(ref, context)),
-              ),
-            ),
+          // Safe-area inset comes from the layout-level [SafeArea] above, so
+          // the control only carries its own on-stage edge inset.
+          PlayerCollapseControl(
+            inset: EdgeInsets.only(left: t.space8, top: t.space8),
           ),
         ],
       ),

--- a/lib/features/player/presentation/layouts/video_player_layout.dart
+++ b/lib/features/player/presentation/layouts/video_player_layout.dart
@@ -1,7 +1,6 @@
 /// Video surface + transcript side panel (desktop-friendly split).
 library;
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -10,13 +9,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:enjoy_player/core/interaction/haptics.dart';
 import 'package:enjoy_player/core/interaction/mouse_tracker_safe.dart';
 import 'package:enjoy_player/core/platform/player_content_layout.dart';
-import 'package:enjoy_player/features/player/application/player_collapse.dart';
 import 'package:enjoy_player/features/player/application/player_controller.dart';
 import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_state_providers.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'package:enjoy_player/features/player/application/player_surface_registry.dart';
-import 'package:enjoy_player/features/player/presentation/widgets/player_frosted_back_button.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_collapse_control.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/player_surface_target.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/youtube_login_video_frame_button.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/youtube_open_in_browser_button.dart';
@@ -239,22 +237,6 @@ class _VideoColumn extends StatelessWidget {
   }
 }
 
-/// Collapse control that stays visible while playing (same persistence as
-/// the YouTube account cluster at bottom-right).
-class _VideoBackButton extends ConsumerWidget {
-  const _VideoBackButton();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 8, top: 8),
-      child: PlayerFrostedBackButton(
-        onPressed: () => unawaited(collapseExpandedPlayer(ref, context)),
-      ),
-    );
-  }
-}
-
 /// Title + scrim, shown only while paused or buffering.
 class _VideoPausedTitleOverlay extends ConsumerWidget {
   const _VideoPausedTitleOverlay();
@@ -347,10 +329,7 @@ class _VideoStageWithChrome extends ConsumerWidget {
                 ),
               ),
             const _VideoPausedTitleOverlay(),
-            const Align(
-              alignment: Alignment.topLeft,
-              child: _VideoBackButton(),
-            ),
+            const PlayerCollapseControl(),
             if (isYoutube)
               const Positioned(
                 bottom: 12,

--- a/lib/features/player/presentation/widgets/global_transport_bar.dart
+++ b/lib/features/player/presentation/widgets/global_transport_bar.dart
@@ -340,29 +340,28 @@ class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
       tooltip: ttPrev,
       icon: const EnjoyChromeIcon(EnjoyChromeGlyph.skipBack),
       enabled: !isBuffering && hasTranscriptLines,
-      onTap: () => ref.read(playerInteractionsProvider.notifier).prevLine(),
+      onTap: () => ref.read(playerInteractionsProvider).prevLine(),
     );
 
     final nextButton = _LineNavButton(
       tooltip: ttNext,
       icon: const EnjoyChromeIcon(EnjoyChromeGlyph.skipForward),
       enabled: !isBuffering && hasTranscriptLines,
-      onTap: () => ref.read(playerInteractionsProvider.notifier).nextLine(),
+      onTap: () => ref.read(playerInteractionsProvider).nextLine(),
     );
 
     final replayButton = _LineNavButton(
       tooltip: ttReplay,
       icon: const EnjoyChromeIcon(EnjoyChromeGlyph.replay),
       enabled: !isBuffering && hasTranscriptLines,
-      onTap: () => ref.read(playerInteractionsProvider.notifier).replayLine(),
+      onTap: () => ref.read(playerInteractionsProvider).replayLine(),
     );
 
     final transcriptControls = <Widget>[prevButton, nextButton, replayButton];
 
     final primaryTransport = <Widget>[playRing, ...transcriptControls];
 
-    void echoToggle() =>
-        ref.read(playerInteractionsProvider.notifier).toggleEcho();
+    void echoToggle() => ref.read(playerInteractionsProvider).toggleEcho();
     final echoButton = OnboardingTarget(
       tipId: OnboardingTipId.playerEcho,
       onTargetAction: echo.active || hasTranscriptLines ? echoToggle : null,
@@ -411,7 +410,7 @@ class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
       onPressed: blurEnabled || hasTranscriptLines
           ? Haptics.wrapTap(
               context,
-              () => ref.read(playerInteractionsProvider.notifier).toggleBlur(),
+              () => ref.read(playerInteractionsProvider).toggleBlur(),
             )
           : null,
       icon: Icon(

--- a/lib/features/player/presentation/widgets/global_transport_bar.dart
+++ b/lib/features/player/presentation/widgets/global_transport_bar.dart
@@ -51,6 +51,13 @@ const double kNarrowSpeedSlotExtra = 12;
 const double kNarrowLayoutSlack = 8;
 const double kNarrowLineNavGap = 4;
 
+/// Height of the transport bar's control row (progress strip sits above it).
+///
+/// Sized to the widest always-on control — the [mobile-transport-line-nav]
+/// play ring — so the bar never reflows when a control is dropped on narrow
+/// layouts.
+const double kTransportControlRowHeight = 56;
+
 /// Which controls fit in the narrow single-row transport bar.
 ///
 /// Play/pause, echo, subtitle (cc), and speed are always-on (never subject to
@@ -485,7 +492,7 @@ class _GlobalTransportBarState extends ConsumerState<GlobalTransportBar> {
               t.space12,
             ),
             child: SizedBox(
-              height: 56,
+              height: kTransportControlRowHeight,
               width: double.infinity,
               child: AnimatedSwitcher(
                 duration: MediaQuery.disableAnimationsOf(context)

--- a/lib/features/player/presentation/widgets/player_collapse_control.dart
+++ b/lib/features/player/presentation/widgets/player_collapse_control.dart
@@ -1,0 +1,70 @@
+/// The player's always-visible collapse control (ADR-0085).
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:enjoy_player/features/player/application/player_collapse.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_frosted_back_button.dart';
+
+/// Frosted `.p-back` circle that pops the expanded player back to its origin
+/// route.
+///
+/// The three host layouts (video stage overlay, audio layout, loading-stage
+/// chrome) differ only in how the button is inset and whether a toolbar-sized
+/// slot / safe-area inset is reserved for it, so those knobs cover every call
+/// site — there is exactly one collapse control implementation.
+class PlayerCollapseControl extends ConsumerWidget {
+  const PlayerCollapseControl({
+    this.inset = const EdgeInsets.only(left: 8, top: 8),
+    this.reserveToolbarHeight = false,
+    this.useSafeArea = false,
+    super.key,
+  });
+
+  /// Loading / minimal-chrome shape: the control is the only element of a
+  /// `kToolbarHeight` title bar, so it is centered in that slot and insets
+  /// horizontally only ([reserveToolbarHeight] centering already accounts for
+  /// the vertical position).
+  const PlayerCollapseControl.loadingChrome({
+    this.useSafeArea = false,
+    super.key,
+  }) : inset = const EdgeInsets.only(left: 8),
+       reserveToolbarHeight = true;
+
+  /// Padding around the frosted button inside its alignment slot.
+  ///
+  /// Defaults to the on-stage inset (8 px from the top-left corner); hosts
+  /// that need to clear a status bar or a neighbouring inset pass their own.
+  final EdgeInsetsGeometry inset;
+
+  /// When true, reserves a `kToolbarHeight` slot and centers the button in it
+  /// (the loading / minimal-chrome shape, where the control is the only
+  /// element of a title bar). When false the button is pinned to the
+  /// top-left of the enclosing [Stack] — the on-stage shape.
+  final bool reserveToolbarHeight;
+
+  /// When true, wraps the control in a top-only [SafeArea] so it clears the
+  /// status bar on phones.
+  final bool useSafeArea;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    Widget content = Padding(
+      padding: inset,
+      child: PlayerFrostedBackButton(
+        onPressed: () => unawaited(collapseExpandedPlayer(ref, context)),
+      ),
+    );
+    content = reserveToolbarHeight
+        ? SizedBox(
+            height: kToolbarHeight,
+            child: Align(alignment: Alignment.centerLeft, child: content),
+          )
+        : Align(alignment: Alignment.topLeft, child: content);
+    if (!useSafeArea) return content;
+    return SafeArea(bottom: false, left: false, right: false, child: content);
+  }
+}

--- a/lib/features/player/presentation/widgets/player_loading_stage.dart
+++ b/lib/features/player/presentation/widgets/player_loading_stage.dart
@@ -1,0 +1,60 @@
+/// Shared 16:9 open-in-flight portal for the local and YouTube loading stages.
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:enjoy_player/features/player/application/player_surface_registry.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_surface_target.dart';
+
+/// 16:9 portal target shown while [openMedia] is in flight.
+///
+/// Both loading stages share this scaffolding — top-only safe area, a 16:9
+/// stage, and a [PlayerSurfaceTarget] claiming a chrome viewport so the
+/// loading → player hand-off never parks (unmounts) the native surface. Only
+/// the claimed id, the enabled gate, the overlay chrome, and the poster child
+/// differ, which is exactly what the parameters cover.
+class PlayerLoadingStage extends StatelessWidget {
+  const PlayerLoadingStage({
+    required this.surfaceId,
+    required this.child,
+    this.enabled = true,
+    this.overlayBuilder,
+    super.key,
+  });
+
+  static const double aspectWidth = 16;
+  static const double aspectHeight = 9;
+
+  /// Chrome viewport id the stage claims. Local/URL open reuses
+  /// [PlayerSurfaceIds.expandedPlayer] so media_kit's Texture is not parked
+  /// mid-open; YouTube claims [PlayerSurfaceIds.expandedPlayerLoading].
+  final String surfaceId;
+
+  /// When false, detaches the target so the host parks (or hides) the surface.
+  final bool enabled;
+
+  /// Chrome drawn above the native surface inside the host stack.
+  final PlayerSurfaceOverlayBuilder? overlayBuilder;
+
+  /// Poster / thumbnail content behind the portal surface.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: true,
+      bottom: false,
+      left: false,
+      right: false,
+      child: AspectRatio(
+        aspectRatio: aspectWidth / aspectHeight,
+        child: PlayerSurfaceTarget(
+          id: surfaceId,
+          enabled: enabled,
+          overlayBuilder: overlayBuilder,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/presentation/widgets/player_surface_host.dart
+++ b/lib/features/player/presentation/widgets/player_surface_host.dart
@@ -27,8 +27,18 @@ class PlayerSurfaceHost extends ConsumerWidget {
   /// When true, ignore any registry attachment and park off-screen.
   final bool forcePark;
 
+  /// Fallback park size when no target has ever reported geometry.
+  ///
+  /// YouTube treats a <360 px player as its mobile breakpoint and flushes ABR
+  /// at it, so a shrink to these dimensions is the play-then-pause stimulus —
+  /// they are only the last-resort park, never the steady-state one.
   static const double _parkWidth = 320;
   static const double _parkHeight = 180;
+
+  /// Extra horizontal clearance (in addition to the full surface width) when
+  /// translating a parked surface off-screen, so an anti-aliased edge or
+  /// drop shadow cannot bleed back into the viewport.
+  static const double _parkClearancePx = 64;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -56,6 +66,7 @@ class PlayerSurfaceHost extends ConsumerWidget {
       overlayParkSize: registry?.size,
       parkWidth: _parkWidth,
       parkHeight: _parkHeight,
+      parkClearancePx: _parkClearancePx,
     );
   }
 }
@@ -68,6 +79,7 @@ class _EngineSurface extends StatefulWidget {
     required this.overlayParkSize,
     required this.parkWidth,
     required this.parkHeight,
+    required this.parkClearancePx,
   });
 
   final PlayerEngine engine;
@@ -78,6 +90,9 @@ class _EngineSurface extends StatefulWidget {
   final Size? overlayParkSize;
   final double parkWidth;
   final double parkHeight;
+
+  /// Extra off-screen clearance — see [PlayerSurfaceHost._parkClearancePx].
+  final double parkClearancePx;
 
   @override
   State<_EngineSurface> createState() => _EngineSurfaceState();
@@ -143,7 +158,7 @@ class _EngineSurfaceState extends State<_EngineSurface> {
         Size(widget.parkWidth, widget.parkHeight);
     final offset = attachment != null
         ? _toLocal(attachment.offset)
-        : Offset(-size.width - 64, 0);
+        : Offset(-size.width - widget.parkClearancePx, 0);
 
     Widget stageFor(double w, double h) {
       if (w <= 0 || h <= 0) return const SizedBox.shrink();

--- a/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
+++ b/lib/features/player/presentation/widgets/transport/transport_progress_strip.dart
@@ -227,7 +227,7 @@ class _TransportProgressStripState
                     });
                     unawaited(
                       ref
-                          .read(playerInteractionsProvider.notifier)
+                          .read(playerInteractionsProvider)
                           .seekToProgressFraction(v),
                     );
                   },

--- a/lib/features/player/presentation/widgets/youtube_loading_video_stage.dart
+++ b/lib/features/player/presentation/widgets/youtube_loading_video_stage.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:enjoy_player/features/player/application/player_engine_provider.dart';
 import 'package:enjoy_player/features/player/application/player_surface_registry.dart';
 import 'package:enjoy_player/features/player/application/youtube_open_preview_provider.dart';
-import 'package:enjoy_player/features/player/presentation/widgets/player_surface_target.dart';
+import 'package:enjoy_player/features/player/presentation/widgets/player_loading_stage.dart';
 import 'package:enjoy_player/features/player/presentation/widgets/youtube_video_poster.dart';
 
 class YoutubeLoadingVideoStage extends ConsumerStatefulWidget {
@@ -19,9 +19,6 @@ class YoutubeLoadingVideoStage extends ConsumerStatefulWidget {
 
   final String mediaId;
   final PlayerSurfaceOverlayBuilder? overlayBuilder;
-
-  static const double aspectWidth = 16;
-  static const double aspectHeight = 9;
 
   @override
   ConsumerState<YoutubeLoadingVideoStage> createState() =>
@@ -70,31 +67,20 @@ class _YoutubeLoadingVideoStageState
     }
 
     // Claim the loading portal whenever a YouTube engine is active — same
-    // pattern as [_LocalLoadingVideoStage]. WebView visibility is gated by
+    // pattern as the local loading stage. WebView visibility is gated by
     // [YoutubePlayerEngine.shouldMountWebView] inside the surface host.
     final showSurface = isYoutube;
 
-    return SafeArea(
-      top: true,
-      bottom: false,
-      left: false,
-      right: false,
-      child: AspectRatio(
-        aspectRatio:
-            YoutubeLoadingVideoStage.aspectWidth /
-            YoutubeLoadingVideoStage.aspectHeight,
-        child: PlayerSurfaceTarget(
-          id: PlayerSurfaceIds.expandedPlayerLoading,
-          enabled: showSurface,
-          overlayBuilder: widget.overlayBuilder,
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              const ColoredBox(color: Colors.black),
-              YoutubeVideoPoster(primaryUrl: thumb, visible: true),
-            ],
-          ),
-        ),
+    return PlayerLoadingStage(
+      surfaceId: PlayerSurfaceIds.expandedPlayerLoading,
+      enabled: showSurface,
+      overlayBuilder: widget.overlayBuilder,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          const ColoredBox(color: Colors.black),
+          YoutubeVideoPoster(primaryUrl: thumb, visible: true),
+        ],
       ),
     );
   }

--- a/lib/features/transcript/presentation/transcript_display_settings_sheet.dart
+++ b/lib/features/transcript/presentation/transcript_display_settings_sheet.dart
@@ -60,7 +60,7 @@ class TranscriptDisplaySettingsSection extends ConsumerWidget {
         subtitle: l10n.transcriptBlurToggleTooltip,
         value: blurOn,
         onChanged: (_) {
-          unawaited(ref.read(playerInteractionsProvider.notifier).toggleBlur());
+          unawaited(ref.read(playerInteractionsProvider).toggleBlur());
         },
       ),
       SubtitleToggleTile(

--- a/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
+++ b/lib/features/transcript/presentation/transcript_echo_region_merged_card.dart
@@ -153,8 +153,7 @@ class EchoRegionMergedCard extends ConsumerWidget {
                     .retranslateLine(i),
               )
             : null,
-        onTap: () =>
-            ref.read(playerInteractionsProvider.notifier).seekToLine(line, i),
+        onTap: () => ref.read(playerInteractionsProvider).seekToLine(line, i),
       );
 
       lineWidgets.add(tile);

--- a/lib/features/transcript/presentation/transcript_line_tile.dart
+++ b/lib/features/transcript/presentation/transcript_line_tile.dart
@@ -126,7 +126,7 @@ class _TranscriptLineTileState extends ConsumerState<TranscriptLineTile> {
     Haptics.selection(context);
     unawaited(
       ref
-          .read(playerInteractionsProvider.notifier)
+          .read(playerInteractionsProvider)
           .seekToWord(widget.line, widget.lineIndex, wordIndex),
     );
   }

--- a/lib/features/transcript/presentation/transcript_scrollable_list.dart
+++ b/lib/features/transcript/presentation/transcript_scrollable_list.dart
@@ -579,7 +579,7 @@ class _TranscriptScrollableListState
                         )
                       : null,
                   onTap: () => ref
-                      .read(playerInteractionsProvider.notifier)
+                      .read(playerInteractionsProvider)
                       .seekToLine(line, lineIndex),
                 );
 

--- a/test/features/hotkeys/app_hotkeys_keyboard_listener_test.dart
+++ b/test/features/hotkeys/app_hotkeys_keyboard_listener_test.dart
@@ -283,6 +283,8 @@ class _FakePlayerController extends PlayerController {
 }
 
 class _FakePlayerInteractions extends PlayerInteractions {
+  _FakePlayerInteractions(super.ref);
+
   var prevLineCalls = 0;
   var nextLineCalls = 0;
   var replayLineCalls = 0;
@@ -292,9 +294,6 @@ class _FakePlayerInteractions extends PlayerInteractions {
   var expandEchoForwardCalls = 0;
   var shrinkEchoBackwardCalls = 0;
   var shrinkEchoForwardCalls = 0;
-
-  @override
-  int build() => 0;
 
   @override
   Future<void> prevLine() async {
@@ -456,7 +455,10 @@ Future<_Harness> _mountHarness(
   final fakeCraft = _FakeCraftController();
   final fakeVocab = _FakeVocabularyReviewSession(initial: vocabState);
   final fakePlayer = _FakePlayerController(sessionOverride: session);
-  final fakeInteractions = _FakePlayerInteractions();
+  // Assigned by the [playerInteractionsProvider] override, which is the only
+  // place a [Ref] is available for the service (issue #668). The reads below
+  // initialize the provider before the harness hands [fakeInteractions] out.
+  late _FakePlayerInteractions fakeInteractions;
   final fakePrefs = _FakePlayerPreferencesCtrl(rate: initialRate);
   final fakeUi = _RecordingUi();
 
@@ -513,7 +515,9 @@ Future<_Harness> _mountHarness(
       craftControllerProvider.overrideWith(() => fakeCraft),
       vocabularyReviewSessionProvider.overrideWith(() => fakeVocab),
       playerControllerProvider.overrideWith(() => fakePlayer),
-      playerInteractionsProvider.overrideWith(() => fakeInteractions),
+      playerInteractionsProvider.overrideWith(
+        (ref) => fakeInteractions = _FakePlayerInteractions(ref),
+      ),
       playerPreferencesCtrlProvider.overrideWith(() => fakePrefs),
       playerUiProvider.overrideWith(() => fakeUi),
       appRouterProvider.overrideWithValue(router),
@@ -529,7 +533,7 @@ Future<_Harness> _mountHarness(
   container.read(craftControllerProvider.notifier);
   container.read(vocabularyReviewSessionProvider.notifier);
   container.read(playerControllerProvider.notifier);
-  container.read(playerInteractionsProvider.notifier);
+  container.read(playerInteractionsProvider);
   container.read(playerPreferencesCtrlProvider.notifier);
   container.read(playerUiProvider.notifier);
 

--- a/test/features/player/application/player_metadata_notifier_test.dart
+++ b/test/features/player/application/player_metadata_notifier_test.dart
@@ -101,7 +101,7 @@ void main() {
 
     final captureGen = controller.openGeneration;
     container
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: id,
           openGeneration: captureGen,
@@ -127,7 +127,7 @@ void main() {
     await controller.openMedia(idB);
 
     container
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: idA,
           openGeneration: captureGen,
@@ -153,7 +153,7 @@ void main() {
     expect(newGen, isNot(captureGen));
 
     container
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: idB,
           openGeneration: captureGen, // stale snapshot
@@ -168,7 +168,7 @@ void main() {
   test('no-op when session is null (no media open)', () async {
     // No openMedia call — session is null.
     container
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: 'whatever',
           openGeneration: 0,
@@ -188,7 +188,7 @@ void main() {
 
     // First, set a thumbnail.
     container
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: id,
           openGeneration: captureGen,
@@ -202,7 +202,7 @@ void main() {
 
     // Now patch again with null thumbnail — implementation must preserve.
     container
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: id,
           openGeneration: controller.openGeneration,
@@ -223,7 +223,7 @@ void main() {
     expect(controller.openGeneration, exactGen);
 
     container
-        .read(playerMetadataProvider.notifier)
+        .read(playerMetadataProvider)
         .patchIfCurrent(
           mediaId: id,
           openGeneration: exactGen + 1, // not the real gen

--- a/test/features/player/application/player_open_coordinator_test.dart
+++ b/test/features/player/application/player_open_coordinator_test.dart
@@ -11,6 +11,7 @@ import 'package:enjoy_player/features/player/application/player_engine.dart';
 import 'package:enjoy_player/features/player/application/player_engine_test_double_provider.dart';
 import 'package:enjoy_player/features/player/application/player_open_coordinator.dart';
 import 'package:enjoy_player/features/player/application/player_position_tracker.dart';
+import 'package:enjoy_player/features/player/application/position_buckets.dart';
 import 'package:enjoy_player/features/player/domain/playback_session.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_blur_mode_provider.dart';
 import 'package:enjoy_player/features/transcript/application/transcript_repository_provider.dart';

--- a/test/features/player/player_collapse_unmount_test.dart
+++ b/test/features/player/player_collapse_unmount_test.dart
@@ -65,7 +65,7 @@ class _PlayerPage extends ConsumerWidget {
       body: Center(
         child: Builder(
           builder: (buttonCtx) => TextButton(
-            // Same shape as _VideoBackButton: context captured from inside
+            // Same shape as PlayerCollapseControl: context captured from inside
             // the chrome body subtree that unmounts on session clear.
             onPressed: () => collapseExpandedPlayer(ref, buttonCtx),
             child: const Text('collapse'),

--- a/test/features/player/player_interactions_class_test.dart
+++ b/test/features/player/player_interactions_class_test.dart
@@ -187,7 +187,7 @@ void main() {
   }
 
   test('prevLine bails out when there is no session', () async {
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.prevLine();
     expect(fake.seekCalls, isEmpty);
     expect(fake.playCallCount, 0);
@@ -195,7 +195,7 @@ void main() {
 
   test('prevLine bails out when there is no transcript', () async {
     setUpSession();
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.prevLine();
     expect(fake.seekCalls, isEmpty);
     expect(fake.playCallCount, 0);
@@ -203,7 +203,7 @@ void main() {
 
   test('nextLine bails out when there are no transcript lines', () async {
     setUpSession();
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.nextLine();
     expect(fake.seekCalls, isEmpty);
     expect(fake.playCallCount, 0);
@@ -214,7 +214,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 2.5); // inside line 2
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.nextLine();
     expect(fake.seekCalls, [const Duration(seconds: 4)]);
     expect(fake.playCallCount, 1);
@@ -225,7 +225,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 8.0); // past last line
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.nextLine();
     expect(fake.seekCalls, [const Duration(seconds: 6)]);
     expect(fake.playCallCount, 1);
@@ -236,7 +236,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 4.5); // inside line 3
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.prevLine();
     expect(fake.seekCalls, [const Duration(seconds: 2)]);
     expect(fake.playCallCount, 1);
@@ -247,7 +247,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 0.5);
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.prevLine();
     expect(fake.seekCalls, [const Duration(seconds: 0)]);
     expect(fake.playCallCount, 1);
@@ -266,7 +266,7 @@ void main() {
           endTimeSeconds: 4,
         );
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.nextLine();
     // next = endLineIndex + 1 = 2 -> startSeconds=4
     expect(fake.seekCalls, [const Duration(seconds: 4)]);
@@ -286,7 +286,7 @@ void main() {
           endTimeSeconds: 6,
         );
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.prevLine();
     expect(fake.seekCalls, [const Duration(seconds: 0)]);
     expect(fake.playCallCount, 1);
@@ -297,7 +297,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 4.5);
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.replayLine();
     expect(fake.seekCalls, [const Duration(seconds: 4)]);
     expect(fake.playCallCount, 1);
@@ -318,7 +318,7 @@ void main() {
             endTimeSeconds: 4,
           );
 
-      final n = container.read(playerInteractionsProvider.notifier);
+      final n = container.read(playerInteractionsProvider);
       await n.replayLine();
       expect(fake.seekCalls, [const Duration(seconds: 2)]);
       expect(fake.playCallCount, 1);
@@ -330,7 +330,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 4.5);
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.toggleEcho();
     final echo = container.read(echoModeProvider);
     expect(echo.active, isTrue);
@@ -351,7 +351,7 @@ void main() {
           endTimeSeconds: 4,
         );
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.toggleEcho();
     expect(container.read(echoModeProvider).active, isFalse);
   });
@@ -398,7 +398,7 @@ void main() {
     );
     setUpSession(currentTime: 1.0); // before any future line
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.toggleEcho();
     expect(container.read(echoModeProvider).active, isFalse);
   });
@@ -408,7 +408,7 @@ void main() {
     await seedTranscript();
     setUpSession();
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.toggleBlur();
     expect(container.read(transcriptBlurModeProvider), isTrue);
 
@@ -423,7 +423,7 @@ void main() {
     setUpSession();
     container.read(transcriptBlurModeProvider.notifier).activate();
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.toggleBlur();
     expect(container.read(transcriptBlurModeProvider), isFalse);
   });
@@ -432,13 +432,13 @@ void main() {
     await insertAudioRow(mediaId);
     setUpSession();
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.toggleBlur();
     expect(container.read(transcriptBlurModeProvider), isFalse);
   });
 
   test('toggleBlur bails out when there is no session', () async {
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.toggleBlur();
     expect(container.read(transcriptBlurModeProvider), isFalse);
   });
@@ -450,7 +450,7 @@ void main() {
       await seedTranscript();
       setUpSession(currentTime: 4.5);
 
-      final n = container.read(playerInteractionsProvider.notifier);
+      final n = container.read(playerInteractionsProvider);
       // echo is off — all four should be no-ops
       await n.expandEchoBackward();
       await n.expandEchoForward();
@@ -490,7 +490,7 @@ void main() {
           endTimeSeconds: 6,
         );
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     // No transcript — echo state should be unchanged.
     await n.expandEchoBackward();
     await n.expandEchoForward();
@@ -505,7 +505,7 @@ void main() {
     await insertAudioRow(mediaId);
     setUpSession();
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.seekToProgressFraction(0.5);
     expect(fake.seekCalls, [const Duration(seconds: 15)]); // 30 * 0.5
 
@@ -522,13 +522,13 @@ void main() {
       mediaId,
     ).copyWith(durationSeconds: 0);
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.seekToProgressFraction(0.5);
     expect(fake.seekCalls, isEmpty);
   });
 
   test('seekToProgressFraction bails out when no session', () async {
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.seekToProgressFraction(0.5);
     expect(fake.seekCalls, isEmpty);
   });
@@ -538,7 +538,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 2.5);
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.seekToLine(lines[2], 2);
     expect(fake.seekCalls, [const Duration(seconds: 4)]);
     expect(fake.playCallCount, 1);
@@ -559,7 +559,7 @@ void main() {
             endTimeSeconds: 2,
           );
 
-      final n = container.read(playerInteractionsProvider.notifier);
+      final n = container.read(playerInteractionsProvider);
       await n.seekToLine(lines[2], 2);
       final echo = container.read(echoModeProvider);
       expect(echo.startLineIndex, 2);
@@ -574,7 +574,7 @@ void main() {
     await seedTranscript();
     setUpSession(currentTime: 0.5);
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.nextLine(); // populates cache via primaryTranscriptRowForMedia
     expect(fake.seekCalls, hasLength(1));
 
@@ -592,7 +592,7 @@ void main() {
       // No transcript seeded for alt — should clear cache to empty.
 
       setUpSession(forMedia: mediaId, currentTime: 0.5);
-      final n = container.read(playerInteractionsProvider.notifier);
+      final n = container.read(playerInteractionsProvider);
       await n.nextLine();
       expect(fake.seekCalls, hasLength(1));
 
@@ -611,7 +611,7 @@ void main() {
     () async {
       await insertAudioRow(mediaId);
       await seedTranscript();
-      final n = container.read(playerInteractionsProvider.notifier);
+      final n = container.read(playerInteractionsProvider);
       await n.replayLine();
       expect(fake.seekCalls, isEmpty);
     },
@@ -624,7 +624,7 @@ void main() {
       await seedTranscript();
       setUpSession(currentTime: 0.5);
 
-      final n = container.read(playerInteractionsProvider.notifier);
+      final n = container.read(playerInteractionsProvider);
       await n.nextLine(); // populates the keepAlive cache with the old import
       expect(fake.seekCalls, [const Duration(seconds: 2)]);
 
@@ -643,7 +643,7 @@ void main() {
 
   test('replayLine bails out when there are no lines', () async {
     setUpSession();
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.replayLine();
     expect(fake.seekCalls, isEmpty);
   });
@@ -681,7 +681,7 @@ void main() {
       ],
     );
 
-    final n = container.read(playerInteractionsProvider.notifier);
+    final n = container.read(playerInteractionsProvider);
     await n.seekToWord(nested, 0, 1);
     expect(fake.seekCalls, [const Duration(milliseconds: 1500)]);
     expect(fake.playCallCount, 1);
@@ -711,7 +711,7 @@ void main() {
             endTimeSeconds: 6,
           );
 
-      final n = container.read(playerInteractionsProvider.notifier);
+      final n = container.read(playerInteractionsProvider);
       await n.seekToWord(nested, 0, 1);
       final echo = container.read(echoModeProvider);
       expect(echo.startLineIndex, 0);
@@ -734,7 +734,7 @@ void main() {
     );
 
     await container
-        .read(playerInteractionsProvider.notifier)
+        .read(playerInteractionsProvider)
         .seekToProgressFraction(0.5);
     expect(
       container.read(wordPracticeSessionProvider(mediaId)).isLooping,

--- a/test/features/player/presentation/widgets/transport/transport_progress_strip_test.dart
+++ b/test/features/player/presentation/widgets/transport/transport_progress_strip_test.dart
@@ -25,10 +25,9 @@ final PlaybackChrome _chrome = (
 
 /// Records the seeks the strip issues without dragging a real engine in.
 class _RecordingInteractions extends PlayerInteractions {
-  final List<double> seekFractions = [];
+  _RecordingInteractions(super.ref);
 
-  @override
-  int build() => 0;
+  final List<double> seekFractions = [];
 
   @override
   Future<void> seekToProgressFraction(double fraction) async {
@@ -73,11 +72,14 @@ void main() {
 
   setUp(() {
     positions = StreamController<Duration>.broadcast();
-    interactions = _RecordingInteractions();
     container = ProviderContainer(
       overrides: [
         transportSliderPositionProvider.overrideWith((ref) => positions.stream),
-        playerInteractionsProvider.overrideWith(() => interactions),
+        // Assigned here because the service now needs the provider's Ref
+        // (issue #668); the strip is pumped before [interactions] is read.
+        playerInteractionsProvider.overrideWith(
+          (ref) => interactions = _RecordingInteractions(ref),
+        ),
       ],
     );
   });

--- a/test/features/player/youtube_warm_test.dart
+++ b/test/features/player/youtube_warm_test.dart
@@ -1,12 +1,12 @@
 // Coverage for lib/features/player/application/youtube_warm.dart
-// (warmYoutubeSurfaceIfNeeded, warmYoutubeSurfaceForVideoId) and
+// (warmYoutubeSurfaceIfNeeded) and
 // lib/core/audio/recording_preview_player_provider.dart
 // (recordingPreviewPlayerProvider).
 //
-// `youtube_warm` exposes two top-level helpers that take a `WidgetRef` and
-// read `playerControllerProvider` to call `warmYoutubeSurface()`. We wire
-// each through a real `Consumer` widget under `tester.pumpWidget` so the
-// real call sites are exercised end-to-end.
+// `youtube_warm` exposes a top-level helper that takes a `WidgetRef` and
+// reads `playerControllerProvider` to call `warmYoutubeSurface()`. We wire
+// it through a real `Consumer` widget under `tester.pumpWidget` so the
+// real call site is exercised end-to-end.
 import 'package:drift/native.dart';
 import 'package:enjoy_player/core/audio/recording_preview_player.dart';
 import 'package:enjoy_player/core/audio/recording_preview_player_provider.dart';
@@ -34,18 +34,6 @@ class _InvokeWarmIfNeeded extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     warmYoutubeSurfaceIfNeeded(ref, provider: provider);
-    onInvoked(ref.read(playerEngineRevProvider));
-    return const SizedBox.shrink();
-  }
-}
-
-class _InvokeWarmForVideoId extends ConsumerWidget {
-  const _InvokeWarmForVideoId({required this.onInvoked});
-  final void Function(int engineRev) onInvoked;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    warmYoutubeSurfaceForVideoId(ref);
     onInvoked(ref.read(playerEngineRevProvider));
     return const SizedBox.shrink();
   }
@@ -154,22 +142,27 @@ void main() {
       },
     );
 
-    testWidgets('warmYoutubeSurfaceForVideoId triggers immediately', (
-      tester,
-    ) async {
-      var observedRev = -1;
-      await tester.pumpWidget(
-        _scope(
-          fake: fake,
-          db: db,
-          child: _InvokeWarmForVideoId(onInvoked: (v) => observedRev = v),
-        ),
-      );
-      await tester.pump();
+    testWidgets(
+      'warmYoutubeSurfaceIfNeeded triggers immediately for an explicit youtube '
+      'provider (the folded-in no-argument call path)',
+      (tester) async {
+        var observedRev = -1;
+        await tester.pumpWidget(
+          _scope(
+            fake: fake,
+            db: db,
+            child: _InvokeWarmIfNeeded(
+              provider: 'youtube',
+              onInvoked: (v) => observedRev = v,
+            ),
+          ),
+        );
+        await tester.pump();
 
-      // Same short-circuit when the test-double provider is non-null.
-      expect(observedRev, 0);
-    });
+        // Same short-circuit when the test-double provider is non-null.
+        expect(observedRev, 0);
+      },
+    );
   });
 
   group('recordingPreviewPlayerProvider', () {

--- a/test/features/transcript/transcript_display_gating_test.dart
+++ b/test/features/transcript/transcript_display_gating_test.dart
@@ -29,6 +29,8 @@ class _SpyKaraoke extends KaraokeHighlightSettingsOverride {
 }
 
 class _ToggleBlurInteractions extends PlayerInteractions {
+  _ToggleBlurInteractions(super.ref);
+
   @override
   Future<void> toggleBlur() async {
     ref.read(transcriptBlurModeProvider.notifier).toggle();
@@ -111,7 +113,7 @@ void main() {
         karaoke: KaraokeHighlightSettingsOverride(false),
         extraOverrides: [
           playerInteractionsProvider.overrideWith(
-            () => _ToggleBlurInteractions(),
+            (ref) => _ToggleBlurInteractions(ref),
           ),
         ],
         readiness: const TranscriptDisplayReadiness(


### PR DESCRIPTION
Sweep of small, independent cleanups from #668, in one PR. No behavior change except the two explicitly intended fixes (item 8's hydration guard and item 7's defensive cancel).

## Presentation duplication + magic numbers

- [x] **1. One `PlayerCollapseControl`** replaces the three hand-rolled collapse back-button stacks
  — `lib/features/player/presentation/widgets/player_collapse_control.dart` (new)
  — `lib/features/player/presentation/layouts/video_player_layout.dart` (deleted `_VideoBackButton`)
  — `lib/features/player/presentation/layouts/audio_player_layout.dart`
  — `lib/features/player/presentation/expanded_player_widgets.dart` (deleted `_VideoCollapseOnlyOverlay`)
  Knobs: `inset`, `reserveToolbarHeight`, `useSafeArea`, plus a `loadingChrome` constructor for the toolbar-slot shape.
- [x] **2. One parameterized loading stage** replaces the duplicated 16:9 scaffolding
  — `lib/features/player/presentation/widgets/player_loading_stage.dart` (new)
  — `lib/features/player/presentation/expanded_player_widgets.dart` (`_LocalLoadingVideoStage`)
  — `lib/features/player/presentation/widgets/youtube_loading_video_stage.dart`
  Parameters are the surface id, `enabled` gate, overlay, and poster child. The YouTube stage's engine watch + poster warm-up (#678/#677 territory) and the local stage's shared `expandedPlayer` viewport id + shrink overlay are preserved exactly.
- [x] **3. Bare geometry literals → named constants**
  — `lib/features/player/presentation/widgets/player_surface_host.dart`: `_parkClearancePx` (was a bare `-64`) plus docs on why 320×180 is only a last-resort park
  — `lib/features/player/presentation/widgets/global_transport_bar.dart`: `kTransportControlRowHeight` (was a bare `56`)

## Application-layer cleanup

- [x] **4. `youtube_session.dart`** — `resetForOpen`/`resetForClear` reset 14 identical latches in two hand-maintained lists; both now call `_resetTransportLatches({required videoId})`. Open-only fields, the clear-only `_mountRequested`, and the emit sequences stay with their callers. #677's mount completer untouched.
- [x] **5. Dummy-state notifiers → plain keepAlive `Provider<Service>`**
  — `lib/features/player/application/player_interactions.dart` — the `(row.id, row.timelineJson)` lines-cache key from #678 is preserved verbatim; only the shell changed
  — `lib/features/player/application/player_metadata_notifier.dart`
  16 lib + 35 test call sites drop `.notifier`; the three test fakes now take the provider's `Ref`.
- [x] **6. `playback_session_persister.dart` / `position_buckets.dart`** — `kPlaybackSessionDebounceMs` and `kMaxPendingPositionAgeMs` co-located with `kPositionBucketSessionEmitMs`, which documents their interplay; doc comments now cross-reference the bucket.
- [x] **7. `player_position_tracker.dart`** — `subscribe` detaches before installing new `_positionSub`/`_durationSub`. Detach nulls the fields synchronously and cancels without awaiting, so the async cancel cannot clobber the fresh subscriptions. *(intended behavior change)*
- [x] **8. `player_preferences_provider.dart`** — the settings-DB read moved inside `_hydrate`'s try (a Drift throw no longer escapes `build`'s microtask unhandled), and the assign is skipped when state already moved off `PlayerPreferences.defaults`. Comparison is field-wise: the model keeps identity `==` so Riverpod keeps notifying on every setter. *(intended behavior change)*
- [x] **9. `youtube_webview_navigation.dart`** — deleted the trailing no-op `if (...) return;` in `loadCurrentVideoIfAttached`.
- [x] **10. `youtube_warm.dart`** — `warmYoutubeSurfaceForVideoId` (which ignored the videoId in its name) folded into `warmYoutubeSurfaceIfNeeded`; `discover_feed_tile.dart` passes `provider: 'youtube'`.

Not touched: `global_transport_bar`'s `ref.listen` placement and `player_surface_target`'s dead branch (both #667).

## Test plan

- [x] `flutter analyze` — 5 pre-existing info-level issues, identical to the `main` baseline
- [x] `flutter test` — full suite: **5894 passed, 2 skipped, 0 failed**
- [x] `flutter test test/features/player` — 690 passed, incl. `video_player_layout_test`, `audio_player_layout_test`, `expanded_player_widgets_test`, `youtube_loading_video_stage_test`, `global_transport_bar_test`, `player_surface_host_test`
- [x] `flutter test test/features/hotkeys test/features/transcript test/features/discover` — 831 passed (the suites that exercise the converted providers)
- [x] `dart format` — clean
- [x] `bash .github/scripts/check_codegen_drift.sh` — regenerated output matches the working tree (`build_runner` writes 0 outputs), so the codegen-drift gate stays green

Fixes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
