### PR TITLE
perf(youtube): observer-driven watch inject, poster gating, paused poll backoff

### DIFF
--- a/lib/features/player/application/engines/youtube/youtube_page_inject.dart
+++ b/lib/features/player/application/engines/youtube/youtube_page_inject.dart
@@ -42,6 +42,9 @@ const String kYoutubeMobileWatchInjectScript = r'''
   var savedTime=0;        // last known main-video position
   var reloading=false;    // are we in the middle of a reload?
 
+  // --- Reactive enforcement ---
+  var enforcePending=false;  // a coalesced sweep is already queued
+
   // --- Utility ---
   function isAd(){
     return player && player.classList.contains('ad-showing');
@@ -96,18 +99,52 @@ const String kYoutubeMobileWatchInjectScript = r'''
     '.ytp-caption-window-rollup,.ytp-caption-segment,'+
     '.player-captions-container,.captions-text';
 
+  // --- Write-once styling (issue #662) ---
+  // Every element this script styles is stamped, and a stamped element is
+  // never re-written unless its block has actually been undone: the property
+  // blocks below are constants, so re-writing an intact one only invalidates
+  // layout. This is what makes a reactive sweep cheap — a settled DOM costs a
+  // handful of expando + CSS reads instead of ~40 !important property writes.
+  var STAMP='__enjoyYtStyled';
+
+  // [mark] is one property of the block, read back on later sweeps. Our
+  // declarations are !important, so a page write to the same property loses
+  // the cascade; only a removal or a wholesale style-attribute rewrite can
+  // undo us, and that is exactly what a cleared [mark] detects. One property
+  // read per element per sweep replaces the old 300 ms unconditional rewrite.
+  function styleOnce(el,props,mark){
+    if(!el) return;
+    if(el[STAMP]){
+      if(!mark) return;
+      try{
+        if(el.style.getPropertyValue(mark)===props[mark]) return;
+      }catch(e){return;}
+    }
+    el[STAMP]=1;
+    for(var k in props){
+      if(Object.prototype.hasOwnProperty.call(props,k)){
+        el.style.setProperty(k,props[k],'important');
+      }
+    }
+  }
+
   // Re-apply inline hide — YouTube sometimes sets competing inline styles
-  // that outrank a one-shot <style> rule after track changes.
+  // that outrank a one-shot <style> rule after track changes. Fresh caption
+  // nodes are unstamped, so each new window is hidden on the sweep that
+  // observes it. The <style> rule in [installInlineGuards] is the other
+  // backstop.
   function hideCaptionDom(){
     var root=player||document;
     var nodes=root.querySelectorAll
       ? root.querySelectorAll(captionSel)
       : [];
     for(var i=0;i<nodes.length;i++){
-      nodes[i].style.setProperty('display','none','important');
-      nodes[i].style.setProperty('visibility','hidden','important');
-      nodes[i].style.setProperty('opacity','0','important');
-      nodes[i].style.setProperty('pointer-events','none','important');
+      styleOnce(nodes[i],{
+        display:'none',
+        visibility:'hidden',
+        opacity:'0',
+        'pointer-events':'none'
+      },'display');
     }
   }
 
@@ -167,6 +204,17 @@ const String kYoutubeMobileWatchInjectScript = r'''
         window.flutter_inappwebview.callHandler(
           'onVideoEvent',args[0],args.length>1?args[1]:null);
       });
+    });
+    // Position sampler for the ad hand-off (issue #662): [savedTime] used to
+    // be refreshed by the same 300 ms tick that ran the layout pass, so with
+    // that tick gone it needs a driver of its own. `timeupdate` (~4 Hz while
+    // playing) is free — page-local, no Dart round-trip. Deliberately NOT in
+    // [events]: it must never reach the Dart transport switch.
+    video.addEventListener('timeupdate',function(){
+      if(isAd()) return;
+      if(isFinite(video.currentTime)&&video.currentTime>0){
+        savedTime=video.currentTime;
+      }
     });
   }
 
@@ -234,6 +282,145 @@ const String kYoutubeMobileWatchInjectScript = r'''
     while(tmp && tmp!==player){mids.push(tmp);tmp=tmp.parentElement;}
   }
 
+  // --- Reactive layout enforcement (issue #662) ---
+  // The heavy pass below used to run on a 300 ms interval for as long as the
+  // document lived: ~40 !important property writes across document / body /
+  // player / mids / video, a querySelectorAll sweep and the ancestor sibling
+  // scan — against a DOM that is settled a second after load. That is
+  // continuous style + layout invalidation inside the WebView for a whole
+  // session, for zero information. The pass now runs once per DOM shape and
+  // is re-run reactively (see [installLayoutObservers]); [STAMP] is the
+  // idempotence early-exit that keeps each reactive sweep cheap.
+
+  // Structural churn anywhere in the document: YouTube injecting overlays,
+  // caption windows or a rebuilt player, and any new sibling that the
+  // ancestor scan must hide.
+  // Attribute churn is watched on the pinned elements ONLY (subtree:false):
+  // the progress bar and spinner inside the player rewrite style every
+  // frame and must never schedule a sweep. `ad-showing` is a class on the
+  // player container, so an ad transition rides this same record — the
+  // ad-detection cadence is the observer, not a timer.
+  var mo=null;
+
+  function observeLayoutTargets(){
+    if(!mo) return;
+    mo.disconnect();
+    try{
+      mo.observe(document.documentElement,
+                 {childList:true,subtree:true,attributes:false});
+    }catch(e){}
+    var pinned=[];
+    if(player) pinned.push(player);
+    if(v) pinned.push(v);
+    for(var i=0;i<mids.length;i++){pinned.push(mids[i]);}
+    for(i=0;i<pinned.length;i++){
+      try{
+        mo.observe(pinned[i],{
+          childList:false,
+          subtree:false,
+          attributes:true,
+          attributeFilter:['class','style']
+        });
+      }catch(e){}
+    }
+  }
+
+  function installLayoutObservers(){
+    if(typeof MutationObserver!=='function') return;
+    try{mo=new MutationObserver(scheduleEnforce);}catch(e){mo=null;return;}
+    observeLayoutTargets();
+  }
+
+  // Coalesce a mutation burst into one sweep. A plain short timer, not
+  // requestAnimationFrame: rAF stops firing for a hidden/backgrounded view,
+  // and this page is exactly the surface that gets parked (ADR-0066) — the
+  // ad transition it would delay is the one we least want to miss.
+  function scheduleEnforce(){
+    if(enforcePending||reloading) return;
+    enforcePending=true;
+    setTimeout(function(){
+      enforcePending=false;
+      enforce();
+    },50);
+  }
+
+  function applyLayout(){
+    styleOnce(document.documentElement,
+              {overflow:'hidden',background:'#000'},'overflow');
+    styleOnce(document.body,
+              {margin:'0',padding:'0',overflow:'hidden',background:'#000'},
+              'margin');
+
+    if(player){
+      styleOnce(player,{
+        position:'fixed',
+        top:'0',
+        left:'0',
+        width:'100vw',
+        height:'100vh',
+        'z-index':'999999',
+        overflow:'hidden',
+        background:'#000',
+        margin:'0',
+        padding:'0',
+        transform:'none',
+        display:'block',
+        visibility:'visible',
+        opacity:'1'
+      },'position');
+    }
+
+    mids.forEach(function(el){
+      styleOnce(el,{
+        width:'100%',
+        height:'100%',
+        display:'block',
+        visibility:'visible',
+        opacity:'1',
+        position:'absolute',
+        top:'0',
+        left:'0',
+        overflow:'hidden',
+        'max-height':'none',
+        'max-width':'none',
+        'min-height':'0',
+        margin:'0',
+        padding:'0',
+        transform:'none',
+        background:'#000'
+      },'min-height');
+    });
+
+    if(v){
+      styleOnce(v,{
+        width:'100%',
+        height:'100%',
+        position:'absolute',
+        top:'0',
+        left:'0',
+        display:'block',
+        visibility:'visible',
+        'object-fit':'contain',
+        margin:'0',
+        padding:'0',
+        transform:'none',
+        background:'#000'
+      },'object-fit');
+    }
+
+    for(var i=0;i<chain.length;i++){
+      var parent=chain[i].parentElement;
+      if(!parent) continue;
+      Array.from(parent.children).forEach(function(sib){
+        if(sib===chain[i]) return;
+        var tag=sib.tagName;
+        if(tag==='STYLE'||tag==='SCRIPT'||tag==='LINK'
+           ||tag==='META'||tag==='HEAD') return;
+        styleOnce(sib,{display:'none'},'display');
+      });
+    }
+  }
+
   // --- Enforce layout + detect video swap + ad transition ---
   function enforce(){
     if(reloading) return;
@@ -264,6 +451,9 @@ const String kYoutubeMobileWatchInjectScript = r'''
       v.autoplay=false;
       v.removeAttribute('autoplay');
       v.loop=false;
+      // The swapped <video> and its wrappers are new elements: re-point the
+      // attribute observer at them before the next sweep.
+      observeLayoutTargets();
       setTimeout(function(){syncState(v);},200);
     }
     if(!v) return;
@@ -273,75 +463,7 @@ const String kYoutubeMobileWatchInjectScript = r'''
     hideCaptionDom();
     disableYoutubeCaptions();
 
-    var de=document.documentElement;
-    de.style.setProperty('overflow','hidden','important');
-    de.style.setProperty('background','#000','important');
-    var b=document.body;
-    b.style.setProperty('margin','0','important');
-    b.style.setProperty('padding','0','important');
-    b.style.setProperty('overflow','hidden','important');
-    b.style.setProperty('background','#000','important');
-
-    if(player){
-      player.style.setProperty('position','fixed','important');
-      player.style.setProperty('top','0','important');
-      player.style.setProperty('left','0','important');
-      player.style.setProperty('width','100vw','important');
-      player.style.setProperty('height','100vh','important');
-      player.style.setProperty('z-index','999999','important');
-      player.style.setProperty('overflow','hidden','important');
-      player.style.setProperty('background','#000','important');
-      player.style.setProperty('margin','0','important');
-      player.style.setProperty('padding','0','important');
-      player.style.setProperty('transform','none','important');
-      player.style.setProperty('display','block','important');
-      player.style.setProperty('visibility','visible','important');
-      player.style.setProperty('opacity','1','important');
-    }
-
-    mids.forEach(function(el){
-      el.style.setProperty('width','100%','important');
-      el.style.setProperty('height','100%','important');
-      el.style.setProperty('display','block','important');
-      el.style.setProperty('visibility','visible','important');
-      el.style.setProperty('opacity','1','important');
-      el.style.setProperty('position','absolute','important');
-      el.style.setProperty('top','0','important');
-      el.style.setProperty('left','0','important');
-      el.style.setProperty('overflow','hidden','important');
-      el.style.setProperty('max-height','none','important');
-      el.style.setProperty('max-width','none','important');
-      el.style.setProperty('min-height','0','important');
-      el.style.setProperty('margin','0','important');
-      el.style.setProperty('padding','0','important');
-      el.style.setProperty('transform','none','important');
-      el.style.setProperty('background','#000','important');
-    });
-
-    v.style.setProperty('width','100%','important');
-    v.style.setProperty('height','100%','important');
-    v.style.setProperty('position','absolute','important');
-    v.style.setProperty('top','0','important');
-    v.style.setProperty('left','0','important');
-    v.style.setProperty('display','block','important');
-    v.style.setProperty('visibility','visible','important');
-    v.style.setProperty('object-fit','contain','important');
-    v.style.setProperty('margin','0','important');
-    v.style.setProperty('padding','0','important');
-    v.style.setProperty('transform','none','important');
-    v.style.setProperty('background','#000','important');
-
-    for(var i=0;i<chain.length;i++){
-      var parent=chain[i].parentElement;
-      if(!parent) continue;
-      Array.from(parent.children).forEach(function(sib){
-        if(sib===chain[i]) return;
-        var tag=sib.tagName;
-        if(tag==='STYLE'||tag==='SCRIPT'||tag==='LINK'
-           ||tag==='META'||tag==='HEAD') return;
-        sib.style.setProperty('display','none','important');
-      });
-    }
+    applyLayout();
   }
 
   function setup(){
@@ -357,7 +479,15 @@ const String kYoutubeMobileWatchInjectScript = r'''
 
     installInlineGuards();
     enforce();
-    setInterval(enforce,300);
+    installLayoutObservers();
+
+    // Belt-and-braces only — the observers carry enforcement (see
+    // [installLayoutObservers]). One sweep a second costs a pass of expando
+    // reads because of [STAMP], where the 300 ms full rewrite this replaced
+    // invalidated layout for the whole session. It is also the only driver
+    // on a WebView without MutationObserver, and the last resort for a style
+    // overwrite on an element the attribute observer does not pin.
+    setInterval(enforce,1000);
 
     v.autoplay=false;
     v.removeAttribute('autoplay');

--- a/lib/features/player/application/engines/youtube/youtube_player_engine.dart
+++ b/lib/features/player/application/engines/youtube/youtube_player_engine.dart
@@ -199,7 +199,14 @@ class YoutubePlayerEngine implements PlayerEngine {
       stream: buffering,
       initialData: _session.buffering,
       builder: (context, snapshot) {
-        final showPoster = snapshot.data ?? _session.buffering;
+        final bufferingNow = snapshot.data ?? _session.buffering;
+        // The poster is a "playback never started" affordance, not a
+        // buffering one (issue #662): keyed to the session's first-playing
+        // latch, so a mid-playback `waiting` no longer fades the static
+        // thumbnail OVER the live frame. A stall after playback has started
+        // gets the small spinner instead.
+        final posterVisible = bufferingNow && !_session.loggedFirstPlaying;
+        final showSpinner = bufferingNow && _session.loggedFirstPlaying;
         return ValueListenableBuilder<int>(
           valueListenable: _session.mountTick,
           builder: (context, _, _) {
@@ -212,7 +219,7 @@ class YoutubePlayerEngine implements PlayerEngine {
                 // InAppWebView constructor itself asserts without a backend).
                 if (!youTubeEngineOptedOutHere && _session.shouldMountWebView)
                   _buildWebViewHost(),
-                if (_session.tapToPlayHintActive && !showPoster)
+                if (_session.tapToPlayHintActive && !posterVisible)
                   _YoutubeTapToPlayHint(
                     label:
                         AppLocalizations.of(context)?.youtubeTapToPlayHint ??
@@ -220,8 +227,9 @@ class YoutubePlayerEngine implements PlayerEngine {
                   ),
                 YoutubeVideoPoster(
                   primaryUrl: _session.posterUrl,
-                  visible: showPoster,
+                  visible: posterVisible,
                 ),
+                if (showSpinner) const _YoutubeBufferingIndicator(),
               ],
             );
           },
@@ -437,6 +445,38 @@ class _YoutubeTapToPlayHint extends StatelessWidget {
                 style: const TextStyle(color: Colors.white70, fontSize: 16),
               ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Mid-playback buffering affordance (issue #662).
+///
+/// The poster used to be the only buffering overlay, which meant every
+/// `waiting` after playback had started faded a static thumbnail over the
+/// live frame. Once playback has started the stall is signalled with this
+/// instead: a small spinner on a light scrim, never covering the video.
+class _YoutubeBufferingIndicator extends StatelessWidget {
+  const _YoutubeBufferingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    // IgnorePointer: a stall must stay tappable (pause / seek) like any
+    // other moment of playback.
+    return const IgnorePointer(
+      ignoring: true,
+      child: ColoredBox(
+        color: Colors.black26,
+        child: Center(
+          child: SizedBox(
+            width: 44,
+            height: 44,
+            child: CircularProgressIndicator(
+              strokeWidth: 3,
+              color: Colors.white70,
+            ),
           ),
         ),
       ),

--- a/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
+++ b/lib/features/player/application/engines/youtube/youtube_webview_poll_loop.dart
@@ -35,13 +35,21 @@ typedef YoutubeRetryPlayFn = Future<void> Function(InAppWebViewController? web);
 
 final _logPoll = logNamed('YouTubeWebViewPollLoop');
 
-/// Periodic DOM poll for `<video>` play state (see [YoutubeStatePoller]).
+/// DOM poll for `<video>` play state (see [YoutubeStatePoller]).
+///
+/// A one-shot [Timer] chain, not [Timer.periodic]: the cadence is a decision
+/// made per tick. While anything is live — playing, an unconfirmed pause
+/// streak, a paused position that is still moving — it is [pollTick]; once a
+/// pause is CONFIRMED and quiet it backs off to [pausedPollBackoff] (issue
+/// #662), and [start] puts it back on every play intent or state transition.
 class YoutubeWebViewPollLoop {
   YoutubeWebViewPollLoop({
     required this.session,
     required this.webController,
     required this.onFirstPlaying,
     this.onPlaybackProgress,
+    this.pollTick = YoutubeAudiblePlaybackPolicy.pollTick,
+    this.pausedPollBackoff = defaultPausedPollBackoff,
     YoutubePollFn? pollFn,
     YoutubeRetryPlayFn? retryPlay,
   }) : pollFn = pollFn ?? YoutubeStatePoller.poll,
@@ -57,6 +65,16 @@ class YoutubeWebViewPollLoop {
              await YoutubeWebViewBridge.playWhenReady(web);
            });
 
+  /// Cadence once a pause is confirmed AND the position has stopped moving
+  /// (issue #662). Shadow reading pauses a lot, and every tick is a JS
+  /// evaluation inside the WebView; 250 ms buys nothing on a paused element.
+  /// Never applied before a pause is confirmed — the confirmation window
+  /// itself ([YoutubeSession.pauseConfirmPollTicks] × [pollTick], which the
+  /// audible-playback joint invariant is checked against) must keep its full
+  /// resolution, and an idle-but-never-played document still needs fast
+  /// sampling to catch its first metadata.
+  static const Duration defaultPausedPollBackoff = Duration(seconds: 1);
+
   final YoutubeSession session;
   final InAppWebViewController? Function() webController;
   final YoutubeFirstPlayingFn onFirstPlaying;
@@ -69,22 +87,43 @@ class YoutubeWebViewPollLoop {
   /// One-shot play re-issue for the immediate-pause retry (D8).
   final YoutubeRetryPlayFn retryPlay;
 
+  /// Live cadence — [YoutubeAudiblePlaybackPolicy.pollTick] is the canonical
+  /// home of the default (the pause-confirmation invariant reads against it).
+  final Duration pollTick;
+
+  /// Cadence while a confirmed pause sits quiet; see
+  /// [defaultPausedPollBackoff].
+  final Duration pausedPollBackoff;
+
   Timer? _pollTimer;
   Timer? _pollKickTimer;
 
-  /// A poll is awaited but not finished yet. [Timer.periodic] does not wait
-  /// for the previous callback, so a read that outlives one
-  /// [YoutubeAudiblePlaybackPolicy.pollTick] — a heavy page, the inject
-  /// interval, a GC pause — used to let the next tick issue a second read
-  /// while the first was still outstanding. Two overlapping reads resolve in
-  /// completion order, not issue order, so the OLDER DOM snapshot could apply
-  /// last: a stale `s=1` landing after end-of-media runs
-  /// [YoutubeSession.notePlayingConfirmed], which clears `_playbackCompleted`
-  /// and re-emits `playing=true` on a video that is already over (issue #655).
-  /// Dropping the tick rather than queuing it keeps the cadence self-correcting
-  /// — the next period samples the DOM again, so a slow page loses nothing but
-  /// the ordering hazard.
+  /// A poll is awaited but not finished yet. The timer chain does not wait
+  /// for the previous callback, so a read that outlives one [pollTick] — a
+  /// heavy page, the inject sweep, a GC pause — used to let the next tick
+  /// issue a second read while the first was still outstanding. Two
+  /// overlapping reads resolve in completion order, not issue order, so the
+  /// OLDER DOM snapshot could apply last: a stale `s=1` landing after
+  /// end-of-media runs [YoutubeSession.notePlayingConfirmed], which clears
+  /// `_playbackCompleted` and re-emits `playing=true` on a video that is
+  /// already over (issue #655). Dropping the tick rather than queuing it
+  /// keeps the cadence self-correcting — the next period samples the DOM
+  /// again, so a slow page loses nothing but the ordering hazard.
   bool _pollInFlight = false;
+
+  /// A pause has been confirmed since the last play intent. The backoff is
+  /// keyed to a CONFIRMED pause only: [decidePollTransition] reports
+  /// [PauseStreaking] while Dart still believes it is playing, and every
+  /// later paused read is a [PollIdleTick], so "idle" alone would back the
+  /// loop off before it ever confirmed anything.
+  bool _pauseConfirmed = false;
+
+  /// The confirmed pause is not producing new information — the position has
+  /// stopped moving since the previous read.
+  bool _pauseQuiet = false;
+
+  /// Position from the previous read; the "quiet" half of the backoff test.
+  Duration _lastReadPosition = Duration.zero;
 
   bool get isRunning => _pollTimer != null;
 
@@ -97,12 +136,15 @@ class YoutubeWebViewPollLoop {
   }
 
   void start() {
-    if (_pollTimer != null) return;
+    // A play intent (or any state transition) restores the fast cadence even
+    // while the loop is already running — a backed-off loop must not stretch
+    // the wait for the first read after a play command. Re-arming rather than
+    // early-returning keeps the old "start twice is one timer" property.
+    _pauseConfirmed = false;
+    _pauseQuiet = false;
     session.resetPauseStreak();
-    _pollTimer = Timer.periodic(
-      YoutubeAudiblePlaybackPolicy.pollTick,
-      (_) => _tick(),
-    );
+    _pollTimer?.cancel();
+    _scheduleNext();
   }
 
   void stop() {
@@ -110,6 +152,21 @@ class YoutubeWebViewPollLoop {
     _pollTimer = null;
     _pollKickTimer?.cancel();
     _pollKickTimer = null;
+  }
+
+  void _scheduleNext() {
+    _pollTimer = Timer(
+      _pauseConfirmed && _pauseQuiet ? pausedPollBackoff : pollTick,
+      _onTick,
+    );
+  }
+
+  /// One-shot chain link. Re-arms BEFORE the read so the cadence stays
+  /// independent of read latency — exactly the [Timer.periodic] property the
+  /// in-flight guard was written against.
+  void _onTick() {
+    _scheduleNext();
+    unawaited(_tick());
   }
 
   Future<void> _tick() async {
@@ -131,6 +188,10 @@ class YoutubeWebViewPollLoop {
             }) {
               if (session.disposed) return;
               session.emitPosition(position);
+              // "Quiet" is measured against the previous read, before any of
+              // the transitions below touch session state.
+              final positionMoved = position != _lastReadPosition;
+              _lastReadPosition = position;
               if (newDuration != null &&
                   newDuration > Duration.zero &&
                   newDuration != session.lastDuration) {
@@ -158,6 +219,10 @@ class YoutubeWebViewPollLoop {
                 case PauseStreaking(:final confirmed, :final newStreak):
                   session.notePauseStreak(newStreak);
                   if (confirmed) {
+                    // Confirmed AND the frame has stopped moving → the only
+                    // state [pausedPollBackoff] may apply to.
+                    _pauseConfirmed = true;
+                    _pauseQuiet = !positionMoved;
                     final immediate = session.isImmediatePause(DateTime.now());
                     final retry = decideImmediatePauseRetry(
                       immediate: immediate,
@@ -228,8 +293,20 @@ class YoutubeWebViewPollLoop {
                   if (session.buffering) {
                     session.emitBuffering(false);
                   }
+                  // Any sign of life returns the loop to the fast cadence.
+                  _pauseConfirmed = false;
+                  _pauseQuiet = false;
                 case PollIdleTick():
                   session.resetPauseStreak();
+                  // An idle tick is what a confirmed pause looks like from
+                  // here on (see [_pauseConfirmed]) — a seek-while-paused
+                  // briefly un-quiets it, and the next stable read re-arms
+                  // the backoff. Before any pause is confirmed this must
+                  // leave the cadence alone: a document that has never
+                  // played is still waiting for its first metadata.
+                  if (_pauseConfirmed) {
+                    _pauseQuiet = !positionMoved;
+                  }
               }
             },
       );

--- a/lib/features/player/presentation/widgets/youtube_video_poster.dart
+++ b/lib/features/player/presentation/widgets/youtube_video_poster.dart
@@ -24,10 +24,20 @@ class _YoutubeVideoPosterState extends State<YoutubeVideoPoster> {
   String? _activeUrl;
   bool _useMqFallback = false;
 
+  /// The fade-out has finished, so the (fully transparent) poster can leave
+  /// the tree. Without this the child had to be dropped synchronously on
+  /// `visible: false` — which is what made the 220 ms fade-out dead code:
+  /// `SizedBox.shrink()` replaced the [AnimatedOpacity] before it could
+  /// animate to 0 (issue #662).
+  bool _fadedOut = false;
+
   @override
   void initState() {
     super.initState();
     _activeUrl = widget.primaryUrl;
+    // Built hidden from the start: nothing is on screen to fade, so there is
+    // no animation to wait for either.
+    _fadedOut = !widget.visible;
   }
 
   @override
@@ -37,18 +47,31 @@ class _YoutubeVideoPosterState extends State<YoutubeVideoPoster> {
       _useMqFallback = false;
       _activeUrl = widget.primaryUrl;
     }
+    if (widget.visible) {
+      // Re-arm the fade for the next hide.
+      _fadedOut = false;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final url = _activeUrl;
-    if (url == null || url.isEmpty || !widget.visible) {
+    if (url == null || url.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    // Nothing was on screen to fade, so go straight to the empty box.
+    if (!widget.visible && _fadedOut) {
       return const SizedBox.shrink();
     }
 
     return AnimatedOpacity(
       opacity: widget.visible ? 1 : 0,
       duration: const Duration(milliseconds: 220),
+      onEnd: () {
+        if (!widget.visible && mounted && !_fadedOut) {
+          setState(() => _fadedOut = true);
+        }
+      },
       child: ColoredBox(
         color: Colors.black,
         child: Image(

--- a/test/features/player/application/engines/youtube/youtube_webview_poll_loop_test.dart
+++ b/test/features/player/application/engines/youtube/youtube_webview_poll_loop_test.dart
@@ -678,5 +678,201 @@ void main() {
         loop.stop();
       },
     );
+
+    group('cadence (issue #662)', () {
+      // `onFirstPlaying` is wired the way the controller wires it. That is
+      // not cosmetic: without the first-playing latch the session's
+      // recovery-hint timer would be armed on every pause confirmation and
+      // would still be pending when the testWidgets zone is verified.
+      YoutubeWebViewPollLoop buildLoop(_FakePollDriver driver) {
+        return YoutubeWebViewPollLoop(
+          session: session,
+          webController: () => null,
+          onFirstPlaying: session.markFirstPlayingLogged,
+          pollFn: driver.poll,
+        );
+      }
+
+      /// Advances fake time [window] in 50 ms steps and returns how many poll
+      /// reads the loop issued. 50 ms < pollTick, so the step size can never
+      /// skip a tick, and every cadence used here is a multiple of the step.
+      Future<int> readsOver(
+        WidgetTester tester,
+        _FakePollDriver driver,
+        Duration window,
+      ) async {
+        final start = driver.calls;
+        var elapsed = Duration.zero;
+        while (elapsed < window) {
+          await tester.pump(const Duration(milliseconds: 50));
+          await tester.idle();
+          elapsed += const Duration(milliseconds: 50);
+        }
+        return driver.calls - start;
+      }
+
+      testWidgets('playing is sampled every pollTick', (tester) async {
+        final driver = _FakePollDriver();
+        final loop = buildLoop(driver);
+        session.emitPlaying(true);
+
+        loop.start();
+        for (var i = 1; i <= 4; i++) {
+          await tester.pump(loop.pollTick);
+          await tester.idle();
+          driver.emit(
+            position: Duration(milliseconds: 250 * i),
+            jsPaused: false,
+          );
+        }
+
+        expect(driver.calls, 4, reason: 'one read per 250 ms while playing');
+        expect(session.loggedFirstPlaying, isTrue);
+
+        // The fake-async zone is verified for pending timers before the
+        // tearDowns run, so the chain must be stopped inside the body.
+        loop.stop();
+      });
+
+      testWidgets('a document that never played is NOT backed off', (
+        tester,
+      ) async {
+        // Dart never believed this document was playing, so no pause is ever
+        // confirmed (every paused read is a PollIdleTick). The loop must stay
+        // fast: this is the document still waiting for its first metadata,
+        // and the backoff may only follow a confirmed pause.
+        final driver = _FakePollDriver();
+        final loop = buildLoop(driver);
+
+        loop.start();
+        final reads = await readsOver(
+          tester,
+          driver,
+          const Duration(seconds: 2),
+        );
+        driver.emit(position: Duration.zero, jsPaused: true);
+
+        expect(reads, 8, reason: '250 ms cadence before any confirmed pause');
+        expect(session.playing, isFalse);
+        expect(session.loggedFirstPlaying, isFalse);
+
+        loop.stop();
+      });
+
+      testWidgets(
+        'a confirmed quiet pause backs off to ~1/s; a play intent restores '
+        'the fast cadence immediately',
+        (tester) async {
+          final driver = _FakePollDriver();
+          final loop = buildLoop(driver);
+          const position = Duration(seconds: 30);
+          session.emitPlaying(true);
+
+          loop.start();
+          // Playing: four full-cadence samples.
+          for (var i = 1; i <= 4; i++) {
+            await tester.pump(loop.pollTick);
+            await tester.idle();
+            driver.emit(
+              position: Duration(milliseconds: 250 * i),
+              jsPaused: false,
+            );
+          }
+          // Then a pause confirming at a still position.
+          for (var i = 0; i < YoutubeSession.pauseConfirmPollTicks; i++) {
+            await tester.pump(loop.pollTick);
+            await tester.idle();
+            driver.emit(position: position, jsPaused: true);
+          }
+          expect(session.playing, isFalse);
+
+          // The tick armed BEFORE the confirming read is still fast; consume
+          // it so the measurement below starts on a backoff-armed boundary.
+          await tester.pump(loop.pollTick);
+          await tester.idle();
+
+          expect(
+            await readsOver(tester, driver, const Duration(seconds: 2)),
+            2,
+            reason: 'a confirmed quiet pause is sampled about once a second',
+          );
+          expect(
+            await readsOver(tester, driver, const Duration(seconds: 2)),
+            2,
+            reason: 'the backoff holds while nothing changes',
+          );
+
+          // A play intent must not wait out the backed-off period.
+          loop.start();
+          expect(
+            await readsOver(tester, driver, loop.pollTick),
+            1,
+            reason: 'start() re-arms at pollTick',
+          );
+          expect(
+            await readsOver(tester, driver, const Duration(seconds: 1)),
+            4,
+            reason: 'the fast cadence is back',
+          );
+
+          loop.stop();
+        },
+      );
+
+      testWidgets(
+        'a seek while paused un-quiets the loop, then it re-settles',
+        (tester) async {
+          final driver = _FakePollDriver();
+          final loop = buildLoop(driver);
+          session.emitPlaying(true);
+
+          loop.start();
+          for (var i = 1; i <= 2; i++) {
+            await tester.pump(loop.pollTick);
+            await tester.idle();
+            driver.emit(
+              position: Duration(milliseconds: 250 * i),
+              jsPaused: false,
+            );
+          }
+          for (var i = 0; i < YoutubeSession.pauseConfirmPollTicks; i++) {
+            await tester.pump(loop.pollTick);
+            await tester.idle();
+            driver.emit(position: const Duration(seconds: 30), jsPaused: true);
+          }
+          await tester.pump(loop.pollTick);
+          await tester.idle();
+          expect(
+            await readsOver(tester, driver, const Duration(seconds: 1)),
+            1,
+            reason: 'precondition: backed off',
+          );
+
+          // The user seeks while paused. The tick armed before this delivery is
+          // still backed off; the one after it runs at the fast cadence.
+          driver.emit(position: const Duration(seconds: 45), jsPaused: true);
+          expect(
+            await readsOver(tester, driver, loop.pausedPollBackoff),
+            1,
+            reason: 'the arming predates the moved position',
+          );
+          expect(
+            await readsOver(tester, driver, loop.pollTick),
+            1,
+            reason: 'a moving position is live state — pollTick cadence',
+          );
+
+          // The position settles again, and the loop backs off with it.
+          driver.emit(position: const Duration(seconds: 45), jsPaused: true);
+          expect(
+            await readsOver(tester, driver, const Duration(seconds: 1)),
+            1,
+            reason: 'the backoff resumes once the position is quiet',
+          );
+
+          loop.stop();
+        },
+      );
+    });
   });
 }

--- a/test/features/player/presentation/widgets/youtube_video_poster_test.dart
+++ b/test/features/player/presentation/widgets/youtube_video_poster_test.dart
@@ -29,20 +29,44 @@ void main() {
       expect(find.byType(Image), findsNothing);
     });
 
-    testWidgets('renders SizedBox.shrink when visible is false', (
-      tester,
-    ) async {
+    testWidgets('fades out over 220ms before leaving the tree', (tester) async {
+      // Issue #662: `visible: false` used to return SizedBox.shrink()
+      // directly, so the AnimatedOpacity was replaced before it could animate
+      // to 0 — the fade-out was dead code.
+      var visible = true;
+      late StateSetter setVisible;
+
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Scaffold(
-            body: YoutubeVideoPoster(
-              primaryUrl: 'https://example.com/thumb.jpg',
-              visible: false,
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                setVisible = setState;
+                return YoutubeVideoPoster(
+                  primaryUrl: 'https://example.com/thumb.jpg',
+                  visible: visible,
+                );
+              },
             ),
           ),
         ),
       );
+      await tester.pump();
+      expect(find.byType(AnimatedOpacity), findsOneWidget);
 
+      setVisible(() => visible = false);
+      await tester.pump();
+
+      // Mid-fade: still mounted, on its way to transparent.
+      final opacity = tester
+          .widget<AnimatedOpacity>(find.byType(AnimatedOpacity))
+          .opacity;
+      expect(opacity, 0, reason: 'the fade target is fully transparent');
+      expect(find.byType(Image), findsOneWidget);
+
+      // After the fade the poster leaves the tree instead of painting an
+      // invisible image forever.
+      await tester.pumpAndSettle();
       expect(find.byType(Image), findsNothing);
     });
 

--- a/test/features/player/youtube_page_inject_test.dart
+++ b/test/features/player/youtube_page_inject_test.dart
@@ -83,4 +83,100 @@ void main() {
       expect(enforceBody, contains('disableYoutubeCaptions();'));
     });
   });
+
+  // Issue #662: the enforcement used to be a `setInterval(enforce, 300)`
+  // rewrite of ~40 !important properties over a DOM that settles a second
+  // after load. These pin the replacement — reactive enforcement with a
+  // write-once early exit — and the invariants the rewrite must not lose.
+  group('kYoutubeMobileWatchInjectScript enforcement cadence', () {
+    final script = kYoutubeMobileWatchInjectScript;
+
+    test('does not rewrite the layout on a 300 ms interval', () {
+      expect(script, isNot(contains('setInterval(enforce,300)')));
+      // The only interval left is the documented safety net. setup()'s
+      // `setTimeout(setup,300)` retry is not an interval.
+      expect(RegExp(r'setInterval\(').allMatches(script), hasLength(1));
+      expect(script, contains('setInterval(enforce,1000)'));
+    });
+
+    test('re-enforces reactively from a MutationObserver', () {
+      expect(script, contains('new MutationObserver(scheduleEnforce)'));
+      // Structural churn anywhere in the document: injected overlays, caption
+      // windows, a rebuilt player, new siblings for the ancestor scan.
+      expect(script, contains('childList:true,subtree:true'));
+      // Attribute churn on the pinned elements only — subtree:false keeps the
+      // per-frame progress-bar/spinner style writes from scheduling sweeps.
+      expect(script, contains("attributeFilter:['class','style']"));
+      expect(script, contains('function observeLayoutTargets()'));
+      // The observer follows a video swap onto the new element.
+      final enforceBody = script.substring(
+        script.indexOf('function enforce(){'),
+        script.indexOf('function setup(){'),
+      );
+      expect(enforceBody, contains('observeLayoutTargets();'));
+    });
+
+    test('coalesces a mutation burst into a single sweep', () {
+      expect(script, contains('function scheduleEnforce()'));
+      expect(script, contains('if(enforcePending||reloading) return;'));
+    });
+
+    test('each element is written at most once (bounded invocations)', () {
+      // The write-once guard is what bounds a reactive sweep: a stamped
+      // element costs one sentinel property read per sweep, not a re-write of
+      // its whole block. `mark` is the sentinel — it also lets a sweep notice
+      // a block the page overwrote and re-assert it once.
+      expect(script, contains('function styleOnce(el,props,mark)'));
+      expect(script, contains('if(el[STAMP]){\n      if(!mark) return;'));
+      expect(
+        RegExp(r'getPropertyValue\(mark\)').allMatches(script),
+        hasLength(1),
+      );
+      expect(RegExp(r'function styleOnce\(').allMatches(script), hasLength(1));
+      // The only `setProperty` in the script is the one inside that guard — a
+      // write outside it would reintroduce an unbounded rewrite path.
+      final styleOnceBody = script.substring(
+        script.indexOf('function styleOnce('),
+        script.indexOf('  // Re-apply inline hide'),
+      );
+      expect(
+        RegExp(r'\.style\.setProperty\(').allMatches(script),
+        hasLength(1),
+      );
+      expect(styleOnceBody, contains('.style.setProperty('));
+      // The heavy layout pass is a separate function the sweep calls.
+      expect(script, contains('function applyLayout()'));
+      expect(script, contains('applyLayout();'));
+    });
+
+    test(
+      'ad transitions are derived from the observer, not a poll cadence',
+      () {
+        // `ad-showing` is a class on the player container, which the attribute
+        // observation covers — so the ad-reload flow no longer depends on a
+        // 300 ms class check.
+        expect(script, contains("player.classList.contains('ad-showing')"));
+        // ...and the reload flow it drives is intact, including the position
+        // hand-off. `timeupdate` keeps `savedTime` fresh now that the interval
+        // that sampled it is gone — but it must stay page-local, so it is NOT
+        // in the `events` array the Dart transport switch consumes.
+        expect(script, contains("callHandler('onAdReload',savedTime)"));
+        expect(script, contains("video.addEventListener('timeupdate'"));
+        final eventsArray = RegExp(
+          r'var events=\[([^\]]*)\]',
+        ).firstMatch(script)!.group(1)!;
+        expect(eventsArray, isNot(contains('timeupdate')));
+      },
+    );
+
+    test(
+      'single-inject guard, focus pin and syncState hand-off are intact',
+      () {
+        expect(script, contains('if(window.__enjoyYtMwc){return;}'));
+        expect(script, contains('document.hasFocus=function(){return true;}'));
+        expect(script, contains('function syncState(video)'));
+        expect(script, contains('setTimeout(function(){syncState(v);},200);'));
+      },
+    );
+  });
 }

--- a/test/features/player/youtube_player_engine_test.dart
+++ b/test/features/player/youtube_player_engine_test.dart
@@ -7,6 +7,7 @@ import 'package:enjoy_player/features/player/application/engines/youtube/youtube
 import 'package:enjoy_player/features/player/domain/playable_source.dart';
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugDefaultTargetPlatformOverride;
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -403,6 +404,83 @@ void main() {
       session.resetForClear();
       expect(session.userPlayInFlight, isFalse);
       expect(session.lastAutoPlayRetryAt, isNull);
+    });
+  });
+
+  group('YoutubePlayerEngine video stage poster gating (issue #662)', () {
+    // buildVideoStage mounts the WebView host only when the session asked for
+    // a mount, so these drive the transport latches directly and never mount
+    // a surface (no InAppWebView backend in a unit test).
+    Future<void> pumpStage(
+      WidgetTester tester,
+      YoutubePlayerEngine engine,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => engine.buildVideoStage(
+                context: context,
+                maxWidth: 320,
+                maxHeight: 180,
+              ),
+            ),
+          ),
+        ),
+      );
+      // Past the poster's 220 ms fade-out, so a hidden poster has actually
+      // left the tree rather than sitting there at opacity 0.
+      await tester.pump(const Duration(milliseconds: 250));
+    }
+
+    testWidgets('buffers before first playing onto the poster', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final session = YoutubeSession();
+      final engine = YoutubePlayerEngine(session: session);
+      try {
+        session.resetForOpen('abc12345678');
+        engine.setPosterUrl('https://example.com/thumb.jpg');
+        await pumpStage(tester, engine);
+
+        expect(find.byType(Image), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+      await engine.dispose();
+    });
+
+    testWidgets('a mid-playback stall shows a spinner, never the poster', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final session = YoutubeSession();
+      final engine = YoutubePlayerEngine(session: session);
+      try {
+        session.resetForOpen('abc12345678');
+        engine.setPosterUrl('https://example.com/thumb.jpg');
+        await pumpStage(tester, engine);
+        expect(find.byType(Image), findsOneWidget);
+
+        // The wiring YoutubeWebViewEvents uses on a DOM `playing`: confirm,
+        // mark first playing, then clear buffering.
+        session.notePlayingConfirmed();
+        session.markFirstPlayingLogged();
+        session.emitBuffering(false);
+        await pumpStage(tester, engine);
+        expect(find.byType(Image), findsNothing);
+
+        // A `waiting` mid-playback used to fade the static thumbnail back
+        // OVER the live video.
+        session.emitBuffering(true);
+        await pumpStage(tester, engine);
+
+        expect(find.byType(Image), findsNothing);
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+      await engine.dispose();
     });
   });
 


### PR DESCRIPTION
## What / why

- **Watch inject: observer-driven enforcement.** The page script re-applied ~40 `!important` inline properties, a caption `querySelectorAll` sweep and the ancestor sibling scan every 300 ms for as long as the document lived — continuous style + layout invalidation inside the WebView against a DOM that settles a second after load. The heavy pass now runs once per DOM shape and is re-run reactively: a `MutationObserver` on the document subtree for structural churn, plus `class`/`style` attributes on the player container, the `<video>` and the mid wrappers. Each element carries a write-once stamp with one sentinel property read per sweep, so a settled DOM costs reads instead of writes. Bursts coalesce into one sweep per 50 ms.
- **Poster no longer covers a playing video, and its fade actually runs.** The poster was keyed to the buffering stream, so every mid-playback `waiting` faded the static thumbnail over the live frame; `visible: false` also returned `SizedBox.shrink()` before `AnimatedOpacity` could animate to 0, making the 220 ms fade-out dead code. The poster is now a "playback never started" affordance keyed to the session's first-playing latch (`loggedFirstPlaying`), a stall after playback gets a small centered spinner on a light scrim instead, and the poster fades out before leaving the tree (kept the animation — it is still the pre-first-frame path).
- **Poll loop idles while paused.** `Timer.periodic` at 250 ms ran indefinitely after a confirmed pause; shadow reading pauses a lot, and every tick is a JS evaluation inside the WebView. The loop is now a one-shot timer chain that re-arms *before* each read — so the cadence stays independent of read latency and the issue #655 in-flight guard keeps its meaning — and backs off to 1 s once a pause is **confirmed** and the position is quiet. `start()` restores the 250 ms cadence on every play intent or state transition, and a seek-while-paused un-quiets it.

Behaviour preserved in the inject: the `window.__enjoyYtMwc` single-inject guard, the focus pin, caption suppression (CSS + textTracks + player API), the ad-transition reload flow (`onAdReload` + `location.href` position hand-off, now derived from the observer's class record on the player instead of a poll tick), and the video-swap `syncState` hand-off.

## Test plan

- [x] `flutter analyze` — no new findings (the 5 remaining infos are pre-existing on `main`)
- [x] `flutter test test/features/player/application/engines/youtube` + inject/contract/engine/poster dirs — 167 passing
- [x] `flutter test test/features/player` — 702 passing
- [x] New inject tests pin the cadence: no `setInterval(enforce,300)`, one `MutationObserver` driving `enforce`, `subtree:false` attribute watching on the pinned elements only, a single `setProperty` call site inside the write-once guard, `timeupdate` kept out of the Dart `events` array
- [x] New poll-loop cadence tests (fake-async): 8 reads / 2 s while playing, 2 reads / 2 s on a confirmed quiet pause, never backed off before a pause is confirmed, `start()` restores the fast cadence, a seek un-quiets then re-settles
- [x] New engine widget tests: buffering before first playing shows the poster with no spinner; a mid-playback stall shows the spinner and no poster; poster widget test covers the now-live 220 ms fade-out
- [x] Executed the real injected script against a throwaway fake-DOM harness: 0 style writes over 6 s of settled idling (660 before, from the 300 ms rewrite), injected caption nodes hidden, an in-place inline restyle of a stamped caption/sibling repaired exactly once, video swap handed off, ad start → no reload / ad end → `onAdReload(42.7)` + `watch?v=…&t=42s` + `waiting`

Fixes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
