### PR TITLE
feat(credits): show usedBefore in usage records

### DIFF
--- a/lib/features/credits/presentation/credits_usage_screen.dart
+++ b/lib/features/credits/presentation/credits_usage_screen.dart
@@ -556,6 +556,10 @@ class _UsageTable extends StatelessWidget {
         DataColumn(label: Text(l10n.creditsUsageTableService)),
         DataColumn(label: Text(l10n.creditsUsageTableTier)),
         DataColumn(numeric: true, label: Text(l10n.creditsUsageTableRequired)),
+        DataColumn(
+          numeric: true,
+          label: Text(l10n.creditsUsageTableUsedBefore),
+        ),
         DataColumn(numeric: true, label: Text(l10n.creditsUsageTableUsedAfter)),
         DataColumn(label: Text(l10n.creditsUsageTableStatus)),
       ],
@@ -579,6 +583,7 @@ class _UsageTable extends StatelessWidget {
               DataCell(Text(serviceTypeLabel(l10n, log.serviceType))),
               DataCell(Text(log.tier)),
               DataCell(Text('${log.creditsRequired}')),
+              DataCell(Text('${log.usedBefore}')),
               DataCell(Text('${log.usedAfter}')),
               DataCell(
                 Text(
@@ -682,6 +687,21 @@ class _UsageLogCard extends StatelessWidget {
                     ),
                     SizedBox(height: t.space4),
                     Text('${log.creditsRequired}', style: numberStyle),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.creditsUsageTableUsedBefore,
+                      style: tt.labelSmall?.copyWith(
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                    SizedBox(height: t.space4),
+                    Text('${log.usedBefore}', style: numberStyle),
                   ],
                 ),
               ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1054,6 +1054,7 @@
   "creditsUsageTableService": "Service",
   "creditsUsageTableTier": "Tier",
   "creditsUsageTableRequired": "Required",
+  "creditsUsageTableUsedBefore": "Used before",
   "creditsUsageTableUsedAfter": "Used after",
   "creditsUsageTableStatus": "Status",
   "creditsUsageAllowed": "Allowed",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3525,6 +3525,12 @@ abstract class AppLocalizations {
   /// **'Required'**
   String get creditsUsageTableRequired;
 
+  /// No description provided for @creditsUsageTableUsedBefore.
+  ///
+  /// In en, this message translates to:
+  /// **'Used before'**
+  String get creditsUsageTableUsedBefore;
+
   /// No description provided for @creditsUsageTableUsedAfter.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1889,6 +1889,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get creditsUsageTableRequired => 'Required';
 
   @override
+  String get creditsUsageTableUsedBefore => 'Used before';
+
+  @override
   String get creditsUsageTableUsedAfter => 'Used after';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1807,6 +1807,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get creditsUsageTableRequired => '需要';
 
   @override
+  String get creditsUsageTableUsedBefore => '用前';
+
+  @override
   String get creditsUsageTableUsedAfter => '用后';
 
   @override
@@ -5128,6 +5131,9 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get creditsUsageTableRequired => '需要';
+
+  @override
+  String get creditsUsageTableUsedBefore => '用前';
 
   @override
   String get creditsUsageTableUsedAfter => '用后';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -791,6 +791,7 @@
   "creditsUsageTableService": "服务",
   "creditsUsageTableTier": "档位",
   "creditsUsageTableRequired": "需要",
+  "creditsUsageTableUsedBefore": "用前",
   "creditsUsageTableUsedAfter": "用后",
   "creditsUsageTableStatus": "状态",
   "creditsUsageAllowed": "允许",

--- a/lib/l10n/app_zh_CN.arb
+++ b/lib/l10n/app_zh_CN.arb
@@ -632,6 +632,7 @@
   "creditsUsageTableService": "服务",
   "creditsUsageTableTier": "档位",
   "creditsUsageTableRequired": "需要",
+  "creditsUsageTableUsedBefore": "用前",
   "creditsUsageTableUsedAfter": "用后",
   "creditsUsageTableStatus": "状态",
   "creditsUsageAllowed": "允许",

--- a/test/data/files/ffmpeg_media_probe_test.dart
+++ b/test/data/files/ffmpeg_media_probe_test.dart
@@ -219,9 +219,12 @@ Stream #0:5(en): Subtitle: subrip
       expect(shellEscape('/tmp/has space.wav'), '"/tmp/has space.wav"');
     });
 
-    test('wraps paths containing a double quote in double quotes and escapes it', () {
-      expect(shellEscape(r'/tmp/odd"name.wav'), r'"/tmp/odd\"name.wav"');
-    });
+    test(
+      'wraps paths containing a double quote in double quotes and escapes it',
+      () {
+        expect(shellEscape(r'/tmp/odd"name.wav'), r'"/tmp/odd\"name.wav"');
+      },
+    );
 
     test('wraps paths containing both space and quote', () {
       expect(shellEscape(r'/tmp/a "b".wav'), r'"/tmp/a \"b\".wav"');

--- a/test/features/credits/presentation/credits_usage_screen_test.dart
+++ b/test/features/credits/presentation/credits_usage_screen_test.dart
@@ -157,6 +157,10 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.byType(CreditsUsageScreen), findsOneWidget);
+    // Required / usedBefore / usedAfter columns all render their values.
+    expect(find.text('10'), findsOneWidget);
+    expect(find.text('100'), findsOneWidget);
+    expect(find.text('110'), findsOneWidget);
   });
 
   testWidgets('error state shows retry button', (tester) async {


### PR DESCRIPTION
## Summary
- Usage audit rows only displayed **Required** and **Used after**, even though `CreditsUsageLog` already parses `usedBefore` — confusing when reconciling balance changes.
- Add a **Used before** numeric column to the wide `DataTable`, and a third stat (Required / Used before / Used after) to the narrow `_UsageLogCard`.
- New l10n key `creditsUsageTableUsedBefore` (en: "Used before", zh/zh_CN: "用前"), regenerated localizations.
- Screen test now asserts all three values (`10` / `100` / `110`) actually render.
- Separate commit reformats `ffmpeg_media_probe_test.dart` (dart 3.13 local formatter vs 3.12 CI skew) — required by the pre-push format check, no behavior change.

## Test plan
- [x] `flutter test test/features/credits/presentation/credits_usage_screen_test.dart` — 10/10 pass
- [x] `flutter analyze` clean on changed files
- [x] `check_dart_format` ok locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)