### PR TITLE
fix(notices): keep the snackbar message at full width when it has an action

### DIFF
--- a/lib/core/notices/app_notice.dart
+++ b/lib/core/notices/app_notice.dart
@@ -90,7 +90,7 @@ abstract final class AppNotice {
       late final Color foregroundColor;
       late final IconData icon;
       late final Duration duration;
-      late final bool showCloseIcon;
+      late final bool wantsDismiss;
 
       switch (kind) {
         case _AppNoticeKind.success:
@@ -98,25 +98,25 @@ abstract final class AppNotice {
           foregroundColor = cs.onPrimaryContainer;
           icon = Icons.check_circle_rounded;
           duration = const Duration(seconds: 3);
-          showCloseIcon = false;
+          wantsDismiss = false;
         case _AppNoticeKind.error:
           backgroundColor = cs.errorContainer;
           foregroundColor = cs.onErrorContainer;
           icon = Icons.error_rounded;
           duration = const Duration(seconds: 5);
-          showCloseIcon = true;
+          wantsDismiss = true;
         case _AppNoticeKind.info:
           backgroundColor = cs.surfaceContainerHigh;
           foregroundColor = cs.onSurface;
           icon = Icons.info_rounded;
           duration = const Duration(seconds: 3);
-          showCloseIcon = false;
+          wantsDismiss = false;
         case _AppNoticeKind.warning:
           backgroundColor = cs.tertiaryContainer;
           foregroundColor = cs.onTertiaryContainer;
           icon = Icons.warning_rounded;
           duration = const Duration(seconds: 4);
-          showCloseIcon = true;
+          wantsDismiss = true;
       }
 
       if (kind == _AppNoticeKind.error || kind == _AppNoticeKind.warning) {
@@ -161,18 +161,31 @@ abstract final class AppNotice {
             borderRadius: BorderRadius.circular(radius),
           ),
           backgroundColor: backgroundColor,
-          showCloseIcon: showCloseIcon,
-          closeIconColor: foregroundColor,
+          // Both the action and the dismiss button are laid out by
+          // [_AppNoticeBody] instead of SnackBar's own slots: once the built-in
+          // action is wider than `actionOverflowThreshold` (25% of the bar by
+          // default) Flutter moves it onto its own row and still reserves 40%
+          // of the width beside the message, which squeezed the
+          // credits-exhausted copy into a ~60% column on phones.
+          showCloseIcon: false,
           duration: duration,
-          action: action,
+          // SnackBar infers `persist` from `action != null`; the action now
+          // lives in the body, so actionable notices opt in explicitly and keep
+          // waiting for the user instead of timing out.
+          persist: action != null,
           margin: EdgeInsets.fromLTRB(sideMargin, 0, sideMargin, bottomPad),
-          content: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(icon, color: foregroundColor, size: 22),
-              SizedBox(width: tokens?.space12 ?? 12),
-              Expanded(child: Text(message, style: textStyle)),
-            ],
+          content: _AppNoticeBody(
+            icon: icon,
+            message: message,
+            textStyle: textStyle,
+            foregroundColor: foregroundColor,
+            gap: tokens?.space12 ?? 12,
+            action: action,
+            onDismiss: wantsDismiss
+                ? () => m.hideCurrentSnackBar(
+                    reason: SnackBarClosedReason.dismiss,
+                  )
+                : null,
           ),
         ),
       );
@@ -197,5 +210,91 @@ abstract final class AppNotice {
       // No ProviderScope (e.g. isolated widget tests) — snackbar still shows.
       return null;
     }
+  }
+}
+
+/// Notice body: semantic icon, full-width message, and an optional trailing
+/// row with the action and the dismiss button.
+///
+/// Laid out here rather than through [SnackBar.action] /
+/// [SnackBar.showCloseIcon] so the message always owns the bar's full inner
+/// width — see the note in [AppNotice._show].
+class _AppNoticeBody extends StatelessWidget {
+  const _AppNoticeBody({
+    required this.icon,
+    required this.message,
+    required this.textStyle,
+    required this.foregroundColor,
+    required this.gap,
+    this.action,
+    this.onDismiss,
+  });
+
+  final IconData icon;
+  final String message;
+  final TextStyle? textStyle;
+  final Color foregroundColor;
+  final double gap;
+  final SnackBarAction? action;
+  final VoidCallback? onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = Theme.of(context).extension<EnjoyThemeTokens>();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: foregroundColor, size: 22),
+            SizedBox(width: gap),
+            Expanded(child: Text(message, style: textStyle)),
+          ],
+        ),
+        if (action != null || onDismiss != null)
+          Padding(
+            padding: EdgeInsets.only(top: tokens?.space4 ?? 4),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (action != null)
+                  // Flexible so a long localized label shrinks with the bar
+                  // instead of overflowing it; the dismiss button stays whole.
+                  Flexible(
+                    // Layout only: [SnackBarAction] resolves its own label
+                    // color and keeps its one-shot + auto-dismiss behaviour.
+                    // The horizontal padding replaces the margin SnackBar used
+                    // to add around its own action slot.
+                    child: TextButtonTheme(
+                      data: TextButtonThemeData(
+                        style: TextButton.styleFrom(
+                          padding: EdgeInsets.symmetric(
+                            horizontal: tokens?.space8 ?? 8,
+                          ),
+                        ),
+                      ),
+                      child: action!,
+                    ),
+                  ),
+                if (onDismiss != null)
+                  IconButton(
+                    tooltip: MaterialLocalizations.of(context).closeButtonLabel,
+                    onPressed: onDismiss,
+                    icon: const Icon(Icons.close),
+                    iconSize: 22,
+                    color: foregroundColor,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints.tightFor(
+                      width: 40,
+                      height: 40,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
   }
 }

--- a/lib/core/notices/app_notice.dart
+++ b/lib/core/notices/app_notice.dart
@@ -21,38 +21,47 @@ final GlobalKey<ScaffoldMessengerState> appScaffoldMessengerKey =
 
 enum _AppNoticeKind { success, error, info, warning }
 
+/// An action button rendered inside the notice body.
+///
+/// Deliberately not [SnackBarAction]: SnackBar's own action slot squeezes the
+/// message (see the note in [AppNotice._show]), and its label can neither
+/// ellipsize nor take the notice palette. The body renders the button itself;
+/// pressing it once fires [AppNoticeAction.onPressed] and dismisses the
+/// notice, like [SnackBarAction].
+typedef AppNoticeAction = ({String label, VoidCallback onPressed});
+
 /// Typed, theme-aware SnackBars for lightweight feedback.
 abstract final class AppNotice {
   static void success(
     BuildContext context,
     String message, {
-    SnackBarAction? action,
+    AppNoticeAction? action,
   }) => _show(context, _AppNoticeKind.success, message, action: action);
 
   static void error(
     BuildContext context,
     String message, {
-    SnackBarAction? action,
+    AppNoticeAction? action,
   }) => _show(context, _AppNoticeKind.error, message, action: action);
 
   static void info(
     BuildContext context,
     String message, {
-    SnackBarAction? action,
+    AppNoticeAction? action,
   }) => _show(context, _AppNoticeKind.info, message, action: action);
 
   /// Partial failures, warnings, or attention-worthy non-errors.
   static void warning(
     BuildContext context,
     String message, {
-    SnackBarAction? action,
+    AppNoticeAction? action,
   }) => _show(context, _AppNoticeKind.warning, message, action: action);
 
   static void _show(
     BuildContext context,
     _AppNoticeKind kind,
     String message, {
-    SnackBarAction? action,
+    AppNoticeAction? action,
   }) {
     if (!context.mounted) return;
     if (appScaffoldMessengerKey.currentState == null &&
@@ -84,7 +93,7 @@ abstract final class AppNotice {
 
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
-      final tokens = theme.extension<EnjoyThemeTokens>();
+      final tokens = EnjoyThemeTokens.of(context);
 
       late final Color backgroundColor;
       late final Color foregroundColor;
@@ -125,14 +134,14 @@ abstract final class AppNotice {
 
       final mq = MediaQuery.of(context);
       final shellExtra = RootShellBottomInset.clearanceOf(context);
-      final horizontal = tokens?.space16 ?? 16.0;
+      final horizontal = tokens.space16;
       // padding.bottom can exceed the physical safe inset when an ancestor
       // Scaffold reports an over-tall bottomNavigationBar (extendBody feeds
       // max(padding, bottomWidgetsHeight) into the body MediaQuery). Clamp to
       // viewPadding so a leaked inset can never push the notice off screen —
       // a floating SnackBar taller than the screen aborts every layout.
       final safeBottom = math.min(mq.padding.bottom, mq.viewPadding.bottom);
-      final bottomPad = safeBottom + shellExtra + (tokens?.space16 ?? 16.0);
+      final bottomPad = safeBottom + shellExtra + tokens.space16;
       final maxW = mq.size.width;
       final innerMax = math.max(0.0, maxW - horizontal * 2);
       final snackMaxWidth = maxW >= 600 && innerMax > 0
@@ -142,12 +151,26 @@ abstract final class AppNotice {
           ? math.max(horizontal, (maxW - snackMaxWidth) / 2)
           : horizontal;
 
-      final radius = tokens?.radiusXl ?? 16.0;
-      final elevation = tokens?.elevationSheet ?? 3.0;
+      final radius = tokens.radiusXl;
+      final elevation = tokens.elevationSheet;
 
       final textStyle = theme.textTheme.bodyMedium?.copyWith(
         color: foregroundColor,
       );
+
+      // One-shot like [SnackBarAction]: fire once, then dismiss.
+      var actionTriggered = false;
+      final bodyAction = action == null
+          ? null
+          : (
+              label: action.label,
+              onPressed: () {
+                if (actionTriggered) return;
+                actionTriggered = true;
+                action.onPressed();
+                m.hideCurrentSnackBar(reason: SnackBarClosedReason.action);
+              },
+            );
 
       // Park the permanent player surface while the snackbar is visible so
       // WebView2 / media_kit platform views cannot cover the notice (ADR-0066).
@@ -161,26 +184,27 @@ abstract final class AppNotice {
             borderRadius: BorderRadius.circular(radius),
           ),
           backgroundColor: backgroundColor,
-          // Both the action and the dismiss button are laid out by
-          // [_AppNoticeBody] instead of SnackBar's own slots: once the built-in
-          // action is wider than `actionOverflowThreshold` (25% of the bar by
-          // default) Flutter moves it onto its own row and still reserves 40%
-          // of the width beside the message, which squeezed the
-          // credits-exhausted copy into a ~60% column on phones.
-          showCloseIcon: false,
           duration: duration,
           // SnackBar infers `persist` from `action != null`; the action now
-          // lives in the body, so actionable notices opt in explicitly and keep
-          // waiting for the user instead of timing out.
+          // lives in the body, so actionable notices opt in explicitly and
+          // keep waiting for the user instead of timing out.
           persist: action != null,
           margin: EdgeInsets.fromLTRB(sideMargin, 0, sideMargin, bottomPad),
+          // The action and the dismiss button are laid out by
+          // [_AppNoticeBody] instead of SnackBar's own slots: once the
+          // built-in action is wider than `actionOverflowThreshold` (25% of
+          // the bar by default) Flutter moves it onto its own row and still
+          // reserves 40% of the width beside the message, which squeezed the
+          // credits-exhausted copy into a ~60% column on phones. Padding is
+          // owned here too, so the SDK's vertical padding wraps the message
+          // row only and never stacks around the trailing action row.
+          padding: EdgeInsets.symmetric(horizontal: tokens.space16),
           content: _AppNoticeBody(
             icon: icon,
             message: message,
             textStyle: textStyle,
             foregroundColor: foregroundColor,
-            gap: tokens?.space12 ?? 12,
-            action: action,
+            action: bodyAction,
             onDismiss: wantsDismiss
                 ? () => m.hideCurrentSnackBar(
                     reason: SnackBarClosedReason.dismiss,
@@ -213,8 +237,10 @@ abstract final class AppNotice {
   }
 }
 
-/// Notice body: semantic icon, full-width message, and an optional trailing
-/// row with the action and the dismiss button.
+/// Notice body: semantic icon and a full-width message. The dismiss button
+/// rides inline with the message while it is alone (SnackBar's own geometry),
+/// and moves into a trailing row beside the action otherwise — minus the 40%
+/// width reserve [SnackBar] hard-codes for overflowing actions.
 ///
 /// Laid out here rather than through [SnackBar.action] /
 /// [SnackBar.showCloseIcon] so the message always owns the bar's full inner
@@ -225,7 +251,6 @@ class _AppNoticeBody extends StatelessWidget {
     required this.message,
     required this.textStyle,
     required this.foregroundColor,
-    required this.gap,
     this.action,
     this.onDismiss,
   });
@@ -234,67 +259,71 @@ class _AppNoticeBody extends StatelessWidget {
   final String message;
   final TextStyle? textStyle;
   final Color foregroundColor;
-  final double gap;
-  final SnackBarAction? action;
+  final AppNoticeAction? action;
   final VoidCallback? onDismiss;
 
   @override
   Widget build(BuildContext context) {
-    final tokens = Theme.of(context).extension<EnjoyThemeTokens>();
+    final tokens = EnjoyThemeTokens.of(context);
+    final action = this.action;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Icon(icon, color: foregroundColor, size: 22),
-            SizedBox(width: gap),
-            Expanded(child: Text(message, style: textStyle)),
+            SizedBox(width: tokens.space12),
+            Expanded(
+              // Vertical rhythm matches SnackBar's own single-line padding, so
+              // a dismiss-only notice is exactly as tall as the default
+              // layout it replaced.
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                child: Text(message, style: textStyle),
+              ),
+            ),
+            if (action == null && onDismiss != null) _dismissButton(context),
           ],
         ),
-        if (action != null || onDismiss != null)
+        if (action != null)
           Padding(
-            padding: EdgeInsets.only(top: tokens?.space4 ?? 4),
+            padding: EdgeInsets.only(top: tokens.space4, bottom: 14),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                if (action != null)
-                  // Flexible so a long localized label shrinks with the bar
-                  // instead of overflowing it; the dismiss button stays whole.
-                  Flexible(
-                    // Layout only: [SnackBarAction] resolves its own label
-                    // color and keeps its one-shot + auto-dismiss behaviour.
-                    // The horizontal padding replaces the margin SnackBar used
-                    // to add around its own action slot.
-                    child: TextButtonTheme(
-                      data: TextButtonThemeData(
-                        style: TextButton.styleFrom(
-                          padding: EdgeInsets.symmetric(
-                            horizontal: tokens?.space8 ?? 8,
-                          ),
-                        ),
-                      ),
-                      child: action!,
+                // Flexible + maxLines so a long localized label ellipsizes
+                // instead of wrapping the button or overflowing the bar.
+                Flexible(
+                  child: TextButton(
+                    style: TextButton.styleFrom(
+                      foregroundColor: foregroundColor,
+                      padding: EdgeInsets.symmetric(horizontal: tokens.space8),
+                    ),
+                    onPressed: action.onPressed,
+                    child: Text(
+                      action.label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                if (onDismiss != null)
-                  IconButton(
-                    tooltip: MaterialLocalizations.of(context).closeButtonLabel,
-                    onPressed: onDismiss,
-                    icon: const Icon(Icons.close),
-                    iconSize: 22,
-                    color: foregroundColor,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                  ),
+                ),
+                if (onDismiss != null) _dismissButton(context),
               ],
             ),
           ),
       ],
     );
   }
+
+  /// Same affordance as SnackBar's built-in close icon: SDK semantics key,
+  /// 24dp glyph, `closeButtonTooltip`, and the default 48dp tap target.
+  Widget _dismissButton(BuildContext context) => IconButton(
+    key: StandardComponentType.closeButton.key,
+    tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+    onPressed: onDismiss,
+    icon: const Icon(Icons.close),
+    iconSize: 24,
+    color: foregroundColor,
+  );
 }

--- a/lib/features/ai/presentation/ai_playground_screen.dart
+++ b/lib/features/ai/presentation/ai_playground_screen.dart
@@ -84,14 +84,20 @@ class _AiPlaygroundScreenState extends ConsumerState<AiPlaygroundScreen> {
   void _maybePromptByokSettings(Object e) {
     if (e is! ByokNotConfiguredFailure || !mounted) return;
     final l10n = AppLocalizations.of(context)!;
-    // Shared notice instead of a raw SnackBar: keeps the message full width and
-    // the CTA styling consistent with every other AI error surface.
+    // Capture the router while this context is alive: actionable notices
+    // persist through the root messenger and can outlive this route, where a
+    // bare `context.push` would look up a deactivated element.
+    final router = GoRouter.of(context);
+    // Shared notice instead of a raw SnackBar: keeps the message full width
+    // and the CTA styling consistent with every other AI error surface. Like
+    // those surfaces, a warning intentionally replaces any visible/queued
+    // notice instead of stacking (FR-006).
     AppNotice.warning(
       context,
       formatByokNotConfiguredMessage(e, l10n),
-      action: SnackBarAction(
+      action: (
         label: l10n.settingsAiProvidersTileTitle,
-        onPressed: () => context.push(aiProvidersSettingsPath),
+        onPressed: () => router.push(aiProvidersSettingsPath),
       ),
     );
   }

--- a/lib/features/ai/presentation/ai_playground_screen.dart
+++ b/lib/features/ai/presentation/ai_playground_screen.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/errors/app_failure.dart';
 import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/features/ai/application/ai_byok_error_mapping.dart';
 import 'package:enjoy_player/features/ai/application/ai_modality_config_controller.dart';
 import 'package:enjoy_player/features/ai/application/ai_services.dart';
@@ -83,13 +84,14 @@ class _AiPlaygroundScreenState extends ConsumerState<AiPlaygroundScreen> {
   void _maybePromptByokSettings(Object e) {
     if (e is! ByokNotConfiguredFailure || !mounted) return;
     final l10n = AppLocalizations.of(context)!;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(formatByokNotConfiguredMessage(e, l10n)),
-        action: SnackBarAction(
-          label: l10n.settingsAiProvidersTileTitle,
-          onPressed: () => context.push(aiProvidersSettingsPath),
-        ),
+    // Shared notice instead of a raw SnackBar: keeps the message full width and
+    // the CTA styling consistent with every other AI error surface.
+    AppNotice.warning(
+      context,
+      formatByokNotConfiguredMessage(e, l10n),
+      action: SnackBarAction(
+        label: l10n.settingsAiProvidersTileTitle,
+        onPressed: () => context.push(aiProvidersSettingsPath),
       ),
     );
   }

--- a/lib/features/asr/presentation/asr_generation_launcher.dart
+++ b/lib/features/asr/presentation/asr_generation_launcher.dart
@@ -80,6 +80,9 @@ Future<void> launchAsrGeneration(
   } else if (job?.phase == AsrGenerationPhase.error) {
     final l10n = AppLocalizations.of(context)!;
     final failure = job!.creditsFailure;
+    // Router captured while the context is alive: the persisted notice
+    // can outlive this route (see AppNotice).
+    final router = GoRouter.of(context);
     AppNotice.error(
       context,
       // Numbered credits message when the 402 envelope was parsed (spec 045);
@@ -90,9 +93,9 @@ Future<void> launchAsrGeneration(
       // One-tap recovery rides only on credits failures (spec 045).
       action: failure == null
           ? null
-          : SnackBarAction(
+          : (
               label: creditsCtaLabel(l10n),
-              onPressed: () => context.push('/subscription'),
+              onPressed: () => router.push('/subscription'),
             ),
     );
   }

--- a/lib/features/craft/presentation/audio_stage.dart
+++ b/lib/features/craft/presentation/audio_stage.dart
@@ -13,6 +13,7 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
@@ -113,12 +114,9 @@ class _AudioStageState extends ConsumerState<AudioStage> {
     // the failure card will be shown by the build method instead.
     if (result == null) return;
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(AppLocalizations.of(context)!.craftSavedToLibrary),
-        behavior: SnackBarBehavior.floating,
-        duration: const Duration(seconds: 2),
-      ),
+    AppNotice.success(
+      context,
+      AppLocalizations.of(context)!.craftSavedToLibrary,
     );
     maybeShowCraftSolidTranscriptSttHint(
       context,

--- a/lib/features/craft/presentation/capture_stage.dart
+++ b/lib/features/craft/presentation/capture_stage.dart
@@ -15,6 +15,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 
 import 'package:enjoy_player/core/logging/log.dart';
+import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/features/craft/application/craft_controller.dart';
 import 'package:enjoy_player/features/craft/domain/craft_job_state.dart';
 import 'package:enjoy_player/features/craft/presentation/widgets/craft_failure_card.dart';
@@ -119,9 +120,7 @@ class _CaptureStageState extends ConsumerState<CaptureStage> {
     if (!granted) {
       _recordingPending = false;
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(l10n.craftRecordingMicDenied)));
+        AppNotice.warning(context, l10n.craftRecordingMicDenied);
       }
       return;
     }

--- a/lib/features/craft/presentation/craft_solid_transcript_stt_hint.dart
+++ b/lib/features/craft/presentation/craft_solid_transcript_stt_hint.dart
@@ -1,13 +1,14 @@
-/// Shows a once-per-session snackbar after Craft saves solid synthesis cues.
+/// Shows a once-per-session info notice after Craft saves solid synthesis cues.
 library;
 
 import 'package:flutter/material.dart';
 
+import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/features/craft/domain/craft_solid_transcript_hint_gate.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
 
 /// If [savedSolidTimeline] and the session gate allows, show a dismissible
-/// floating snackbar. Never starts ASR.
+/// info notice. Never starts ASR.
 void maybeShowCraftSolidTranscriptSttHint(
   BuildContext context, {
   required bool savedSolidTimeline,
@@ -19,11 +20,5 @@ void maybeShowCraftSolidTranscriptSttHint(
   final l10n = AppLocalizations.of(context);
   if (l10n == null) return;
 
-  ScaffoldMessenger.of(context).showSnackBar(
-    SnackBar(
-      content: Text(l10n.craftSolidTranscriptSttHint),
-      behavior: SnackBarBehavior.floating,
-      duration: const Duration(seconds: 5),
-    ),
-  );
+  AppNotice.info(context, l10n.craftSolidTranscriptSttHint);
 }

--- a/lib/features/pronounce/presentation/pronounce_icon_button.dart
+++ b/lib/features/pronounce/presentation/pronounce_icon_button.dart
@@ -100,14 +100,17 @@ class PronounceIconButton extends ConsumerWidget {
         AppNotice.info(context, l10n.pronounceSignInRequired);
       } on CreditsFailure catch (failure) {
         if (!context.mounted) return;
+        // Router captured while the context is alive: the persisted notice
+        // can outlive this route (see AppNotice).
+        final router = GoRouter.of(context);
         // Numbered message when the worker envelope was parsed (spec 045)
         // plus the one-tap recovery CTA; warning tone retained.
         AppNotice.warning(
           context,
           creditsFailureMessage(failure, l10n),
-          action: SnackBarAction(
+          action: (
             label: creditsCtaLabel(l10n),
-            onPressed: () => context.push('/subscription'),
+            onPressed: () => router.push('/subscription'),
           ),
         );
       } on AppFailure {

--- a/lib/features/shadow_reading/presentation/recording_assessment_flow.dart
+++ b/lib/features/shadow_reading/presentation/recording_assessment_flow.dart
@@ -122,6 +122,9 @@ Future<void> triggerRecordingAssessment({
       :final debugMessage,
       :final creditsFailure,
     ):
+      // Router captured while the context is alive: the persisted notice
+      // can outlive this route (see AppNotice).
+      final router = GoRouter.of(context);
       AppNotice.error(
         context,
         recordingAssessmentFailureMessage(
@@ -132,9 +135,9 @@ Future<void> triggerRecordingAssessment({
         ),
         // One-tap recovery rides only on the credits kind (spec 045).
         action: kind == RecordingAssessmentFailureKind.credits
-            ? SnackBarAction(
+            ? (
                 label: creditsCtaLabel(l10n),
-                onPressed: () => context.push('/subscription'),
+                onPressed: () => router.push('/subscription'),
               )
             : null,
       );

--- a/lib/features/subscription/presentation/credits_failure_actions.dart
+++ b/lib/features/subscription/presentation/credits_failure_actions.dart
@@ -48,12 +48,15 @@ String creditsCtaLabel(AppLocalizations l10n) =>
 /// one-tap CTA to the subscription screen (plans + credits packages).
 void showCreditsFailureNotice(BuildContext context, CreditsFailure failure) {
   final l10n = AppLocalizations.of(context)!;
+  // Router captured while the context is alive: the persisted notice
+  // can outlive the originating route (see AppNotice).
+  final router = GoRouter.of(context);
   AppNotice.error(
     context,
     creditsFailureMessage(failure, l10n),
-    action: SnackBarAction(
+    action: (
       label: creditsCtaLabel(l10n),
-      onPressed: () => context.push('/subscription'),
+      onPressed: () => router.push('/subscription'),
     ),
   );
 }

--- a/lib/features/vocabulary/presentation/vocabulary_review_session_screen.dart
+++ b/lib/features/vocabulary/presentation/vocabulary_review_session_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/interaction/enjoy_tappable.dart';
+import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/routing/player_navigation.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/typography.dart';
@@ -105,9 +106,7 @@ class _VocabularyReviewSessionScreenState
 
     final ctx = ref.read(vocabularyReviewSessionProvider).currentPrimaryContext;
     if (ctx == null || !vocabularyContextSupportsMediaActions(ctx)) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l10n.vocabularyMediaOpenFailed)));
+      AppNotice.error(context, l10n.vocabularyMediaOpenFailed);
       return;
     }
 

--- a/lib/features/vocabulary/presentation/vocabulary_screen.dart
+++ b/lib/features/vocabulary/presentation/vocabulary_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:enjoy_player/core/layout/enjoy_page_kind.dart';
+import 'package:enjoy_player/core/notices/app_notice.dart';
 import 'package:enjoy_player/core/theme/enjoy_tokens.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_button.dart';
 import 'package:enjoy_player/core/theme/widgets/enjoy_card.dart';
@@ -216,10 +217,9 @@ class _ReviewTab extends ConsumerWidget {
         .start(options);
     if (!context.mounted) return;
     if (!started) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context)!.vocabularyEmptyQueue),
-        ),
+      AppNotice.info(
+        context,
+        AppLocalizations.of(context)!.vocabularyEmptyQueue,
       );
       return;
     }

--- a/test/core/notices/app_notice_test.dart
+++ b/test/core/notices/app_notice_test.dart
@@ -64,7 +64,10 @@ void main() {
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
       final scheme = Theme.of(ctx).colorScheme;
       expect(snackBar.backgroundColor, scheme.errorContainer);
-      expect(snackBar.showCloseIcon, isTrue);
+      expect(find.byIcon(Icons.error_rounded), findsOneWidget);
+      // Dismiss affordance is rendered by the notice body, not SnackBar's slot.
+      expect(snackBar.showCloseIcon, isFalse);
+      expect(find.byIcon(Icons.close), findsOneWidget);
     });
 
     testWidgets('info uses surfaceContainerHigh without close icon', (
@@ -82,6 +85,7 @@ void main() {
       final scheme = Theme.of(ctx).colorScheme;
       expect(snackBar.backgroundColor, scheme.surfaceContainerHigh);
       expect(snackBar.showCloseIcon, isFalse);
+      expect(find.byIcon(Icons.close), findsNothing);
     });
 
     testWidgets('warning uses tertiaryContainer with close icon', (
@@ -98,7 +102,8 @@ void main() {
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
       final scheme = Theme.of(ctx).colorScheme;
       expect(snackBar.backgroundColor, scheme.tertiaryContainer);
-      expect(snackBar.showCloseIcon, isTrue);
+      expect(snackBar.showCloseIcon, isFalse);
+      expect(find.byIcon(Icons.close), findsOneWidget);
     });
 
     testWidgets(
@@ -237,6 +242,79 @@ void main() {
       final box = tester.renderObject<RenderBox>(find.byType(SnackBar));
       expect(box.size.height, lessThan(200));
       expect(tester.takeException(), isNull);
+    });
+
+    // Regression: when SnackBar's built-in action is wider than
+    // `actionOverflowThreshold` (25% of the bar) it moves to its own row and
+    // *still* reserves 40% of the width next to the message, so the
+    // credits-exhausted copy rendered as a narrow ~30% column on phones.
+    // AppNotice owns the action / dismiss layout, so the text keeps the bar's
+    // full inner width.
+    testWidgets('action notice keeps the message at full inner width', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(393 * 3, 851 * 3);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+
+      final messengerKey = GlobalKey<ScaffoldMessengerState>();
+      await tester.pumpWidget(host(messengerKey: messengerKey));
+      final ctx = tester.element(find.byType(Scaffold));
+
+      const message =
+          'AI credits limit reached. Upgrade to Pro or buy a credits '
+          'package to continue.';
+      var tapped = 0;
+      AppNotice.error(
+        ctx,
+        message,
+        action: SnackBarAction(
+          label: 'View plans & packages',
+          onPressed: () => tapped++,
+        ),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      final barWidth = tester
+          .getSize(
+            find
+                .descendant(
+                  of: find.byType(SnackBar),
+                  matching: find.byType(Material),
+                )
+                .first,
+          )
+          .width;
+      final textWidth = tester.getSize(find.text(message)).width;
+      // Icon (22) + gap (12) + gutters are all that is left of the bar, so the
+      // text owns ~82% of it; the broken layout sat at ~30%.
+      expect(textWidth, greaterThan(barWidth * 0.75));
+      // An actionable notice still waits for the user instead of timing out.
+      expect(tester.widget<SnackBar>(find.byType(SnackBar)).persist, isTrue);
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(find.text('View plans & packages'));
+      expect(tapped, 1);
+      await tester.pumpAndSettle();
+      expect(find.text(message), findsNothing);
+    });
+
+    testWidgets('body close button dismisses a notice without an action', (
+      tester,
+    ) async {
+      final messengerKey = GlobalKey<ScaffoldMessengerState>();
+      await tester.pumpWidget(host(messengerKey: messengerKey));
+      final ctx = tester.element(find.byType(Scaffold));
+
+      AppNotice.warning(ctx, 'careful');
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.text('careful'), findsNothing);
     });
   });
 }

--- a/test/core/notices/app_notice_test.dart
+++ b/test/core/notices/app_notice_test.dart
@@ -65,8 +65,9 @@ void main() {
       final scheme = Theme.of(ctx).colorScheme;
       expect(snackBar.backgroundColor, scheme.errorContainer);
       expect(find.byIcon(Icons.error_rounded), findsOneWidget);
-      // Dismiss affordance is rendered by the notice body, not SnackBar's slot.
-      expect(snackBar.showCloseIcon, isFalse);
+      // Dismiss affordance is rendered by the notice body, not SnackBar's slot
+      // (the field is left at its null default; the theme resolves it off).
+      expect(snackBar.showCloseIcon, isNull);
       expect(find.byIcon(Icons.close), findsOneWidget);
     });
 
@@ -84,7 +85,7 @@ void main() {
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
       final scheme = Theme.of(ctx).colorScheme;
       expect(snackBar.backgroundColor, scheme.surfaceContainerHigh);
-      expect(snackBar.showCloseIcon, isFalse);
+      expect(snackBar.showCloseIcon, isNull);
       expect(find.byIcon(Icons.close), findsNothing);
     });
 
@@ -102,7 +103,7 @@ void main() {
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
       final scheme = Theme.of(ctx).colorScheme;
       expect(snackBar.backgroundColor, scheme.tertiaryContainer);
-      expect(snackBar.showCloseIcon, isFalse);
+      expect(snackBar.showCloseIcon, isNull);
       expect(find.byIcon(Icons.close), findsOneWidget);
     });
 
@@ -268,10 +269,7 @@ void main() {
       AppNotice.error(
         ctx,
         message,
-        action: SnackBarAction(
-          label: 'View plans & packages',
-          onPressed: () => tapped++,
-        ),
+        action: (label: 'View plans & packages', onPressed: () => tapped++),
       );
       await tester.pump();
       await tester.pumpAndSettle();
@@ -315,6 +313,66 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('careful'), findsNothing);
+    });
+
+    // Regression: the dismiss button rides inline with the message (SDK
+    // geometry), so a dismiss-only notice stays at SnackBar's own
+    // single-line height instead of growing a trailing row.
+    testWidgets('dismiss-only notice keeps the single-line height', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(393 * 3, 851 * 3);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+
+      final messengerKey = GlobalKey<ScaffoldMessengerState>();
+      await tester.pumpWidget(host(messengerKey: messengerKey));
+      final ctx = tester.element(find.byType(Scaffold));
+
+      AppNotice.error(ctx, 'one line');
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      // The close button's 48dp tap target sets the row height — anything
+      // taller means the dismiss button grew its own trailing row again.
+      // Measure the bar itself (inside the floating margin wrapper).
+      final bar = tester.renderObject<RenderBox>(
+        find
+            .descendant(
+              of: find.byType(SnackBar),
+              matching: find.byType(Material),
+            )
+            .first,
+      );
+      expect(bar.size.height, lessThan(60));
+      expect(tester.takeException(), isNull);
+    });
+
+    // Regression: the CTA is a body-owned button, so a long localized label
+    // must ellipsize instead of soft-wrapping into a multi-line button.
+    testWidgets('long action label ellipsizes instead of wrapping', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(320 * 3, 700 * 3);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+
+      final messengerKey = GlobalKey<ScaffoldMessengerState>();
+      await tester.pumpWidget(host(messengerKey: messengerKey));
+      final ctx = tester.element(find.byType(Scaffold));
+
+      const label =
+          'View plans & packages and manage your subscription settings';
+      AppNotice.error(
+        ctx,
+        'limit reached',
+        action: (label: label, onPressed: () {}),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(tester.getSize(find.text(label)).height, lessThan(24));
+      expect(tester.takeException(), isNull);
     });
   });
 }

--- a/test/features/craft/presentation/craft_solid_transcript_stt_hint_test.dart
+++ b/test/features/craft/presentation/craft_solid_transcript_stt_hint_test.dart
@@ -40,6 +40,9 @@ void main() {
     await tester.pumpWidget(wrap(const SizedBox.shrink()));
     final ctx = tester.element(find.byType(Scaffold));
     maybeShowCraftSolidTranscriptSttHint(ctx, savedSolidTimeline: true);
+    // AppNotice mounts one frame later than a synchronous SnackBar (it shows
+    // from a post-frame callback).
+    await tester.pump();
     await tester.pump();
     expect(find.byType(SnackBar), findsOneWidget);
     expect(CraftSolidTranscriptHintGate.shownThisSession, isTrue);
@@ -49,6 +52,7 @@ void main() {
     await tester.pumpWidget(wrap(const SizedBox.shrink()));
     final ctx = tester.element(find.byType(Scaffold));
     maybeShowCraftSolidTranscriptSttHint(ctx, savedSolidTimeline: true);
+    await tester.pump();
     await tester.pump();
     expect(find.byType(SnackBar), findsOneWidget);
 

--- a/test/features/pronounce/presentation/pronounce_icon_button_test.dart
+++ b/test/features/pronounce/presentation/pronounce_icon_button_test.dart
@@ -168,9 +168,10 @@ void main() {
       expect(find.textContaining('1500'), findsOneWidget);
       expect(find.text('HTTP 402'), findsNothing);
       // The one-tap recovery CTA rides on the warning snackbar (spec 045).
-      expect(find.text(l10n.subscriptionViewPlansAndPackages), findsOneWidget);
-      final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-      expect(snackBar.action, isNotNull);
+      expect(
+        find.widgetWithText(TextButton, l10n.subscriptionViewPlansAndPackages),
+        findsOneWidget,
+      );
     },
   );
 }

--- a/test/features/pronounce/presentation/pronounce_icon_button_test.dart
+++ b/test/features/pronounce/presentation/pronounce_icon_button_test.dart
@@ -8,6 +8,7 @@ import 'package:enjoy_player/features/pronounce/application/pronounce_playback_c
 import 'package:enjoy_player/features/pronounce/domain/pronounce_target.dart';
 import 'package:enjoy_player/features/pronounce/presentation/pronounce_icon_button.dart';
 import 'package:enjoy_player/l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 
 class _FixedPlaybackController extends PronouncePlaybackController {
   _FixedPlaybackController(this.initial);
@@ -135,15 +136,32 @@ void main() {
   });
 
   testWidgets(
-    'credits failure shows the shared credits message, not raw text',
+    'credits failure shows the shared message and the CTA navigates',
     (tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          const PronounceIconButton(
-            text: 'hello',
-            localeTag: 'en-US',
-            surfaceId: PronounceSurfaceId.lookup,
+      // Real router: the CTA is captured at show-time and must navigate even
+      // though the persisted notice outlives this route (spec 045 FR-003).
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const Scaffold(
+              body: PronounceIconButton(
+                text: 'hello',
+                localeTag: 'en-US',
+                surfaceId: PronounceSurfaceId.lookup,
+              ),
+            ),
           ),
+          GoRoute(
+            path: '/subscription',
+            builder: (context, state) =>
+                const Scaffold(body: Text('subscription-page')),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
           overrides: [
             pronouncePlaybackControllerProvider.overrideWith(
               () => _ThrowingPlaybackController(
@@ -156,6 +174,11 @@ void main() {
               ),
             ),
           ],
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -165,13 +188,17 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
+      // Numbered message, never the raw internal string.
       expect(find.textContaining('1500'), findsOneWidget);
       expect(find.text('HTTP 402'), findsNothing);
-      // The one-tap recovery CTA rides on the warning snackbar (spec 045).
-      expect(
-        find.widgetWithText(TextButton, l10n.subscriptionViewPlansAndPackages),
-        findsOneWidget,
-      );
+
+      // The one-tap recovery CTA rides on the warning snackbar (spec 045);
+      // drive it through the rendered button and assert it navigates.
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.subscriptionViewPlansAndPackages));
+      await tester.pumpAndSettle();
+
+      expect(find.text('subscription-page'), findsOneWidget);
     },
   );
 }

--- a/test/features/subscription/presentation/credits_failure_actions_test.dart
+++ b/test/features/subscription/presentation/credits_failure_actions_test.dart
@@ -77,8 +77,10 @@ void main() {
       expect(find.textContaining('200'), findsOneWidget);
       expect(find.text('HTTP 402'), findsNothing);
 
-      final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-      snackBar.action!.onPressed();
+      // The CTA rides in the notice body (AppNotice lays it out itself), so
+      // drive it through the rendered button rather than SnackBar.action.
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.subscriptionViewPlansAndPackages));
       await tester.pumpAndSettle();
 
       expect(find.text('subscription-page'), findsOneWidget);
@@ -100,8 +102,10 @@ void main() {
     );
     expect(find.text('HTTP 402'), findsNothing);
 
-    final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-    expect(snackBar.action!.label, l10n.subscriptionViewPlansAndPackages);
+    expect(
+      find.widgetWithText(TextButton, l10n.subscriptionViewPlansAndPackages),
+      findsOneWidget,
+    );
   });
 
   testWidgets('repeated credits failures replace rather than stack (FR-006)', (


### PR DESCRIPTION
## Summary

The AI credits-exhausted notice rendered its message in a narrow column on phones (screenshot in the report: `AI 积分已用完。可升级 Pro 或购买积分包以继续使用。` wrapped at ~60% width) instead of using the bar's full width.

Root cause is in Flutter's `SnackBar`, not in our sizing math: once the built-in action (+ close icon) is wider than `actionOverflowThreshold` (25% of the bar) it moves to its own row **and still reserves 40% of the width beside the message** — `if (willOverflowAction) SizedBox(width: snackBarWidth * 0.4)`. The zh CTA `查看方案与积分包` + the close icon are ~52% of a 361 dp phone bar, so the text lost 40% of the bar. No `actionOverflowThreshold` value escapes it: the other branch squeezes the text beside the button instead. Reproduced on the CI-pinned 3.44.0 and local 3.47.2 (identical layout code).

`AppNotice` now lays the action and the dismiss affordance out itself in `_AppNoticeBody` — icon + full-width message row, then an end-aligned trailing row with the CTA and the X — so the message owns the bar's inner width (measured 295 dp of a 361 dp card, up from ~183 dp). `SnackBarAction` is reused as-is, so its one-shot press, auto-dismiss and label color are unchanged; `persist: action != null` is now set explicitly because `SnackBar` infers that flag from its own action slot (without it the credits notice would start timing out instead of waiting for the user), and the CTA is wrapped in `Flexible` so a long localized label shrinks with the bar rather than overflowing it.

The AI playground's raw `SnackBar` (same squeeze) moves to `AppNotice.warning`, which is also what ADR-0066 asks for so the player surface parks.

No issue filed — reported via screenshot on Android.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / chore (no user-visible change)
- [ ] Documentation / ADR

## Platform tested

- [x] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [x] Linux

Widget-level layout verification is platform-independent (`flutter test`); the reported case is Android, desktop paths share the same `AppNotice` seam and the ≥600 dp 520 dp cap is unchanged.

## Checklist

- [x] `bash .github/scripts/validate_ci_gates.sh` passes (Dart format + codegen drift)
- [x] `flutter analyze` is clean
- [x] `flutter test` passes for affected areas (full suite: 5956 passed, 2 skipped)
- [x] If Drift / Riverpod / Freezed annotations changed: regenerated — n/a, no annotations touched
- [x] No new `print()` calls
- [x] No new `kIsWeb` branches
- [x] No new SQL outside Drift DAOs
- [x] No new `Player()` instances outside `PlayerController`
- [ ] If behavior changed: `docs/features/<feature>.md` updated — no feature contract changed; copy, CTA label, destination and dismissal semantics are all identical
- [ ] If architectural: new ADR — not architectural; it stays inside the existing `AppNotice` seam
- [x] New public API symbols have doc comments — `_AppNoticeBody` is private and documented; no public API added or removed

## Test plan

- `bash .github/scripts/validate_ci_gates.sh` → format + codegen drift ok.
- `flutter analyze` → no issues.
- `flutter test` → 5956 passed / 2 skipped.
- New regression test `AppNotice action notice keeps the message at full inner width` (393 dp phone size): asserts the message `Text` is ≥ 75% of the bar's `Material` card (broken layout measured ~30% under the test font, ~51% with real glyph widths), that an actionable notice still sets `persist`, that tapping the CTA fires exactly once and dismisses, and that the body X dismisses an action-less notice.
- Updated surfaces: `credits_failure_actions_test.dart` now taps the rendered CTA and asserts navigation to `/subscription`; `pronounce_icon_button_test.dart` asserts the rendered `TextButton` CTA; the three `AppNotice` kind tests assert the rendered dismiss affordance instead of `SnackBar.showCloseIcon`.
- Caught while writing the tests: without `Flexible` the trailing row overflowed the bar (`RenderFlex overflowed by 31 pixels`) because the test font renders the 21-char label at 296 dp — i.e. a long localized label in a narrow bar is a real overflow risk, now bounded.

## Out of scope / follow-up

- Inline (non-snackbar) credits-error rows in the lookup / dictionary sheets are a separate idiom and already full width; untouched.
- Upstream: the 40% reservation is Flutter's own heuristic (`snack_bar.dart`); if it ever becomes configurable we could go back to the built-in action slot.
- Deliberate visual change worth a reviewer's eye: error/warning notices **without** an action now place the X in the bottom-right row instead of vertically centered at the right edge (~+44 dp taller). This keeps the dismiss control in one predictable, thumb-reachable corner whether or not a CTA is present. Trivially reverted with a conditional in `_AppNoticeBody` if the compact single-line look is preferred.

## Human / owner follow-up

- None.
