### PR TITLE
fix(subscription): show yearly savings badge only on the yearly tab

### DIFF
--- a/lib/features/subscription/presentation/widgets/tier_catalog.dart
+++ b/lib/features/subscription/presentation/widgets/tier_catalog.dart
@@ -138,11 +138,14 @@ class _TierCatalogState extends ConsumerState<TierCatalog> {
           onChanged: (v) => setState(() => _interval = v),
           yearlyLabel: l10n.subscriptionAutoRenewYearly,
           monthlyLabel: l10n.subscriptionAutoRenewMonthly,
-          savingsLabel: savingsPercent == null
-              ? null
-              : l10n.subscriptionTierCatalogIntervalYearSavings(
+          // Savings only applies to yearly billing, so hide the badge on the
+          // monthly tab (null collapses the toggle to its centered solo layout).
+          savingsLabel:
+              _interval == CatalogInterval.year && savingsPercent != null
+              ? l10n.subscriptionTierCatalogIntervalYearSavings(
                   '$savingsPercent',
-                ),
+                )
+              : null,
         ),
         SizedBox(height: t.space20),
         LayoutBuilder(


### PR DESCRIPTION
## Summary
- The tier catalog's "Save 17%" badge rendered on both Monthly and Yearly tabs — the savings label was passed to `_IntervalToggle` unconditionally once plans loaded.
- Gate the label on the active interval: it now only appears when **Yearly** is selected.
- No layout changes: the Monthly tab uses the toggle's existing centered solo path (`savingsLabel == null`), and the Yearly tab keeps the previous toggle+badge row (badge drops below on narrow screens).

## Test plan
- [x] `dart analyze` — no issues
- [x] `flutter test test/features/subscription/presentation/subscription_screen_test.dart` — 6/6 pass, incl. narrow-phone layout-error test
- [ ] Manual: switch Monthly ↔ Yearly on the subscription screen and confirm the badge appears only on Yearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)