### PR TITLE
ci: restore green main — stale codegen, formatter skew, analyzer infos, flaky SDK setup

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -1,0 +1,97 @@
+name: Setup Android SDK
+description: >-
+  Install Android cmdline-tools and the requested SDK packages with retries.
+  android-actions/setup-android fails the job outright when the flaky
+  self-hosted network cannot fetch the dl.google.com package manifests
+  ("IO exception while downloading manifest" → "Failed to find package"),
+  which is transient: the same runner succeeds on the next run. This wrapper
+  tolerates the bootstrap failure and retries the package install with
+  backoff; once the packages persist on the runner's local disk, later runs
+  skip the network entirely.
+
+inputs:
+  packages:
+    description: >-
+      SDK packages to install, e.g. "platforms;android-36 build-tools;36.0.0"
+      (same package ids sdkmanager takes, separated by whitespace).
+    required: true
+  cmdline-tools-version:
+    description: cmdline-tools version passed to android-actions/setup-android.
+    required: false
+    default: "12266719"
+  attempts:
+    description: sdkmanager install attempts before the step fails.
+    required: false
+    default: "5"
+
+runs:
+  using: composite
+  steps:
+    - name: Bootstrap SDK (manifest fetch may flake; retried below)
+      uses: android-actions/setup-android@v3
+      continue-on-error: true
+      with:
+        packages: ${{ inputs.packages }}
+        cmdline-tools-version: ${{ inputs.cmdline-tools-version }}
+        accept-android-sdk-licenses: true
+        log-accepted-android-sdk-licenses: true
+
+    - name: Install SDK packages (retry on flaky dl.google.com)
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+        ATTEMPTS: ${{ inputs.attempts }}
+      run: |
+        set -euo pipefail
+
+        # The bootstrap step exports ANDROID_HOME only when it fully succeeds;
+        # fall back to its documented default location so a flaky bootstrap
+        # that still installed cmdline-tools does not strand us.
+        sdk="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/.android/sdk}}"
+        echo "ANDROID_HOME=$sdk" >> "$GITHUB_ENV"
+        echo "ANDROID_SDK_ROOT=$sdk" >> "$GITHUB_ENV"
+
+        sdkmanager_bin=""
+        for cand in "$sdk/cmdline-tools/latest/bin/sdkmanager" \
+          "$sdk"/cmdline-tools/*/bin/sdkmanager; do
+          if [ -x "$cand" ]; then sdkmanager_bin="$cand"; break; fi
+        done
+        if [ -z "$sdkmanager_bin" ]; then
+          echo "::error::sdkmanager not found under $sdk/cmdline-tools — the bootstrap step failed before installing cmdline-tools"
+          exit 1
+        fi
+
+        # Package id → directory: "platforms;android-36" is installed at
+        # "$sdk/platforms/android-36", "build-tools;36.0.0" likewise.
+        missing=()
+        for pkg in $PACKAGES; do
+          dir="$sdk/$(printf '%s' "$pkg" | tr ';' '/')"
+          if [ -d "$dir" ]; then
+            echo "SDK package present: $pkg"
+          else
+            missing+=("$pkg")
+          fi
+        done
+        if [ "${#missing[@]}" -eq 0 ]; then
+          echo "setup-android: all requested SDK packages already installed."
+          exit 0
+        fi
+        echo "setup-android: installing missing SDK packages: ${missing[*]}"
+
+        max="${ATTEMPTS:-5}"
+        for attempt in $(seq 1 "$max"); do
+          # License acceptance needs the remote manifest too, so only run it
+          # when no accepted licenses are on disk yet.
+          if [ ! -d "$sdk/licenses" ] || [ -z "$(ls -A "$sdk/licenses" 2>/dev/null)" ]; then
+            yes | "$sdkmanager_bin" --licenses >/dev/null || true
+          fi
+          if "$sdkmanager_bin" --install "${missing[@]}"; then
+            echo "setup-android: SDK packages installed (attempt $attempt/$max)."
+            exit 0
+          fi
+          echo "::warning::sdkmanager install failed (attempt $attempt/$max) — flaky dl.google.com fetch; retrying in $((attempt * 15))s"
+          sleep "$((attempt * 15))"
+        done
+
+        echo "::error::sdkmanager could not install ${missing[*]} after $max attempts"
+        exit 1

--- a/.github/scripts/check_dart_format.sh
+++ b/.github/scripts/check_dart_format.sh
@@ -28,6 +28,7 @@ if ! dart format --output=none --set-exit-if-changed "${paths[@]}"; then
   echo "check_dart_format: sources need formatting." >&2
   echo "  Fix with: bash .github/scripts/check_dart_format.sh --fix" >&2
   echo "  Then stage the reformatted files." >&2
+  echo "  Local formatter: $(dart --version 2>&1). CI formats with the Flutter pinned in .github/flutter-version — formatter releases can disagree, so reformat with that SDK if this passes locally but fails CI." >&2
   exit 1
 fi
 

--- a/.github/workflows/android_apk_smoke.yml
+++ b/.github/workflows/android_apk_smoke.yml
@@ -13,6 +13,7 @@ on:
       - "tool/prefetch_media_kit_android_libs.sh"
       - ".github/flutter-version"
       - ".github/actions/setup-flutter/**"
+      - ".github/actions/setup-android/**"
       - ".github/scripts/ensure_linux_tooling.sh"
       - ".github/workflows/android_apk_smoke.yml"
   push:
@@ -30,6 +31,10 @@ permissions:
 jobs:
   apk:
     runs-on: [self-hosted, Linux]
+    # Successful runs land in 11–23 min; 45 min absorbs the setup-android
+    # retry backoff without letting a hung dl.google.com fetch hold the
+    # runner forever (self-hosted jobs have no default timeout).
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 
@@ -40,7 +45,7 @@ jobs:
 
       - uses: ./.github/actions/setup-flutter
 
-      - uses: android-actions/setup-android@v3
+      - uses: ./.github/actions/setup-android
         with:
           packages: >-
             platforms;android-36

--- a/.github/workflows/android_apk_smoke.yml
+++ b/.github/workflows/android_apk_smoke.yml
@@ -11,6 +11,7 @@ on:
       - "android/**"
       - "tool/patch_agp9_pub_plugins.sh"
       - "tool/prefetch_media_kit_android_libs.sh"
+      - "tool/prefetch_sqlite3_libs.sh"
       - ".github/flutter-version"
       - ".github/actions/setup-flutter/**"
       - ".github/actions/setup-android/**"
@@ -64,6 +65,12 @@ jobs:
 
       - name: Prefetch media_kit Android native libs
         run: bash tool/prefetch_media_kit_android_libs.sh
+
+      # The sqlite3 build hook downloads libsqlite3.so from GitHub Releases
+      # with no retries; a blip there kills the whole gradle build
+      # ("Target dart_build failed"). Prefetch like release_android.sh does.
+      - name: Prefetch sqlite3 Android native libs
+        run: bash tool/prefetch_sqlite3_libs.sh
 
       - name: Flutter build apk (debug)
         run: flutter build apk --debug --flavor store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ permissions:
 jobs:
   analyze-test:
     runs-on: [self-hosted, Linux]
+    # Format/analyze run in minutes; the covered app suite plus path-package
+    # suites land well under half an hour. 60 min only bites when a hung
+    # network or test process stalls the job (self-hosted has no default
+    # timeout).
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release_android.yml
+++ b/.github/workflows/release_android.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: ./.github/actions/setup-flutter
 
-      - uses: android-actions/setup-android@v3
+      - uses: ./.github/actions/setup-android
         with:
           packages: >-
             platforms;android-36

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ dart run build_runner build
 bash .github/scripts/check_codegen_drift.sh --fix
 ```
 
-Never hand-edit `*.g.dart` / `*.freezed.dart`. A source change without regenerating the matching generated file fails the **Codegen drift** workflow.
+Never hand-edit `*.g.dart` / `*.freezed.dart`. A source change without regenerating the matching generated file fails the **Codegen drift** workflow — and a stale generated file that lands on `main` blocks every subsequent PR with the same drift (riverpod neighbour hashes cascade, so one forgotten regeneration turns into a red `*.g.dart` for unrelated providers too). Never merge with a red Codegen drift run; fix forward by regenerating in the **main checkout** (not an agent worktree — `build_runner` deletes checked-in generated files there).
 
 ## Verification
 

--- a/docs/ci-self-hosted-runners.md
+++ b/docs/ci-self-hosted-runners.md
@@ -9,6 +9,7 @@ Shared workflow pieces:
 | Path | Purpose |
 |------|---------|
 | [`.github/actions/setup-flutter`](../.github/actions/setup-flutter) | Install/pin Flutter from [`.github/flutter-version`](../.github/flutter-version). Installs into a persistent, version-keyed directory on the runner's local disk and **skips the download entirely** when that version is already present — no `subosito/flutter-action` cache, no GitHub cache API. Reinstalls if the cached tree is missing `bin/flutter` or a working `.git` (required by `flutter --version`). |
+| [`.github/actions/setup-android`](../.github/actions/setup-android) | Wrap `android-actions/setup-android` with retries: the upstream action fails the job when the flaky network cannot fetch dl.google.com package manifests; the wrapper tolerates that, retries the `sdkmanager` install with backoff, and skips the network entirely once the requested packages persist on the runner. |
 | [`.github/actions/setup-macos-runner-env`](../.github/actions/setup-macos-runner-env) | Homebrew PATH, UTF-8 locale, curl HTTP/1.1, `GIT_CONFIG_COUNT=0` (SwiftPM-safe) |
 | [`.github/scripts/apple_spm_hygiene.sh`](../.github/scripts/apple_spm_hygiene.sh) | Host lock + SPM cache clear + retry helpers for Apple CI/release |
 | [`.github/scripts/ensure_linux_tooling.sh`](../.github/scripts/ensure_linux_tooling.sh) | Install apt packages only when missing. On the shared gh-sr agentic pool these are now normally baked into the container image (see below), so this is usually a fast no-op. |

--- a/lib/core/routing/app_router.g.dart
+++ b/lib/core/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'7befb7a06bbc6fd847ab2fc503ff2abc55b4279b';
+String _$appRouterHash() => r'f860d4558b50cd40c408bcac072e93253de23cd2';

--- a/lib/features/player/application/player_controller.g.dart
+++ b/lib/features/player/application/player_controller.g.dart
@@ -11,7 +11,7 @@ part of 'player_controller.dart';
 /// Deterministic end-of-media completion loop (ADR-0044).
 ///
 /// Mirrors the generation-counter + single-flight pattern from
-/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// [SingleFlightGate]: the transport drives itself off
 /// `await`ed completion futures instead of polling the position stream, and
 /// every in-flight await captures a generation id so a stale completion from a
 /// previous media (or a duplicate `completed` event from mpv) is a no-op.
@@ -22,7 +22,7 @@ final playerControllerProvider = PlayerControllerProvider._();
 /// Deterministic end-of-media completion loop (ADR-0044).
 ///
 /// Mirrors the generation-counter + single-flight pattern from
-/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// [SingleFlightGate]: the transport drives itself off
 /// `await`ed completion futures instead of polling the position stream, and
 /// every in-flight await captures a generation id so a stale completion from a
 /// previous media (or a duplicate `completed` event from mpv) is a no-op.
@@ -31,7 +31,7 @@ final class PlayerControllerProvider
   /// Deterministic end-of-media completion loop (ADR-0044).
   ///
   /// Mirrors the generation-counter + single-flight pattern from
-  /// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+  /// [SingleFlightGate]: the transport drives itself off
   /// `await`ed completion futures instead of polling the position stream, and
   /// every in-flight await captures a generation id so a stale completion from a
   /// previous media (or a duplicate `completed` event from mpv) is a no-op.
@@ -62,12 +62,12 @@ final class PlayerControllerProvider
   }
 }
 
-String _$playerControllerHash() => r'8117ab2f35045b90b8cee1852f80664a709e81b1';
+String _$playerControllerHash() => r'863ed2ee58aea808668fc781c1c7220fa9185249';
 
 /// Deterministic end-of-media completion loop (ADR-0044).
 ///
 /// Mirrors the generation-counter + single-flight pattern from
-/// [EchoEnforcer._epoch] / [_openGeneration]: the transport drives itself off
+/// [SingleFlightGate]: the transport drives itself off
 /// `await`ed completion futures instead of polling the position stream, and
 /// every in-flight await captures a generation id so a stale completion from a
 /// previous media (or a duplicate `completed` event from mpv) is a no-op.

--- a/test/core/notices/app_notice_test.dart
+++ b/test/core/notices/app_notice_test.dart
@@ -183,13 +183,13 @@ void main() {
     ) async {
       tester.view.physicalSize = const Size(392.7 * 3, 850.9 * 3);
       tester.view.devicePixelRatio = 3;
-      tester.view.padding = FakeViewPadding(
+      tester.view.padding = const FakeViewPadding(
         left: 0,
         top: 72,
         right: 0,
         bottom: 102,
       );
-      tester.view.viewPadding = FakeViewPadding(
+      tester.view.viewPadding = const FakeViewPadding(
         left: 0,
         top: 72,
         right: 0,

--- a/test/core/theme/widgets/enjoy_bottom_nav_test.dart
+++ b/test/core/theme/widgets/enjoy_bottom_nav_test.dart
@@ -272,13 +272,13 @@ void main() {
       (tester) async {
         tester.view.physicalSize = const Size(392.7 * 3, 850.9 * 3);
         tester.view.devicePixelRatio = 3;
-        tester.view.padding = FakeViewPadding(
+        tester.view.padding = const FakeViewPadding(
           left: 0,
           top: 72,
           right: 0,
           bottom: 102,
         );
-        tester.view.viewPadding = FakeViewPadding(
+        tester.view.viewPadding = const FakeViewPadding(
           left: 0,
           top: 72,
           right: 0,

--- a/test/features/player/player_open_side_effects_test.dart
+++ b/test/features/player/player_open_side_effects_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:drift/native.dart';
 import 'package:enjoy_player/data/api/api_client.dart';
 import 'package:enjoy_player/data/api/services/recording_api.dart';

--- a/test/features/player/presentation/layouts/audio_player_layout_test.dart
+++ b/test/features/player/presentation/layouts/audio_player_layout_test.dart
@@ -55,20 +55,22 @@ void main() {
     );
   });
 
-  testWidgets('desktop adds a roomier top inset for optical balance', (
-    tester,
-  ) async {
-    await tester.pumpWidget(_wrap(transcript: const Text('body')));
-    await tester.pump();
+  testWidgets(
+    'desktop adds a roomier top inset for optical balance',
+    variant: TargetPlatformVariant.only(TargetPlatform.linux),
+    (tester) async {
+      await tester.pumpWidget(_wrap(transcript: const Text('body')));
+      await tester.pump();
 
-    final t = EnjoyThemeTokens.build(
-      ThemeData(brightness: Brightness.light).colorScheme,
-    );
-    expect(
-      _transcriptPadding(tester, 'body').padding,
-      EdgeInsets.fromLTRB(t.space12, t.space32, t.space12, t.space16),
-    );
-  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+      final t = EnjoyThemeTokens.build(
+        ThemeData(brightness: Brightness.light).colorScheme,
+      );
+      expect(
+        _transcriptPadding(tester, 'body').padding,
+        EdgeInsets.fromLTRB(t.space12, t.space32, t.space12, t.space16),
+      );
+    },
+  );
 
   testWidgets('mobile keeps compact top inset under the status-bar area', (
     tester,


### PR DESCRIPTION
## Summary

Main CI has been red since 08-29 09:25 (PR #644). Four independent failures stacked up:

1. **Codegen drift (every run since #681):** #681 renamed `EchoEnforcer` → `SingleFlightGate` in `player_controller.dart` but landed without regenerating `player_controller.g.dart`. Its Codegen drift run failed and the PR merged anyway; riverpod neighbour hashes cascade, so `app_router.g.dart` drifted too and every subsequent PR inherited the same red. This PR commits the regenerated outputs — byte-identical to what CI's build_runner produces.
2. **Dart format (every run since #685):** `audio_player_layout_test.dart` formatted its `variant:` call the way dart 3.13 (authoring machine) wants, but CI pins dart 3.12 — and the two formatters each reformat the other's output for a 3-arg call with the closure in the middle (oscillation, verified with both SDKs). Reordered so the closure is the trailing argument; both formatters treat that as a fixed point; test semantics unchanged.
3. **flutter analyze (masked until now):** five fatal infos (`prefer_const_constructors` on `FakeViewPadding` ×4, unnecessary `dart:async`) waited behind the format failure.
4. **Android smoke (intermittent):** `android-actions/setup-android` died twice on flaky dl.google.com manifest fetches. New `.github/actions/setup-android` retries with backoff and skips the network once packages persist on the runner.

## Robustness hardening

- `timeout-minutes` on the self-hosted `analyze-test` (60) and `apk` (45) jobs — no default timeout there means a hung fetch holds the runner forever.
- `check_dart_format.sh` failure message now prints the local dart version + points at the pinned formatter, so the version-skew failure mode is diagnosable from the log.
- Docs: `setup-android` in the shared-pieces table; AGENTS.md records that a stale generated file cascades and must never be merged.

## Verification

- `dart format` (3.12.0 — CI's exact SDK, downloaded) and (3.13.2) both report the full tree clean
- `flutter analyze` clean; full `flutter test --coverage`: 5949 passed, coverage gate 70.27% ≥ 32%
- pre-push hook (format + codegen drift) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)