### PR TITLE
refactor(ai): collapse cache classes, remove unreachable local-provider stubs

### DIFF
--- a/lib/features/ai/application/ai_capability_providers.dart
+++ b/lib/features/ai/application/ai_capability_providers.dart
@@ -53,8 +53,6 @@ AsrCapability resolveAsrCapability(Ref ref, AIServiceConfig config) {
           secrets: ref.read(byokSecretStoreProvider),
         ),
       };
-    case AIProvider.local:
-      return const UnimplementedAsrCapability();
   }
 }
 
@@ -66,8 +64,6 @@ LlmCapability resolveLlmCapability(Ref ref, AIServiceConfig config) {
       final llmByok = config.llmByok;
       if (llmByok == null) return const ByokNotConfiguredLlmCapability();
       return ByokLlmCapability(llmByok, ref.read(byokSecretStoreProvider));
-    case AIProvider.local:
-      return const UnimplementedLlmCapability();
   }
 }
 
@@ -80,8 +76,6 @@ TranslationCapability resolveTranslationCapability(
       return EnjoyTranslationCapability(ref.read(translationApiProvider));
     case AIProvider.byok:
       return ByokTranslationCapability(resolveLlmCapability(ref, config));
-    case AIProvider.local:
-      return const UnimplementedTranslationCapability();
   }
 }
 
@@ -94,8 +88,6 @@ DictionaryCapability resolveDictionaryCapability(
       return EnjoyDictionaryCapability(ref.read(dictionaryApiProvider));
     case AIProvider.byok:
       return ByokDictionaryCapability(resolveLlmCapability(ref, config));
-    case AIProvider.local:
-      return const UnimplementedDictionaryCapability();
   }
 }
 
@@ -112,8 +104,6 @@ ContextualTranslationCapability resolveContextualTranslationCapability(
       return EnjoyContextualTranslationCapability(
         resolveLlmCapability(ref, config),
       );
-    case AIProvider.local:
-      return const UnimplementedContextualTranslationCapability();
   }
 }
 
@@ -134,8 +124,6 @@ TtsCapability resolveTtsCapability(Ref ref, AIServiceConfig config) {
           secrets: ref.read(byokSecretStoreProvider),
         ),
       };
-    case AIProvider.local:
-      return const UnimplementedTtsCapability();
   }
 }
 
@@ -157,8 +145,6 @@ AssessmentCapability resolveAssessmentCapability(
         config: speechByok,
         secrets: ref.read(byokSecretStoreProvider),
       );
-    case AIProvider.local:
-      return const UnimplementedAssessmentCapability();
   }
 }
 

--- a/lib/features/ai/application/ai_result_cache.dart
+++ b/lib/features/ai/application/ai_result_cache.dart
@@ -33,43 +33,35 @@ import 'package:enjoy_player/features/ai/domain/models/translation_result.dart';
 
 part 'ai_result_cache.g.dart';
 
-/// Read-only diagnostic snapshot of [AiResultCache].
-class AiCacheStats {
-  const AiCacheStats({
-    required this.l1Size,
-    required this.l1Capacity,
-    required this.l2RowCounts,
-  });
-
-  final int l1Size;
-  final int l1Capacity;
-  final Map<AiKind, int> l2RowCounts;
-
-  @override
-  String toString() => 'AiCacheStats(l1=$l1Size/$l1Capacity, l2=$l2RowCounts)';
-}
-
 // ignore_for_file: prefer_initializing_formals
 
 /// Two-tier AI result cache.
 ///
-/// Constructed by [aiResultCacheProvider] in production. Tests construct
-/// it directly with an in-memory `AppDatabase`.
-abstract class AiResultCache<V extends Object> {
+/// One generic class for every payload type — the JSON adapter is injected
+/// as `fromJson` / `toJson` converters. Constructed by the per-kind
+/// providers below; tests construct it directly with an in-memory
+/// `AppDatabase`.
+class AiResultCache<V extends Object> {
   AiResultCache({
     required AiCacheDao dao,
     required L1Store<String, V> l1,
     required Map<AiKind, AiKindPolicy> policies,
     Logger? logger,
+    required V Function(Map<String, dynamic> json) fromJson,
+    required Map<String, dynamic> Function(V value) toJson,
   }) : _dao = dao,
        _l1 = l1,
        _policies = policies,
-       _log = logger ?? logNamed('ai_cache');
+       _log = logger ?? logNamed('ai_cache'),
+       _fromJson = fromJson,
+       _toJson = toJson;
 
   final AiCacheDao _dao;
   final L1Store<String, V> _l1;
   final Map<AiKind, AiKindPolicy> _policies;
   final Logger _log;
+  final V Function(Map<String, dynamic> json) _fromJson;
+  final Map<String, dynamic> Function(V value) _toJson;
 
   /// L1-only synchronous read. Returns null on miss or TTL expiry.
   V? peek({required AiKind kind, required String key}) {
@@ -137,7 +129,7 @@ abstract class AiResultCache<V extends Object> {
     final cacheKey = _cacheKey(kind, key);
     _l1.put(cacheKey, value);
     try {
-      final json = jsonEncode(_encode(value));
+      final json = jsonEncode(_toJson(value));
       await _dao.upsert(kind.wire, key, json, DateTime.now());
     } on Object catch (e, st) {
       _log.warning(
@@ -204,103 +196,12 @@ abstract class AiResultCache<V extends Object> {
     _log.info('ai_cache prune complete');
   }
 
-  /// Read-only diagnostics snapshot.
-  Future<AiCacheStats> stats() async {
-    final l2Counts = <AiKind, int>{};
-    for (final kind in _policies.keys) {
-      l2Counts[kind] = await _dao.countForKind(kind.wire);
-    }
-    return AiCacheStats(
-      l1Size: _l1.size,
-      l1Capacity: _l1.capacity,
-      l2RowCounts: l2Counts,
-    );
-  }
-
   String _cacheKey(AiKind kind, String key) => '${kind.wire}|$key';
 
   V _decode(String payloadJson) {
     final map = jsonDecode(payloadJson) as Map<String, dynamic>;
-    return fromJson(map);
+    return _fromJson(map);
   }
-
-  Map<String, dynamic> _encode(V value) => toJson(value);
-
-  /// Subclass-supplied JSON adapter.
-  V fromJson(Map<String, dynamic> json);
-
-  /// Subclass-supplied JSON adapter.
-  Map<String, dynamic> toJson(V value);
-}
-
-/// Typed convenience wrapper for caching [Map] payloads (e.g. plain
-/// translation / dictionary). Used by the lookup sheet providers.
-class AiMapCache extends AiResultCache<Map<String, dynamic>> {
-  AiMapCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-    super.logger,
-  });
-
-  @override
-  Map<String, dynamic> fromJson(Map<String, dynamic> json) => json;
-
-  @override
-  Map<String, dynamic> toJson(Map<String, dynamic> value) => value;
-}
-
-/// Cache subclass for `TranslationResult` (freezed + json_serializable).
-class AiTranslationCache extends AiResultCache<TranslationResult> {
-  AiTranslationCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-    super.logger,
-  });
-
-  @override
-  TranslationResult fromJson(Map<String, dynamic> json) =>
-      TranslationResult.fromJson(json);
-
-  @override
-  Map<String, dynamic> toJson(TranslationResult value) => value.toJson();
-}
-
-/// Cache subclass for `DictionaryResult` (already has fromJson).
-class AiDictionaryCache extends AiResultCache<DictionaryResult> {
-  AiDictionaryCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-    super.logger,
-  });
-
-  @override
-  DictionaryResult fromJson(Map<String, dynamic> json) =>
-      DictionaryResult.fromJson(json);
-
-  @override
-  Map<String, dynamic> toJson(DictionaryResult value) => value.toJson();
-}
-
-/// Cache subclass for `ContextualTranslationResult` (added in this PR).
-class AiContextualTranslationCache
-    extends AiResultCache<ContextualTranslationResult> {
-  AiContextualTranslationCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-    super.logger,
-  });
-
-  @override
-  ContextualTranslationResult fromJson(Map<String, dynamic> json) =>
-      ContextualTranslationResult.fromJson(json);
-
-  @override
-  Map<String, dynamic> toJson(ContextualTranslationResult value) =>
-      value.toJson();
 }
 
 // ---------------------------------------------------------------------------
@@ -309,11 +210,11 @@ class AiContextualTranslationCache
 
 /// Coalesces the startup prune pass for all AI cache kinds (issue #478).
 ///
-/// Previously each of the four cache providers called `unawaited(cache.prune())`
-/// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
-/// table racing on the same Drift executor. This provider runs the prune once
-/// per database instance; each cache provider watches it to ensure it has
-/// fired before the cache is used.
+/// Previously each of the cache providers called `unawaited(cache.prune())`
+/// at construction — N × len(policies) × 2 SQL ops against the same
+/// `ai_cache` table racing on the same Drift executor. This provider runs
+/// the prune once per database instance; each cache provider watches it to
+/// ensure it has fired before the cache is used.
 @Riverpod(keepAlive: true)
 void aiCacheStartupPrune(Ref ref) {
   final db = ref.watch(appDatabaseProvider);
@@ -334,28 +235,25 @@ void aiCacheStartupPrune(Ref ref) {
   }());
 }
 
-/// Per-user `AiMapCache` (JSON-typed payload). Cleared on sign-out /
-/// user-id change.
-///
-/// The cache is `keepAlive` because lookup-sheet and contextual-translation
-/// flows outlive any single widget mount; closing the sheet must not
-/// invalidate the cache.
-@Riverpod(keepAlive: true)
-AiMapCache aiResultCache(Ref ref) {
+/// Shared construction for the per-kind caches: same L1 sizing (256
+/// entries / 30 min TTL), same policies, and the sign-out / user-change
+/// clear listener so we never serve a previous user's cached results (R7).
+/// L2 is naturally scoped by the active `appDatabaseProvider`; the
+/// listener ensures the in-memory L1 is also dropped.
+AiResultCache<V> _buildPerUserCache<V extends Object>(
+  Ref ref, {
+  required V Function(Map<String, dynamic> json) fromJson,
+  required Map<String, dynamic> Function(V value) toJson,
+}) {
   final db = ref.watch(appDatabaseProvider);
-  final cache = AiMapCache(
+  final cache = AiResultCache<V>(
     dao: db.aiCacheDao,
-    l1: L1Store<String, Map<String, dynamic>>(
-      capacity: 256,
-      ttl: const Duration(minutes: 30),
-    ),
+    l1: L1Store<String, V>(capacity: 256, ttl: const Duration(minutes: 30)),
     policies: defaultAiKindPolicies,
+    fromJson: fromJson,
+    toJson: toJson,
   );
 
-  // Clear L1 + L2 on sign-out or user-id change so we never serve a
-  // previous user's cached translations (R7). L2 is naturally scoped
-  // by the active `appDatabaseProvider`; this listener ensures the
-  // in-memory L1 is also dropped.
   ref.listen(authCtrlProvider, (prev, next) {
     final prevState = prev?.valueOrNull;
     final nextState = next.valueOrNull;
@@ -374,90 +272,30 @@ AiMapCache aiResultCache(Ref ref) {
   return cache;
 }
 
-/// Per-user `AiTranslationCache` (typed `TranslationResult`). Shares the
-/// L2 Drift table with `aiResultCache` (different `AiKind.wire`).
+/// Per-user typed `TranslationResult` cache.
 @Riverpod(keepAlive: true)
-AiTranslationCache aiTranslationCache(Ref ref) {
-  final db = ref.watch(appDatabaseProvider);
-  final cache = AiTranslationCache(
-    dao: db.aiCacheDao,
-    l1: L1Store<String, TranslationResult>(
-      capacity: 256,
-      ttl: const Duration(minutes: 30),
-    ),
-    policies: defaultAiKindPolicies,
-  );
-  ref.listen(authCtrlProvider, (prev, next) {
-    final prevState = prev?.valueOrNull;
-    final nextState = next.valueOrNull;
-    final wasSignedIn = prevState is AuthSignedIn;
-    final isSignedIn = nextState is AuthSignedIn;
-    final userChanged =
-        wasSignedIn &&
-        isSignedIn &&
-        prevState.profile.id != nextState.profile.id;
-    if (!isSignedIn || userChanged) {
-      unawaited(cache.clear());
-    }
-  });
-  ref.watch(aiCacheStartupPruneProvider);
-  return cache;
-}
+AiResultCache<TranslationResult> aiTranslationCache(Ref ref) =>
+    _buildPerUserCache(
+      ref,
+      fromJson: TranslationResult.fromJson,
+      toJson: (value) => value.toJson(),
+    );
 
-/// Per-user `AiDictionaryCache`.
+/// Per-user typed `DictionaryResult` cache.
 @Riverpod(keepAlive: true)
-AiDictionaryCache aiDictionaryCache(Ref ref) {
-  final db = ref.watch(appDatabaseProvider);
-  final cache = AiDictionaryCache(
-    dao: db.aiCacheDao,
-    l1: L1Store<String, DictionaryResult>(
-      capacity: 256,
-      ttl: const Duration(minutes: 30),
-    ),
-    policies: defaultAiKindPolicies,
-  );
-  ref.listen(authCtrlProvider, (prev, next) {
-    final prevState = prev?.valueOrNull;
-    final nextState = next.valueOrNull;
-    final wasSignedIn = prevState is AuthSignedIn;
-    final isSignedIn = nextState is AuthSignedIn;
-    final userChanged =
-        wasSignedIn &&
-        isSignedIn &&
-        prevState.profile.id != nextState.profile.id;
-    if (!isSignedIn || userChanged) {
-      unawaited(cache.clear());
-    }
-  });
-  ref.watch(aiCacheStartupPruneProvider);
-  return cache;
-}
+AiResultCache<DictionaryResult> aiDictionaryCache(Ref ref) =>
+    _buildPerUserCache(
+      ref,
+      fromJson: DictionaryResult.fromJson,
+      toJson: (value) => value.toJson(),
+    );
 
-/// Per-user `AiContextualTranslationCache`.
+/// Per-user typed `ContextualTranslationResult` cache.
 @Riverpod(keepAlive: true)
-AiContextualTranslationCache aiContextualTranslationCache(Ref ref) {
-  final db = ref.watch(appDatabaseProvider);
-  final cache = AiContextualTranslationCache(
-    dao: db.aiCacheDao,
-    l1: L1Store<String, ContextualTranslationResult>(
-      capacity: 256,
-      ttl: const Duration(minutes: 30),
-    ),
-    policies: defaultAiKindPolicies,
-  );
-  ref.listen(authCtrlProvider, (prev, next) {
-    final prevState = prev?.valueOrNull;
-    final nextState = next.valueOrNull;
-    final wasSignedIn = prevState is AuthSignedIn;
-    final isSignedIn = nextState is AuthSignedIn;
-    final userChanged =
-        wasSignedIn &&
-        isSignedIn &&
-        prevState.profile.id != nextState.profile.id;
-    if (!isSignedIn || userChanged) {
-      unawaited(cache.clear());
-    }
-  });
-  ref.watch(aiCacheStartupPruneProvider);
-  return cache;
-}
+AiResultCache<ContextualTranslationResult> aiContextualTranslationCache(
+  Ref ref,
+) => _buildPerUserCache(
+  ref,
+  fromJson: ContextualTranslationResult.fromJson,
+  toJson: (value) => value.toJson(),
+);

--- a/lib/features/ai/application/ai_result_cache.g.dart
+++ b/lib/features/ai/application/ai_result_cache.g.dart
@@ -10,33 +10,33 @@ part of 'ai_result_cache.dart';
 // ignore_for_file: type=lint, type=warning
 /// Coalesces the startup prune pass for all AI cache kinds (issue #478).
 ///
-/// Previously each of the four cache providers called `unawaited(cache.prune())`
-/// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
-/// table racing on the same Drift executor. This provider runs the prune once
-/// per database instance; each cache provider watches it to ensure it has
-/// fired before the cache is used.
+/// Previously each of the cache providers called `unawaited(cache.prune())`
+/// at construction — N × len(policies) × 2 SQL ops against the same
+/// `ai_cache` table racing on the same Drift executor. This provider runs
+/// the prune once per database instance; each cache provider watches it to
+/// ensure it has fired before the cache is used.
 
 @ProviderFor(aiCacheStartupPrune)
 final aiCacheStartupPruneProvider = AiCacheStartupPruneProvider._();
 
 /// Coalesces the startup prune pass for all AI cache kinds (issue #478).
 ///
-/// Previously each of the four cache providers called `unawaited(cache.prune())`
-/// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
-/// table racing on the same Drift executor. This provider runs the prune once
-/// per database instance; each cache provider watches it to ensure it has
-/// fired before the cache is used.
+/// Previously each of the cache providers called `unawaited(cache.prune())`
+/// at construction — N × len(policies) × 2 SQL ops against the same
+/// `ai_cache` table racing on the same Drift executor. This provider runs
+/// the prune once per database instance; each cache provider watches it to
+/// ensure it has fired before the cache is used.
 
 final class AiCacheStartupPruneProvider
     extends $FunctionalProvider<void, void, void>
     with $Provider<void> {
   /// Coalesces the startup prune pass for all AI cache kinds (issue #478).
   ///
-  /// Previously each of the four cache providers called `unawaited(cache.prune())`
-  /// at construction — 4 × len(policies) × 2 SQL ops against the same `ai_cache`
-  /// table racing on the same Drift executor. This provider runs the prune once
-  /// per database instance; each cache provider watches it to ensure it has
-  /// fired before the cache is used.
+  /// Previously each of the cache providers called `unawaited(cache.prune())`
+  /// at construction — N × len(policies) × 2 SQL ops against the same
+  /// `ai_cache` table racing on the same Drift executor. This provider runs
+  /// the prune once per database instance; each cache provider watches it to
+  /// ensure it has fired before the cache is used.
   AiCacheStartupPruneProvider._()
     : super(
         from: null,
@@ -73,86 +73,22 @@ final class AiCacheStartupPruneProvider
 String _$aiCacheStartupPruneHash() =>
     r'5811f5235124494ebaf5495fc005e3c96f40199a';
 
-/// Per-user `AiMapCache` (JSON-typed payload). Cleared on sign-out /
-/// user-id change.
-///
-/// The cache is `keepAlive` because lookup-sheet and contextual-translation
-/// flows outlive any single widget mount; closing the sheet must not
-/// invalidate the cache.
-
-@ProviderFor(aiResultCache)
-final aiResultCacheProvider = AiResultCacheProvider._();
-
-/// Per-user `AiMapCache` (JSON-typed payload). Cleared on sign-out /
-/// user-id change.
-///
-/// The cache is `keepAlive` because lookup-sheet and contextual-translation
-/// flows outlive any single widget mount; closing the sheet must not
-/// invalidate the cache.
-
-final class AiResultCacheProvider
-    extends $FunctionalProvider<AiMapCache, AiMapCache, AiMapCache>
-    with $Provider<AiMapCache> {
-  /// Per-user `AiMapCache` (JSON-typed payload). Cleared on sign-out /
-  /// user-id change.
-  ///
-  /// The cache is `keepAlive` because lookup-sheet and contextual-translation
-  /// flows outlive any single widget mount; closing the sheet must not
-  /// invalidate the cache.
-  AiResultCacheProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'aiResultCacheProvider',
-        isAutoDispose: false,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
-
-  @override
-  String debugGetCreateSourceHash() => _$aiResultCacheHash();
-
-  @$internal
-  @override
-  $ProviderElement<AiMapCache> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
-
-  @override
-  AiMapCache create(Ref ref) {
-    return aiResultCache(ref);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AiMapCache value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<AiMapCache>(value),
-    );
-  }
-}
-
-String _$aiResultCacheHash() => r'a091f85bdab587328537b1aa67a201f36011c981';
-
-/// Per-user `AiTranslationCache` (typed `TranslationResult`). Shares the
-/// L2 Drift table with `aiResultCache` (different `AiKind.wire`).
+/// Per-user typed `TranslationResult` cache.
 
 @ProviderFor(aiTranslationCache)
 final aiTranslationCacheProvider = AiTranslationCacheProvider._();
 
-/// Per-user `AiTranslationCache` (typed `TranslationResult`). Shares the
-/// L2 Drift table with `aiResultCache` (different `AiKind.wire`).
+/// Per-user typed `TranslationResult` cache.
 
 final class AiTranslationCacheProvider
     extends
         $FunctionalProvider<
-          AiTranslationCache,
-          AiTranslationCache,
-          AiTranslationCache
+          AiResultCache<TranslationResult>,
+          AiResultCache<TranslationResult>,
+          AiResultCache<TranslationResult>
         >
-    with $Provider<AiTranslationCache> {
-  /// Per-user `AiTranslationCache` (typed `TranslationResult`). Shares the
-  /// L2 Drift table with `aiResultCache` (different `AiKind.wire`).
+    with $Provider<AiResultCache<TranslationResult>> {
+  /// Per-user typed `TranslationResult` cache.
   AiTranslationCacheProvider._()
     : super(
         from: null,
@@ -169,43 +105,45 @@ final class AiTranslationCacheProvider
 
   @$internal
   @override
-  $ProviderElement<AiTranslationCache> $createElement(
+  $ProviderElement<AiResultCache<TranslationResult>> $createElement(
     $ProviderPointer pointer,
   ) => $ProviderElement(pointer);
 
   @override
-  AiTranslationCache create(Ref ref) {
+  AiResultCache<TranslationResult> create(Ref ref) {
     return aiTranslationCache(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AiTranslationCache value) {
+  Override overrideWithValue(AiResultCache<TranslationResult> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<AiTranslationCache>(value),
+      providerOverride: $SyncValueProvider<AiResultCache<TranslationResult>>(
+        value,
+      ),
     );
   }
 }
 
 String _$aiTranslationCacheHash() =>
-    r'255329c8a3653ebc1da72377c4104f25e794e5c0';
+    r'4d083bac9eeb817b17cba5ac2c39fa58c0c4bd47';
 
-/// Per-user `AiDictionaryCache`.
+/// Per-user typed `DictionaryResult` cache.
 
 @ProviderFor(aiDictionaryCache)
 final aiDictionaryCacheProvider = AiDictionaryCacheProvider._();
 
-/// Per-user `AiDictionaryCache`.
+/// Per-user typed `DictionaryResult` cache.
 
 final class AiDictionaryCacheProvider
     extends
         $FunctionalProvider<
-          AiDictionaryCache,
-          AiDictionaryCache,
-          AiDictionaryCache
+          AiResultCache<DictionaryResult>,
+          AiResultCache<DictionaryResult>,
+          AiResultCache<DictionaryResult>
         >
-    with $Provider<AiDictionaryCache> {
-  /// Per-user `AiDictionaryCache`.
+    with $Provider<AiResultCache<DictionaryResult>> {
+  /// Per-user typed `DictionaryResult` cache.
   AiDictionaryCacheProvider._()
     : super(
         from: null,
@@ -222,43 +160,45 @@ final class AiDictionaryCacheProvider
 
   @$internal
   @override
-  $ProviderElement<AiDictionaryCache> $createElement(
+  $ProviderElement<AiResultCache<DictionaryResult>> $createElement(
     $ProviderPointer pointer,
   ) => $ProviderElement(pointer);
 
   @override
-  AiDictionaryCache create(Ref ref) {
+  AiResultCache<DictionaryResult> create(Ref ref) {
     return aiDictionaryCache(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AiDictionaryCache value) {
+  Override overrideWithValue(AiResultCache<DictionaryResult> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<AiDictionaryCache>(value),
+      providerOverride: $SyncValueProvider<AiResultCache<DictionaryResult>>(
+        value,
+      ),
     );
   }
 }
 
-String _$aiDictionaryCacheHash() => r'3faf13ed889a1d005279546fa66e64256ca91d75';
+String _$aiDictionaryCacheHash() => r'88020b57cac0e22beb4ef888f2132f543e1ed986';
 
-/// Per-user `AiContextualTranslationCache`.
+/// Per-user typed `ContextualTranslationResult` cache.
 
 @ProviderFor(aiContextualTranslationCache)
 final aiContextualTranslationCacheProvider =
     AiContextualTranslationCacheProvider._();
 
-/// Per-user `AiContextualTranslationCache`.
+/// Per-user typed `ContextualTranslationResult` cache.
 
 final class AiContextualTranslationCacheProvider
     extends
         $FunctionalProvider<
-          AiContextualTranslationCache,
-          AiContextualTranslationCache,
-          AiContextualTranslationCache
+          AiResultCache<ContextualTranslationResult>,
+          AiResultCache<ContextualTranslationResult>,
+          AiResultCache<ContextualTranslationResult>
         >
-    with $Provider<AiContextualTranslationCache> {
-  /// Per-user `AiContextualTranslationCache`.
+    with $Provider<AiResultCache<ContextualTranslationResult>> {
+  /// Per-user typed `ContextualTranslationResult` cache.
   AiContextualTranslationCacheProvider._()
     : super(
         from: null,
@@ -275,23 +215,24 @@ final class AiContextualTranslationCacheProvider
 
   @$internal
   @override
-  $ProviderElement<AiContextualTranslationCache> $createElement(
+  $ProviderElement<AiResultCache<ContextualTranslationResult>> $createElement(
     $ProviderPointer pointer,
   ) => $ProviderElement(pointer);
 
   @override
-  AiContextualTranslationCache create(Ref ref) {
+  AiResultCache<ContextualTranslationResult> create(Ref ref) {
     return aiContextualTranslationCache(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AiContextualTranslationCache value) {
+  Override overrideWithValue(AiResultCache<ContextualTranslationResult> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<AiContextualTranslationCache>(value),
+      providerOverride:
+          $SyncValueProvider<AiResultCache<ContextualTranslationResult>>(value),
     );
   }
 }
 
 String _$aiContextualTranslationCacheHash() =>
-    r'5429bf6ef754e46ceee108a9cb27d0c8004da09c';
+    r'402ac37f3c32a217b2177e184d97e9a4a68e0ca2';

--- a/lib/features/ai/data/azure_language_mapper.dart
+++ b/lib/features/ai/data/azure_language_mapper.dart
@@ -20,9 +20,3 @@ String? mapTranscriptLanguageToAzure(String? languageCode) {
   }
   return resolved;
 }
-
-/// Legacy helper — prefer [mapTranscriptLanguageToAzure] and handle `null`.
-@Deprecated('Use mapTranscriptLanguageToAzure and handle null')
-String mapTranscriptLanguageToAzureOrEnUs(String? languageCode) {
-  return mapTranscriptLanguageToAzure(languageCode) ?? 'en-US';
-}

--- a/lib/features/ai/data/stub_ai_capabilities.dart
+++ b/lib/features/ai/data/stub_ai_capabilities.dart
@@ -1,34 +1,16 @@
-import 'package:enjoy_player/features/ai/domain/capabilities/asr_capability.dart';
 import 'package:enjoy_player/features/ai/domain/byok_not_configured_failure.dart';
+import 'package:enjoy_player/features/ai/domain/capabilities/asr_capability.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/assessment_capability.dart';
-import 'package:enjoy_player/features/ai/domain/capabilities/contextual_translation_capability.dart';
-import 'package:enjoy_player/features/ai/domain/capabilities/dictionary_capability.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/llm_capability.dart';
-import 'package:enjoy_player/features/ai/domain/capabilities/translation_capability.dart';
 import 'package:enjoy_player/features/ai/domain/capabilities/tts_capability.dart';
 import 'package:enjoy_player/features/ai/domain/chat_message.dart';
 import 'package:enjoy_player/features/ai/domain/models/asr_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/asr_result.dart';
 import 'package:enjoy_player/features/ai/domain/models/assessment_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/assessment_result.dart';
-import 'package:enjoy_player/features/ai/domain/models/dictionary_result.dart';
-import 'package:enjoy_player/features/ai/domain/models/contextual_translation_result.dart';
-import 'package:enjoy_player/features/ai/domain/models/translation_result.dart';
 import 'package:enjoy_player/features/ai/domain/models/tts_request.dart';
 import 'package:enjoy_player/features/ai/domain/models/tts_result.dart';
 import 'package:enjoy_player/features/ai/domain/modality_kind.dart';
-
-/// Local on-device AI is not implemented in the player yet.
-final class UnimplementedAsrCapability implements AsrCapability {
-  const UnimplementedAsrCapability();
-
-  @override
-  Future<AsrResult> transcribe(AsrRequest request) {
-    throw UnimplementedError(
-      'ASR with local on-device models is not implemented yet.',
-    );
-  }
-}
 
 final class ByokNotConfiguredAsrCapability implements AsrCapability {
   const ByokNotConfiguredAsrCapability();
@@ -36,34 +18,6 @@ final class ByokNotConfiguredAsrCapability implements AsrCapability {
   @override
   Future<AsrResult> transcribe(AsrRequest request) {
     throw const ByokNotConfiguredFailure(ModalityKind.asr);
-  }
-}
-
-final class UnimplementedLlmCapability implements LlmCapability {
-  const UnimplementedLlmCapability();
-
-  @override
-  Future<String> generateChatCompletion({
-    required List<ChatMessage> messages,
-    double? temperature,
-    int? maxTokens,
-    Map<String, dynamic>? responseFormat,
-  }) {
-    throw UnimplementedError(
-      'LLM with local on-device models is not implemented yet.',
-    );
-  }
-
-  @override
-  Future<String> generateText({
-    String? systemPrompt,
-    required String userPrompt,
-    double? temperature,
-    int? maxTokens,
-  }) {
-    throw UnimplementedError(
-      'LLM with local on-device models is not implemented yet.',
-    );
   }
 }
 
@@ -91,84 +45,12 @@ final class ByokNotConfiguredLlmCapability implements LlmCapability {
   }
 }
 
-final class UnimplementedTranslationCapability
-    implements TranslationCapability {
-  const UnimplementedTranslationCapability();
-
-  @override
-  Future<TranslationResult> translate({
-    required String text,
-    required String sourceLanguage,
-    required String targetLanguage,
-    bool? forceRefresh,
-  }) {
-    throw UnimplementedError(
-      'Translation with local on-device models is not implemented yet.',
-    );
-  }
-}
-
-final class UnimplementedContextualTranslationCapability
-    implements ContextualTranslationCapability {
-  const UnimplementedContextualTranslationCapability();
-
-  @override
-  Future<ContextualTranslationResult> translate({
-    required String text,
-    required String sourceLanguage,
-    required String targetLanguage,
-    String? context,
-  }) {
-    throw UnimplementedError(
-      'Contextual translation with local on-device models is not implemented yet.',
-    );
-  }
-}
-
-final class UnimplementedDictionaryCapability implements DictionaryCapability {
-  const UnimplementedDictionaryCapability();
-
-  @override
-  Future<DictionaryResult> lookupDictionary({
-    required String word,
-    required String sourceLanguage,
-    required String targetLanguage,
-    bool? forceRefresh,
-  }) {
-    throw UnimplementedError(
-      'Dictionary with local on-device models is not implemented yet.',
-    );
-  }
-}
-
-final class UnimplementedTtsCapability implements TtsCapability {
-  const UnimplementedTtsCapability();
-
-  @override
-  Future<TtsResult> synthesize(TtsRequest request) {
-    throw UnimplementedError(
-      'TTS with local on-device models is not implemented yet.',
-    );
-  }
-}
-
 final class ByokNotConfiguredTtsCapability implements TtsCapability {
   const ByokNotConfiguredTtsCapability();
 
   @override
   Future<TtsResult> synthesize(TtsRequest request) {
     throw const ByokNotConfiguredFailure(ModalityKind.tts);
-  }
-}
-
-final class UnimplementedAssessmentCapability implements AssessmentCapability {
-  const UnimplementedAssessmentCapability();
-
-  @override
-  Future<AssessmentResult> assess(AssessmentRequest request) {
-    throw UnimplementedError(
-      'Assessment with local on-device models is not implemented yet.',
-    );
   }
 }
 

--- a/lib/features/ai/domain/ai_provider.dart
+++ b/lib/features/ai/domain/ai_provider.dart
@@ -1,2 +1,2 @@
-/// Where AI inference runs (Enjoy cloud worker first; BYOK/local reserved).
-enum AIProvider { enjoy, byok, local }
+/// Where AI inference runs (Enjoy cloud worker or user-supplied BYOK).
+enum AIProvider { enjoy, byok }

--- a/lib/features/ai/presentation/ai_playground_provider_label.dart
+++ b/lib/features/ai/presentation/ai_playground_provider_label.dart
@@ -12,7 +12,6 @@ String formatPlaygroundProviderLabel(
   return switch (config.provider) {
     AIProvider.enjoy => l10n.settingsAiProvidersEnjoyAi,
     AIProvider.byok => _byokLabel(l10n, config),
-    AIProvider.local => l10n.aiPlaygroundProviderLocal,
   };
 }
 

--- a/lib/features/lookup/application/lookup_sheet_result_cache.dart
+++ b/lib/features/lookup/application/lookup_sheet_result_cache.dart
@@ -9,6 +9,9 @@ library;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:enjoy_player/features/ai/application/ai_result_cache.dart';
+import 'package:enjoy_player/features/ai/domain/models/contextual_translation_result.dart';
+import 'package:enjoy_player/features/ai/domain/models/dictionary_result.dart';
+import 'package:enjoy_player/features/ai/domain/models/translation_result.dart';
 
 part 'lookup_sheet_result_cache.g.dart';
 
@@ -19,9 +22,9 @@ final class LookupSheetResultCache {
     this._contextualCache,
   );
 
-  final AiTranslationCache _translationCache;
-  final AiDictionaryCache _dictionaryCache;
-  final AiContextualTranslationCache _contextualCache;
+  final AiResultCache<TranslationResult> _translationCache;
+  final AiResultCache<DictionaryResult> _dictionaryCache;
+  final AiResultCache<ContextualTranslationResult> _contextualCache;
 
   /// Removes every cached entry whose payload matches the given pair.
   ///

--- a/lib/features/lookup/presentation/sections/contextual_translation_lookup_section.dart
+++ b/lib/features/lookup/presentation/sections/contextual_translation_lookup_section.dart
@@ -71,7 +71,7 @@ class ContextualTranslationLookupSection extends ConsumerWidget {
 /// still running; when the response arrives, state is never applied and the UI
 /// stays on the loading shimmer. This widget keeps a single [Future] tied to
 /// [ConsumerState] instead. Completed values are stored in
-/// [AiContextualTranslationCache].
+/// [AiResultCache<ContextualTranslationResult>].
 class _ContextualFetchBody extends ConsumerStatefulWidget {
   const _ContextualFetchBody({
     required this.params,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1225,10 +1225,6 @@
       }
     }
   },
-  "aiPlaygroundProviderLocal": "Local (unavailable)",
-  "@aiPlaygroundProviderLocal": {
-    "description": "Label when AIProvider.local is selected"
-  },
   "aiPlaygroundPickAudio": "Pick audio file",
   "aiPlaygroundTranscribe": "Transcribe",
   "aiPlaygroundChatSystem": "System (optional)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4173,12 +4173,6 @@ abstract class AppLocalizations {
   /// **'BYOK · {detail}'**
   String aiPlaygroundProviderByokDetail(String detail);
 
-  /// Label when AIProvider.local is selected
-  ///
-  /// In en, this message translates to:
-  /// **'Local (unavailable)'**
-  String get aiPlaygroundProviderLocal;
-
   /// No description provided for @aiPlaygroundPickAudio.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2250,9 +2250,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get aiPlaygroundProviderLocal => 'Local (unavailable)';
-
-  @override
   String get aiPlaygroundPickAudio => 'Pick audio file';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2154,9 +2154,6 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get aiPlaygroundProviderLocal => '本地（不可用）';
-
-  @override
   String get aiPlaygroundPickAudio => '选择音频文件';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -944,7 +944,6 @@
   "aiPlaygroundIntro": "通过 Enjoy 云端或「设置 → AI 提供商」中的 BYOK 凭据测试各 AI 能力。翻译与词典跟随 LLM 提供商。",
   "aiPlaygroundActiveProviders": "当前提供商",
   "aiPlaygroundProviderByokDetail": "BYOK · {detail}",
-  "aiPlaygroundProviderLocal": "本地（不可用）",
   "aiPlaygroundPickAudio": "选择音频文件",
   "aiPlaygroundTranscribe": "转写",
   "aiPlaygroundChatSystem": "系统（可选）",

--- a/test/features/ai/ai_cache_providers_coverage_test.dart
+++ b/test/features/ai/ai_cache_providers_coverage_test.dart
@@ -20,6 +20,9 @@ import 'package:enjoy_player/features/ai/application/ai_capability_providers.dar
 import 'package:enjoy_player/features/ai/application/ai_kind_policies.dart';
 import 'package:enjoy_player/features/ai/application/ai_modality_configs.dart';
 import 'package:enjoy_player/features/ai/application/ai_result_cache.dart';
+import 'package:enjoy_player/features/ai/domain/models/contextual_translation_result.dart';
+import 'package:enjoy_player/features/ai/domain/models/dictionary_result.dart';
+import 'package:enjoy_player/features/ai/domain/models/translation_result.dart';
 import 'package:enjoy_player/features/ai/domain/ai_kind.dart';
 import 'package:enjoy_player/features/ai/data/byok/byok_asr_azure_capability.dart';
 import 'package:enjoy_player/features/ai/data/byok/byok_asr_openai_capability.dart';
@@ -91,11 +94,6 @@ class _FakeSecretStore implements ByokSecretStoreBase {
       _keys.containsKey(modality);
 }
 
-class _SignedOutAuthCtrl extends AuthCtrl {
-  @override
-  Future<AuthState> build() async => const AuthSignedOut();
-}
-
 class _SignedInAuthCtrl extends AuthCtrl {
   _SignedInAuthCtrl(this._profileId);
 
@@ -163,17 +161,6 @@ void main() {
   // =========================================================================
 
   group('resolveAsrCapability', () {
-    test('local provider returns UnimplementedAsrCapability', () {
-      final container = _capabilityContainer(
-        _configsWith(asr: const AIServiceConfig(provider: AIProvider.local)),
-      );
-      addTearDown(container.dispose);
-      expect(
-        container.read(asrCapabilityProvider),
-        isA<UnimplementedAsrCapability>(),
-      );
-    });
-
     test(
       'byok with null speechByok returns ByokNotConfiguredAsrCapability',
       () {
@@ -272,17 +259,6 @@ void main() {
       addTearDown(container.dispose);
       expect(container.read(llmCapabilityProvider), isA<ByokLlmCapability>());
     });
-
-    test('local returns UnimplementedLlmCapability', () {
-      final container = _capabilityContainer(
-        _configsWith(llm: const AIServiceConfig(provider: AIProvider.local)),
-      );
-      addTearDown(container.dispose);
-      expect(
-        container.read(llmCapabilityProvider),
-        isA<UnimplementedLlmCapability>(),
-      );
-    });
   });
 
   group('resolveTranslationCapability', () {
@@ -334,19 +310,6 @@ void main() {
         isA<ByokTranslationCapability>(),
       );
     });
-
-    test('local returns UnimplementedTranslationCapability', () {
-      final container = _capabilityContainer(
-        _configsWith(
-          translation: const AIServiceConfig(provider: AIProvider.local),
-        ),
-      );
-      addTearDown(container.dispose);
-      expect(
-        container.read(translationCapabilityProvider),
-        isA<UnimplementedTranslationCapability>(),
-      );
-    });
   });
 
   group('resolveDictionaryCapability', () {
@@ -380,19 +343,6 @@ void main() {
       expect(
         container.read(dictionaryCapabilityProvider),
         isA<ByokDictionaryCapability>(),
-      );
-    });
-
-    test('local returns UnimplementedDictionaryCapability', () {
-      final container = _capabilityContainer(
-        _configsWith(
-          dictionary: const AIServiceConfig(provider: AIProvider.local),
-        ),
-      );
-      addTearDown(container.dispose);
-      expect(
-        container.read(dictionaryCapabilityProvider),
-        isA<UnimplementedDictionaryCapability>(),
       );
     });
   });
@@ -431,17 +381,6 @@ void main() {
         );
       },
     );
-
-    test('local returns UnimplementedContextualTranslationCapability', () {
-      final container = _capabilityContainer(
-        _configsWith(llm: const AIServiceConfig(provider: AIProvider.local)),
-      );
-      addTearDown(container.dispose);
-      expect(
-        container.read(contextualTranslationCapabilityProvider),
-        isA<UnimplementedContextualTranslationCapability>(),
-      );
-    });
   });
 
   group('resolveTtsCapability', () {
@@ -505,17 +444,6 @@ void main() {
         isA<ByokTtsAzureCapability>(),
       );
     });
-
-    test('local returns UnimplementedTtsCapability', () {
-      final container = _capabilityContainer(
-        _configsWith(tts: const AIServiceConfig(provider: AIProvider.local)),
-      );
-      addTearDown(container.dispose);
-      expect(
-        container.read(ttsCapabilityProvider),
-        isA<UnimplementedTtsCapability>(),
-      );
-    });
   });
 
   group('resolveAssessmentCapability', () {
@@ -567,28 +495,15 @@ void main() {
         );
       },
     );
-
-    test('local returns UnimplementedAssessmentCapability', () {
-      final container = _capabilityContainer(
-        _configsWith(
-          assessment: const AIServiceConfig(provider: AIProvider.local),
-        ),
-      );
-      addTearDown(container.dispose);
-      expect(
-        container.read(assessmentCapabilityProvider),
-        isA<UnimplementedAssessmentCapability>(),
-      );
-    });
   });
 
   group('aiModalityConfigsProvider', () {
     test('reflects overridden configs', () {
-      const custom = AIServiceConfig(provider: AIProvider.local);
+      const custom = AIServiceConfig(provider: AIProvider.byok);
       final container = _capabilityContainer(_configsWith(asr: custom));
       addTearDown(container.dispose);
       final configs = container.read(aiModalityConfigsProvider);
-      expect(configs.asr.provider, AIProvider.local);
+      expect(configs.asr.provider, AIProvider.byok);
       expect(configs.llm.provider, AIProvider.enjoy);
     });
   });
@@ -596,108 +511,6 @@ void main() {
   // =========================================================================
   // ai_result_cache.dart — Riverpod provider coverage
   // =========================================================================
-
-  group('aiResultCacheProvider', () {
-    late AppDatabase db;
-
-    setUp(() {
-      db = AppDatabase(executor: NativeDatabase.memory());
-    });
-
-    tearDown(() async {
-      await db.close();
-    });
-
-    test('creates a working AiMapCache', () async {
-      final container = ProviderContainer(
-        overrides: [
-          appDatabaseProvider.overrideWithValue(db),
-          authCtrlProvider.overrideWith(() => _SignedInAuthCtrl('test-user')),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      final cache = container.read(aiResultCacheProvider);
-      expect(cache, isA<AiMapCache>());
-
-      // Verify it works end-to-end.
-      final result = await cache.lookup(
-        kind: AiKind.translation,
-        key: 'test-key',
-        loader: () async => {'translatedText': 'hola'},
-      );
-      expect(result['translatedText'], 'hola');
-      expect(cache.peek(kind: AiKind.translation, key: 'test-key'), isNotNull);
-    });
-
-    test('clears cache on sign-out', () async {
-      final container = ProviderContainer(
-        overrides: [
-          appDatabaseProvider.overrideWithValue(db),
-          authCtrlProvider.overrideWith(() => _SignedInAuthCtrl('test-user')),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      final cache = container.read(aiResultCacheProvider);
-      await cache.remember(
-        kind: AiKind.translation,
-        key: 'k1',
-        value: {'v': 'cached'},
-      );
-      expect(cache.peek(kind: AiKind.translation, key: 'k1'), isNotNull);
-
-      // Simulate sign-out by invalidating authCtrl and replacing with
-      // signed-out state.
-      container.invalidate(authCtrlProvider);
-      // Re-read to trigger the provider rebuild with new auth state.
-      // We need a new container to simulate the state transition.
-      final container2 = ProviderContainer(
-        overrides: [
-          appDatabaseProvider.overrideWithValue(db),
-          authCtrlProvider.overrideWith(_SignedOutAuthCtrl.new),
-        ],
-      );
-      addTearDown(container2.dispose);
-
-      // The new container creates a fresh cache; the old one's listener
-      // would have fired clear() on sign-out. Verify the new cache is empty.
-      final cache2 = container2.read(aiResultCacheProvider);
-      expect(cache2.peek(kind: AiKind.translation, key: 'k1'), isNull);
-    });
-
-    test('clears cache on user-id change', () async {
-      // Seed data with user-A.
-      final containerA = ProviderContainer(
-        overrides: [
-          appDatabaseProvider.overrideWithValue(db),
-          authCtrlProvider.overrideWith(() => _SignedInAuthCtrl('user-A')),
-        ],
-      );
-      addTearDown(containerA.dispose);
-
-      final cacheA = containerA.read(aiResultCacheProvider);
-      await cacheA.remember(
-        kind: AiKind.translation,
-        key: 'k1',
-        value: {'v': 'user-A-data'},
-      );
-
-      // Simulate user change: new container with user-B.
-      final containerB = ProviderContainer(
-        overrides: [
-          appDatabaseProvider.overrideWithValue(db),
-          authCtrlProvider.overrideWith(() => _SignedInAuthCtrl('user-B')),
-        ],
-      );
-      addTearDown(containerB.dispose);
-
-      final cacheB = containerB.read(aiResultCacheProvider);
-      // Fresh L1 for the new container; L2 may still have old data but
-      // the provider's prune/clear logic handles isolation.
-      expect(cacheB.peek(kind: AiKind.translation, key: 'k1'), isNull);
-    });
-  });
 
   group('aiTranslationCacheProvider', () {
     late AppDatabase db;
@@ -710,7 +523,7 @@ void main() {
       await db.close();
     });
 
-    test('creates a working AiTranslationCache', () async {
+    test('creates a working translation cache', () async {
       final container = ProviderContainer(
         overrides: [
           appDatabaseProvider.overrideWithValue(db),
@@ -720,7 +533,7 @@ void main() {
       addTearDown(container.dispose);
 
       final cache = container.read(aiTranslationCacheProvider);
-      expect(cache, isA<AiTranslationCache>());
+      expect(cache, isA<AiResultCache<TranslationResult>>());
     });
   });
 
@@ -735,7 +548,7 @@ void main() {
       await db.close();
     });
 
-    test('creates a working AiDictionaryCache', () async {
+    test('creates a working dictionary cache', () async {
       final container = ProviderContainer(
         overrides: [
           appDatabaseProvider.overrideWithValue(db),
@@ -745,7 +558,7 @@ void main() {
       addTearDown(container.dispose);
 
       final cache = container.read(aiDictionaryCacheProvider);
-      expect(cache, isA<AiDictionaryCache>());
+      expect(cache, isA<AiResultCache<DictionaryResult>>());
     });
   });
 
@@ -760,7 +573,7 @@ void main() {
       await db.close();
     });
 
-    test('creates a working AiContextualTranslationCache', () async {
+    test('creates a working contextual translation cache', () async {
       final container = ProviderContainer(
         overrides: [
           appDatabaseProvider.overrideWithValue(db),
@@ -770,7 +583,7 @@ void main() {
       addTearDown(container.dispose);
 
       final cache = container.read(aiContextualTranslationCacheProvider);
-      expect(cache, isA<AiContextualTranslationCache>());
+      expect(cache, isA<AiResultCache<ContextualTranslationResult>>());
     });
   });
 
@@ -784,13 +597,15 @@ void main() {
       addTearDown(() => db.close());
 
       // Close the DB to force L2 writes to fail.
-      final cache = AiMapCache(
+      final cache = AiResultCache<Map<String, dynamic>>(
         dao: db.aiCacheDao,
         l1: L1Store<String, Map<String, dynamic>>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: (json) => json,
+        toJson: (value) => value,
       );
 
       // First verify it works normally.
@@ -819,13 +634,15 @@ void main() {
     test('closed DB on L2 read falls through to loader', () async {
       final db = AppDatabase(executor: NativeDatabase.memory());
 
-      final cache = AiMapCache(
+      final cache = AiResultCache<Map<String, dynamic>>(
         dao: db.aiCacheDao,
         l1: L1Store<String, Map<String, dynamic>>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: (json) => json,
+        toJson: (value) => value,
       );
 
       // Seed L1 only (no L2).
@@ -849,118 +666,6 @@ void main() {
         // If the DAO read throws (closed DB), the error propagates.
         // This is acceptable — the test documents the behavior.
       }
-    });
-  });
-
-  group('AiCacheStats toString edge cases', () {
-    test('empty l2RowCounts map', () {
-      const stats = AiCacheStats(l1Size: 0, l1Capacity: 256, l2RowCounts: {});
-      final str = stats.toString();
-      expect(str, contains('l1=0/256'));
-      expect(str, contains('l2={}'));
-    });
-
-    test('multiple kinds in l2RowCounts', () {
-      const stats = AiCacheStats(
-        l1Size: 5,
-        l1Capacity: 128,
-        l2RowCounts: {
-          AiKind.translation: 100,
-          AiKind.dictionary: 50,
-          AiKind.contextualTranslation: 25,
-          AiKind.autoTranslateLine: 200,
-        },
-      );
-      final str = stats.toString();
-      expect(str, contains('l1=5/128'));
-      expect(str, contains('AiKind.translation'));
-    });
-  });
-
-  group('AiResultCache evictForPair with special characters', () {
-    late AppDatabase db;
-    late AiMapCache cache;
-
-    setUp(() {
-      db = AppDatabase(executor: NativeDatabase.memory());
-      cache = AiMapCache(
-        dao: db.aiCacheDao,
-        l1: L1Store<String, Map<String, dynamic>>(
-          capacity: 8,
-          ttl: const Duration(minutes: 5),
-        ),
-        policies: defaultAiKindPolicies,
-      );
-    });
-
-    tearDown(() async {
-      await db.close();
-    });
-
-    test('handles language tags with hyphens', () async {
-      await db.aiCacheDao.upsert(
-        'translation',
-        'k1',
-        '{"v":"x","sourceLanguage":"zh-Hans","targetLanguage":"pt-BR"}',
-        DateTime.now(),
-      );
-      await db.aiCacheDao.upsert(
-        'translation',
-        'k2',
-        '{"v":"y","sourceLanguage":"en","targetLanguage":"pt-BR"}',
-        DateTime.now(),
-      );
-
-      await cache.evictForPair(
-        sourceLanguage: 'zh-Hans',
-        targetLanguage: 'pt-BR',
-      );
-
-      expect(await db.aiCacheDao.read('translation', 'k1'), isNull);
-      expect(await db.aiCacheDao.read('translation', 'k2'), isNotNull);
-    });
-  });
-
-  group('AiResultCache prune with autoTranslateLine kind', () {
-    late AppDatabase db;
-
-    setUp(() {
-      db = AppDatabase(executor: NativeDatabase.memory());
-    });
-
-    tearDown(() async {
-      await db.close();
-    });
-
-    test('prunes autoTranslateLine kind per its policy', () async {
-      final cache = AiMapCache(
-        dao: db.aiCacheDao,
-        l1: L1Store<String, Map<String, dynamic>>(
-          capacity: 8,
-          ttl: const Duration(minutes: 5),
-        ),
-        policies: {
-          AiKind.autoTranslateLine: const AiKindPolicy(
-            ttl: Duration(minutes: 30),
-            l2RowCap: 3,
-            l2AgeCutoff: Duration(days: 1),
-          ),
-        },
-      );
-
-      for (var i = 0; i < 10; i++) {
-        await db.aiCacheDao.upsert(
-          'auto_translate_line',
-          'line$i',
-          '{"v":"$i"}',
-          DateTime.now().subtract(Duration(seconds: i)),
-        );
-      }
-
-      await cache.prune();
-
-      final count = await db.aiCacheDao.countForKind('auto_translate_line');
-      expect(count, 3);
     });
   });
 }

--- a/test/features/ai/ai_result_cache_test.dart
+++ b/test/features/ai/ai_result_cache_test.dart
@@ -6,35 +6,24 @@ import 'package:enjoy_player/features/ai/application/ai_result_cache.dart';
 import 'package:enjoy_player/features/ai/domain/ai_kind.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _StringCache extends AiResultCache<String> {
-  _StringCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-  });
-
-  @override
-  String fromJson(Map<String, dynamic> json) => json['v'] as String;
-
-  @override
-  Map<String, dynamic> toJson(String value) => {'v': value};
+AiResultCache<String> _stringCache(AppDatabase db) {
+  return AiResultCache<String>(
+    dao: db.aiCacheDao,
+    l1: L1Store<String, String>(capacity: 8, ttl: const Duration(seconds: 1)),
+    policies: defaultAiKindPolicies,
+    fromJson: (json) => json['v'] as String,
+    toJson: (value) => {'v': value},
+  );
 }
 
 void main() {
   group('AiResultCache', () {
     late AppDatabase db;
-    late _StringCache cache;
+    late AiResultCache<String> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _StringCache(
-        dao: db.aiCacheDao,
-        l1: L1Store<String, String>(
-          capacity: 8,
-          ttl: const Duration(seconds: 1),
-        ),
-        policies: defaultAiKindPolicies,
-      );
+      cache = _stringCache(db);
     });
 
     tearDown(() async {
@@ -250,7 +239,7 @@ void main() {
       // Translation's default cap is 4096; that's higher than 50, so prune
       // should be a no-op here. To exercise the eviction path, lower the
       // cap by constructing a custom policies map.
-      final tightCache = _StringCache(
+      final tightCache = AiResultCache<String>(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 4,
@@ -263,21 +252,12 @@ void main() {
             l2AgeCutoff: Duration(days: 30),
           ),
         },
+        fromJson: (json) => json['v'] as String,
+        toJson: (value) => {'v': value},
       );
       await tightCache.prune();
       final after = await db.aiCacheDao.countForKind('translation');
       expect(after, 5);
-    });
-
-    test('stats returns snapshot of L1 and L2', () async {
-      await cache.remember(kind: AiKind.translation, key: 'a', value: 'a');
-      await cache.remember(kind: AiKind.dictionary, key: 'b', value: 'b');
-      final stats = await cache.stats();
-      expect(stats.l1Size, 2);
-      expect(stats.l1Capacity, 8);
-      expect(stats.l2RowCounts[AiKind.translation], 1);
-      expect(stats.l2RowCounts[AiKind.dictionary], 1);
-      expect(stats.l2RowCounts[AiKind.contextualTranslation], 0);
     });
 
     test('L2 I/O failure degrades gracefully on lookup', () async {

--- a/test/features/ai/application/ai_result_cache_extended_test.dart
+++ b/test/features/ai/application/ai_result_cache_extended_test.dart
@@ -9,58 +9,56 @@ import 'package:enjoy_player/features/ai/domain/models/dictionary_result.dart';
 import 'package:enjoy_player/features/ai/domain/models/translation_result.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _StringCache extends AiResultCache<String> {
-  _StringCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-  });
-
-  @override
-  String fromJson(Map<String, dynamic> json) => json['v'] as String;
-
-  @override
-  Map<String, dynamic> toJson(String value) => {'v': value};
+AiResultCache<String> stringCache({
+  required AiCacheDao dao,
+  required L1Store<String, String> l1,
+  required Map<AiKind, AiKindPolicy> policies,
+}) {
+  return AiResultCache<String>(
+    dao: dao,
+    l1: l1,
+    policies: policies,
+    fromJson: (json) => json['v'] as String,
+    toJson: (value) => {'v': value},
+  );
 }
 
-class _ThrowingEncodeCache extends AiResultCache<String> {
-  _ThrowingEncodeCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-  });
-
-  @override
-  String fromJson(Map<String, dynamic> json) => json['v'] as String;
-
-  @override
-  Map<String, dynamic> toJson(String value) =>
-      throw StateError('encode failure');
+AiResultCache<String> throwingEncodeCache({
+  required AiCacheDao dao,
+  required L1Store<String, String> l1,
+  required Map<AiKind, AiKindPolicy> policies,
+}) {
+  return AiResultCache<String>(
+    dao: dao,
+    l1: l1,
+    policies: policies,
+    fromJson: (json) => json['v'] as String,
+    toJson: (value) => throw StateError('encode failure'),
+  );
 }
 
-class _ThrowingDecodeCache extends AiResultCache<String> {
-  _ThrowingDecodeCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-  });
-
-  @override
-  String fromJson(Map<String, dynamic> json) =>
-      throw const FormatException('decode failure');
-
-  @override
-  Map<String, dynamic> toJson(String value) => {'v': value};
+AiResultCache<String> throwingDecodeCache({
+  required AiCacheDao dao,
+  required L1Store<String, String> l1,
+  required Map<AiKind, AiKindPolicy> policies,
+}) {
+  return AiResultCache<String>(
+    dao: dao,
+    l1: l1,
+    policies: policies,
+    fromJson: (json) => throw const FormatException('decode failure'),
+    toJson: (value) => {'v': value},
+  );
 }
 
 void main() {
   group('AiResultCache.peek', () {
     late AppDatabase db;
-    late _StringCache cache;
+    late AiResultCache<String> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _StringCache(
+      cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -84,7 +82,7 @@ void main() {
     });
 
     test('returns null after TTL expiry', () async {
-      final shortTtl = _StringCache(
+      final shortTtl = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(capacity: 8, ttl: Duration.zero),
         policies: defaultAiKindPolicies,
@@ -112,7 +110,7 @@ void main() {
     });
 
     test('expired L1 entry falls through to L2', () async {
-      final shortTtl = _StringCache(
+      final shortTtl = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(capacity: 8, ttl: Duration.zero),
         policies: defaultAiKindPolicies,
@@ -140,7 +138,7 @@ void main() {
     });
 
     test('expired L1 with no L2 calls loader', () async {
-      final shortTtl = _StringCache(
+      final shortTtl = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(capacity: 8, ttl: Duration.zero),
         policies: defaultAiKindPolicies,
@@ -173,7 +171,7 @@ void main() {
     });
 
     test('LRU-evicted entry falls through to L2', () async {
-      final tinyCache = _StringCache(
+      final tinyCache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 2,
@@ -218,11 +216,11 @@ void main() {
 
   group('AiResultCache.lookup L2 decode failure', () {
     late AppDatabase db;
-    late _ThrowingDecodeCache cache;
+    late AiResultCache<String> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _ThrowingDecodeCache(
+      cache = throwingDecodeCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -277,7 +275,7 @@ void main() {
     });
 
     test('L2 encode failure is swallowed and L1 still written', () async {
-      final throwingCache = _ThrowingEncodeCache(
+      final throwingCache = throwingEncodeCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -298,7 +296,7 @@ void main() {
     });
 
     test('overwrites existing L1 and L2 entries', () async {
-      final cache = _StringCache(
+      final cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -318,11 +316,11 @@ void main() {
 
   group('AiResultCache.invalidate', () {
     late AppDatabase db;
-    late _StringCache cache;
+    late AiResultCache<String> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _StringCache(
+      cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -354,11 +352,11 @@ void main() {
 
   group('AiResultCache.evictForPair', () {
     late AppDatabase db;
-    late _StringCache cache;
+    late AiResultCache<String> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _StringCache(
+      cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -437,7 +435,7 @@ void main() {
     });
 
     test('only clears kinds present in policies map', () async {
-      final limitedCache = _StringCache(
+      final limitedCache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -472,7 +470,7 @@ void main() {
     });
 
     test('clears L1 completely', () async {
-      final cache = _StringCache(
+      final cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -509,7 +507,7 @@ void main() {
     });
 
     test('age cutoff removes old rows', () async {
-      final cache = _StringCache(
+      final cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -541,7 +539,7 @@ void main() {
     });
 
     test('zero row cap skips eviction', () async {
-      final cache = _StringCache(
+      final cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -571,7 +569,7 @@ void main() {
     });
 
     test('zero age cutoff skips age pruning', () async {
-      final cache = _StringCache(
+      final cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -600,7 +598,7 @@ void main() {
     });
 
     test('prunes multiple kinds independently', () async {
-      final cache = _StringCache(
+      final cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -642,7 +640,7 @@ void main() {
     });
 
     test('row cap and age cutoff applied together', () async {
-      final cache = _StringCache(
+      final cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -683,75 +681,21 @@ void main() {
     });
   });
 
-  group('AiResultCache.stats', () {
+  group('Map-payload cache', () {
     late AppDatabase db;
-    late _StringCache cache;
+    late AiResultCache<Map<String, dynamic>> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _StringCache(
-        dao: db.aiCacheDao,
-        l1: L1Store<String, String>(
-          capacity: 16,
-          ttl: const Duration(minutes: 5),
-        ),
-        policies: defaultAiKindPolicies,
-      );
-    });
-
-    tearDown(() async {
-      await db.close();
-    });
-
-    test('reports zero counts on empty cache', () async {
-      final stats = await cache.stats();
-      expect(stats.l1Size, 0);
-      expect(stats.l1Capacity, 16);
-      for (final count in stats.l2RowCounts.values) {
-        expect(count, 0);
-      }
-    });
-
-    test('reflects L2-only entries not in L1', () async {
-      await db.aiCacheDao.upsert(
-        'translation',
-        'l2only',
-        '{"v":"x"}',
-        DateTime.now(),
-      );
-
-      final stats = await cache.stats();
-      expect(stats.l1Size, 0);
-      expect(stats.l2RowCounts[AiKind.translation], 1);
-    });
-  });
-
-  group('AiCacheStats.toString', () {
-    test('formats correctly', () {
-      const stats = AiCacheStats(
-        l1Size: 3,
-        l1Capacity: 256,
-        l2RowCounts: {AiKind.translation: 10, AiKind.dictionary: 5},
-      );
-      final str = stats.toString();
-      expect(str, contains('l1=3/256'));
-      expect(str, contains('l2='));
-    });
-  });
-
-  group('AiMapCache', () {
-    late AppDatabase db;
-    late AiMapCache cache;
-
-    setUp(() {
-      db = AppDatabase(executor: NativeDatabase.memory());
-      cache = AiMapCache(
+      cache = AiResultCache<Map<String, dynamic>>(
         dao: db.aiCacheDao,
         l1: L1Store<String, Map<String, dynamic>>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: (json) => json,
+        toJson: (value) => value,
       );
     });
 
@@ -773,13 +717,15 @@ void main() {
       final l2 = await db.aiCacheDao.read('translation', 'k1');
       expect(l2, isNotNull);
 
-      final freshCache = AiMapCache(
+      final freshCache = AiResultCache<Map<String, dynamic>>(
         dao: db.aiCacheDao,
         l1: L1Store<String, Map<String, dynamic>>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: (json) => json,
+        toJson: (value) => value,
       );
       final fromL2 = await freshCache.lookup(
         kind: AiKind.translation,
@@ -801,19 +747,21 @@ void main() {
     });
   });
 
-  group('AiTranslationCache', () {
+  group('Translation cache', () {
     late AppDatabase db;
-    late AiTranslationCache cache;
+    late AiResultCache<TranslationResult> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = AiTranslationCache(
+      cache = AiResultCache<TranslationResult>(
         dao: db.aiCacheDao,
         l1: L1Store<String, TranslationResult>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: TranslationResult.fromJson,
+        toJson: (value) => value.toJson(),
       );
     });
 
@@ -834,13 +782,15 @@ void main() {
         value: original,
       );
 
-      final freshCache = AiTranslationCache(
+      final freshCache = AiResultCache<TranslationResult>(
         dao: db.aiCacheDao,
         l1: L1Store<String, TranslationResult>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: TranslationResult.fromJson,
+        toJson: (value) => value.toJson(),
       );
 
       final fromL2 = await freshCache.lookup(
@@ -867,19 +817,21 @@ void main() {
     });
   });
 
-  group('AiDictionaryCache', () {
+  group('Dictionary cache', () {
     late AppDatabase db;
-    late AiDictionaryCache cache;
+    late AiResultCache<DictionaryResult> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = AiDictionaryCache(
+      cache = AiResultCache<DictionaryResult>(
         dao: db.aiCacheDao,
         l1: L1Store<String, DictionaryResult>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: DictionaryResult.fromJson,
+        toJson: (value) => value.toJson(),
       );
     });
 
@@ -910,13 +862,15 @@ void main() {
         value: original,
       );
 
-      final freshCache = AiDictionaryCache(
+      final freshCache = AiResultCache<DictionaryResult>(
         dao: db.aiCacheDao,
         l1: L1Store<String, DictionaryResult>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: DictionaryResult.fromJson,
+        toJson: (value) => value.toJson(),
       );
 
       final fromL2 = await freshCache.lookup(
@@ -965,19 +919,21 @@ void main() {
     });
   });
 
-  group('AiContextualTranslationCache', () {
+  group('Contextual translation cache', () {
     late AppDatabase db;
-    late AiContextualTranslationCache cache;
+    late AiResultCache<ContextualTranslationResult> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = AiContextualTranslationCache(
+      cache = AiResultCache<ContextualTranslationResult>(
         dao: db.aiCacheDao,
         l1: L1Store<String, ContextualTranslationResult>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: ContextualTranslationResult.fromJson,
+        toJson: (value) => value.toJson(),
       );
     });
 
@@ -996,13 +952,15 @@ void main() {
         value: original,
       );
 
-      final freshCache = AiContextualTranslationCache(
+      final freshCache = AiResultCache<ContextualTranslationResult>(
         dao: db.aiCacheDao,
         l1: L1Store<String, ContextualTranslationResult>(
           capacity: 8,
           ttl: const Duration(minutes: 5),
         ),
         policies: defaultAiKindPolicies,
+        fromJson: ContextualTranslationResult.fromJson,
+        toJson: (value) => value.toJson(),
       );
 
       final fromL2 = await freshCache.lookup(
@@ -1043,11 +1001,11 @@ void main() {
 
   group('AiResultCache.lookup forceRefresh edge cases', () {
     late AppDatabase db;
-    late _StringCache cache;
+    late AiResultCache<String> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _StringCache(
+      cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,
@@ -1100,11 +1058,11 @@ void main() {
 
   group('AiResultCache cross-kind isolation', () {
     late AppDatabase db;
-    late _StringCache cache;
+    late AiResultCache<String> cache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
-      cache = _StringCache(
+      cache = stringCache(
         dao: db.aiCacheDao,
         l1: L1Store<String, String>(
           capacity: 8,

--- a/test/features/ai/data/stub_ai_capabilities_test.dart
+++ b/test/features/ai/data/stub_ai_capabilities_test.dart
@@ -26,16 +26,6 @@ AssessmentRequest _assessReq() => AssessmentRequest(
 );
 
 void main() {
-  group('UnimplementedAsrCapability', () {
-    test('transcribe() throws UnimplementedError', () async {
-      const c = UnimplementedAsrCapability();
-      await expectLater(
-        () => c.transcribe(_asrReq()),
-        throwsA(isA<UnimplementedError>()),
-      );
-    });
-  });
-
   group('ByokNotConfiguredAsrCapability', () {
     test('transcribe() throws ByokNotConfiguredFailure for ASR', () async {
       const c = ByokNotConfiguredAsrCapability();
@@ -45,24 +35,6 @@ void main() {
       } on ByokNotConfiguredFailure catch (e) {
         expect(e.modality, ModalityKind.asr);
       }
-    });
-  });
-
-  group('UnimplementedLlmCapability', () {
-    test('generateChatCompletion() throws UnimplementedError', () async {
-      const c = UnimplementedLlmCapability();
-      await expectLater(
-        () => c.generateChatCompletion(messages: const []),
-        throwsA(isA<UnimplementedError>()),
-      );
-    });
-
-    test('generateText() throws UnimplementedError', () async {
-      const c = UnimplementedLlmCapability();
-      await expectLater(
-        () => c.generateText(userPrompt: 'hi'),
-        throwsA(isA<UnimplementedError>()),
-      );
     });
   });
 
@@ -91,59 +63,6 @@ void main() {
     });
   });
 
-  group('UnimplementedTranslationCapability', () {
-    test('translate() throws UnimplementedError', () async {
-      const c = UnimplementedTranslationCapability();
-      await expectLater(
-        () => c.translate(
-          text: 'hola',
-          sourceLanguage: 'es',
-          targetLanguage: 'en',
-        ),
-        throwsA(isA<UnimplementedError>()),
-      );
-    });
-  });
-
-  group('UnimplementedContextualTranslationCapability', () {
-    test('translate() throws UnimplementedError', () async {
-      const c = UnimplementedContextualTranslationCapability();
-      await expectLater(
-        () => c.translate(
-          text: 'bank',
-          sourceLanguage: 'en',
-          targetLanguage: 'zh',
-          context: 'deposit money',
-        ),
-        throwsA(isA<UnimplementedError>()),
-      );
-    });
-  });
-
-  group('UnimplementedDictionaryCapability', () {
-    test('lookupDictionary() throws UnimplementedError', () async {
-      const c = UnimplementedDictionaryCapability();
-      await expectLater(
-        () => c.lookupDictionary(
-          word: 'bank',
-          sourceLanguage: 'en',
-          targetLanguage: 'zh',
-        ),
-        throwsA(isA<UnimplementedError>()),
-      );
-    });
-  });
-
-  group('UnimplementedTtsCapability', () {
-    test('synthesize() throws UnimplementedError', () async {
-      const c = UnimplementedTtsCapability();
-      await expectLater(
-        () => c.synthesize(const TtsRequest(text: 'hi', language: 'en')),
-        throwsA(isA<UnimplementedError>()),
-      );
-    });
-  });
-
   group('ByokNotConfiguredTtsCapability', () {
     test('synthesize() throws ByokNotConfiguredFailure for TTS', () async {
       const c = ByokNotConfiguredTtsCapability();
@@ -153,16 +72,6 @@ void main() {
       } on ByokNotConfiguredFailure catch (e) {
         expect(e.modality, ModalityKind.tts);
       }
-    });
-  });
-
-  group('UnimplementedAssessmentCapability', () {
-    test('assess() throws UnimplementedError', () async {
-      const c = UnimplementedAssessmentCapability();
-      await expectLater(
-        () => c.assess(_assessReq()),
-        throwsA(isA<UnimplementedError>()),
-      );
     });
   });
 

--- a/test/features/ai/presentation/ai_playground_provider_label_test.dart
+++ b/test/features/ai/presentation/ai_playground_provider_label_test.dart
@@ -21,15 +21,6 @@ void main() {
     expect(label, 'Enjoy AI');
   });
 
-  test('local provider → "Local (unavailable)"', () async {
-    final l10n = await _loadL10n();
-    final label = formatPlaygroundProviderLabel(
-      l10n,
-      const AIServiceConfig(provider: AIProvider.local),
-    );
-    expect(label, 'Local (unavailable)');
-  });
-
   test('BYOK + known preset id → "BYOK · preset label"', () async {
     final l10n = await _loadL10n();
     final config = const AIServiceConfig(

--- a/test/features/lookup/application/lookup_section_providers_test.dart
+++ b/test/features/lookup/application/lookup_section_providers_test.dart
@@ -73,28 +73,32 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late AppDatabase db;
-  late AiTranslationCache translationCache;
-  late AiDictionaryCache dictionaryCache;
+  late AiResultCache<TranslationResult> translationCache;
+  late AiResultCache<DictionaryResult> dictionaryCache;
   late _FakeTranslationCapability translationCap;
   late _FakeDictionaryCapability dictionaryCap;
 
   setUp(() {
     db = AppDatabase(executor: NativeDatabase.memory());
-    translationCache = AiTranslationCache(
+    translationCache = AiResultCache<TranslationResult>(
       dao: db.aiCacheDao,
       l1: L1Store<String, TranslationResult>(
         capacity: 8,
         ttl: const Duration(minutes: 30),
       ),
       policies: defaultAiKindPolicies,
+      fromJson: TranslationResult.fromJson,
+      toJson: (value) => value.toJson(),
     );
-    dictionaryCache = AiDictionaryCache(
+    dictionaryCache = AiResultCache<DictionaryResult>(
       dao: db.aiCacheDao,
       l1: L1Store<String, DictionaryResult>(
         capacity: 8,
         ttl: const Duration(minutes: 30),
       ),
       policies: defaultAiKindPolicies,
+      fromJson: DictionaryResult.fromJson,
+      toJson: (value) => value.toJson(),
     );
     translationCap = _FakeTranslationCapability(
       const TranslationResult(translatedText: 'hello', targetLanguage: 'zh'),

--- a/test/features/lookup/lookup_sheet_result_cache_test.dart
+++ b/test/features/lookup/lookup_sheet_result_cache_test.dart
@@ -6,25 +6,25 @@ import 'package:enjoy_player/features/ai/application/ai_result_cache.dart';
 import 'package:enjoy_player/features/ai/domain/ai_kind.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _StringCache extends AiResultCache<String> {
-  _StringCache({
-    required super.dao,
-    required super.l1,
-    required super.policies,
-  });
-
-  @override
-  String fromJson(Map<String, dynamic> json) => json['v'] as String;
-
-  @override
-  Map<String, dynamic> toJson(String value) => {'v': value};
+AiResultCache<String> _stringCache(
+  AppDatabase db,
+  L1Store<String, String> l1,
+  Map<AiKind, AiKindPolicy> policies,
+) {
+  return AiResultCache<String>(
+    dao: db.aiCacheDao,
+    l1: l1,
+    policies: policies,
+    fromJson: (json) => json['v'] as String,
+    toJson: (value) => {'v': value},
+  );
 }
 
 void main() {
   group('AiResultCache evictForPair', () {
     late AppDatabase db;
-    late _StringCache translationCache;
-    late _StringCache dictCache;
+    late AiResultCache<String> translationCache;
+    late AiResultCache<String> dictCache;
 
     setUp(() {
       db = AppDatabase(executor: NativeDatabase.memory());
@@ -35,13 +35,10 @@ void main() {
       // the encoded JSON to contain sourceLanguage/targetLanguage. We do
       // writes through DAO directly for the scan case, and via the cache for
       // the normal case.
-      translationCache = _StringCache(
-        dao: db.aiCacheDao,
-        l1: L1Store<String, String>(
-          capacity: 8,
-          ttl: const Duration(seconds: 1),
-        ),
-        policies: {
+      translationCache = _stringCache(
+        db,
+        L1Store<String, String>(capacity: 8, ttl: const Duration(seconds: 1)),
+        {
           AiKind.translation: const AiKindPolicy(
             ttl: Duration(minutes: 30),
             l2RowCap: 4096,
@@ -49,13 +46,10 @@ void main() {
           ),
         },
       );
-      dictCache = _StringCache(
-        dao: db.aiCacheDao,
-        l1: L1Store<String, String>(
-          capacity: 8,
-          ttl: const Duration(seconds: 1),
-        ),
-        policies: {
+      dictCache = _stringCache(
+        db,
+        L1Store<String, String>(capacity: 8, ttl: const Duration(seconds: 1)),
+        {
           AiKind.dictionary: const AiKindPolicy(
             ttl: Duration(minutes: 30),
             l2RowCap: 4096,

--- a/test/features/lookup/presentation/sections/contextual_translation_lookup_section_test.dart
+++ b/test/features/lookup/presentation/sections/contextual_translation_lookup_section_test.dart
@@ -94,17 +94,19 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late AppDatabase db;
-  late AiContextualTranslationCache ctxCache;
+  late AiResultCache<ContextualTranslationResult> ctxCache;
 
   setUp(() {
     db = AppDatabase(executor: NativeDatabase.memory());
-    ctxCache = AiContextualTranslationCache(
+    ctxCache = AiResultCache<ContextualTranslationResult>(
       dao: db.aiCacheDao,
       l1: L1Store<String, ContextualTranslationResult>(
         capacity: 16,
         ttl: const Duration(minutes: 30),
       ),
       policies: defaultAiKindPolicies,
+      fromJson: ContextualTranslationResult.fromJson,
+      toJson: (value) => value.toJson(),
     );
   });
 

--- a/test/features/lookup/presentation/sections/dictionary_lookup_section_test.dart
+++ b/test/features/lookup/presentation/sections/dictionary_lookup_section_test.dart
@@ -107,17 +107,19 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late AppDatabase db;
-  late AiDictionaryCache dictCache;
+  late AiResultCache<DictionaryResult> dictCache;
 
   setUp(() {
     db = AppDatabase(executor: NativeDatabase.memory());
-    dictCache = AiDictionaryCache(
+    dictCache = AiResultCache<DictionaryResult>(
       dao: db.aiCacheDao,
       l1: L1Store<String, DictionaryResult>(
         capacity: 16,
         ttl: const Duration(minutes: 30),
       ),
       policies: defaultAiKindPolicies,
+      fromJson: DictionaryResult.fromJson,
+      toJson: (value) => value.toJson(),
     );
   });
 


### PR DESCRIPTION
Part of #695 / resolves #700 (over-engineering audit — AI feature). Net -330 lines including generated code.

## What lands
- **`AIProvider.local` + 7 `Unimplemented*Capability` stubs deleted (120L)** — the settings `SegmentedButton` only offers enjoy/byok, nothing persists `'local'`, and the persisted-config parser (`AIProvider.values.firstWhere(..., orElse: () => AIProvider.enjoy)`) already degrades a stale stored `'local'` to the enjoy fallback — **no migration needed**, verified against `ai_modality_config_repository.dart`. Also removed: the playground label switch arm the audit missed (`ai_playground_provider_label.dart`) and the now-dead `aiPlaygroundProviderLocal` l10n key (template + zh, regenerated).
- **Four cache subclasses + four providers → one generic class + one factory (150L)** — `AiTranslationCache` / `AiDictionaryCache` / `AiContextualTranslationCache` (+ dead `AiMapCache`) shared identical shape; now `AiResultCache<V>` with injected `fromJson`/`toJson`, and `_buildPerUserCache` owns the identical 256-entry / 30-min L1 sizing, startup-prune watch, and sign-out/user-change clear listener. Same capacity, TTL, evict semantics — the existing ai_cache tests are the spec and pass with only mechanical construction-site updates. `ai_result_cache.g.dart` regenerated (riverpod neighbour hashes included).
- **`AiMapCache` + `aiResultCacheProvider` deleted (55L)** — zero production callers, alive only in `ai_cache_providers_coverage_test.dart` (group removed; the generic edge-case coverage in it was ported to `AiResultCache<Map<String, dynamic>>` with identity converters).
- **`AiCacheStats` + `stats()` deleted (35L)** — diagnostics with zero lib callers; test call sites pruned.
- **`mapTranscriptLanguageToAzureOrEnUs` deleted (5L)** — `@Deprecated` wrapper, zero callers.

## Deviation from the audit (deliberate)
**`peek()` stays.** The issue classes it as dead diagnostics, but `peek` is the only synchronous L1 observation primitive and `ai_result_cache_test.dart` asserts L1-hit/TTL/LRU-eviction behavior through it a dozen times. Removing it would force the spec tests through `lookup` with loader side effects, weakening exactly the tests the issue calls "the spec". Zero-cost keep; happy to revisit with a spec rewrite.

## Verification
`bash .github/scripts/validate_ci_gates.sh --fix --analyze --test` green: format, codegen drift (no residual drift), analyze 0 issues, **5931 tests pass**.

Fixes #700